### PR TITLE
Refactor recovery to use resource managers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "memmap2",
  "natord",
  "nom",
+ "once_cell",
  "parking_lot",
  "parking_lot_core",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ axum = { version = "0.7", features = ["macros", "json"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["fs", "trace", "cors"] }
 serde_json = "1.0"
+once_cell = "1.19"
 io-uring = { version = "0.6", optional = true }
 crc32fast = "1.4"
 libc = "0.2.176"

--- a/src/plan/physical_planner/physical_planner.rs
+++ b/src/plan/physical_planner/physical_planner.rs
@@ -45,13 +45,8 @@ impl PhysicalPlanner<'_> {
                 table_schema.clone(),
                 columns.clone(),
             )),
-            LogicalPlan::DropTable(DropTable { 
-                name, 
-                if_exists 
-            }) => {
-                PhysicalPlan::DropTable(PhysicalDropTable::new(
-                name.clone(), 
-                *if_exists))
+            LogicalPlan::DropTable(DropTable { name, if_exists }) => {
+                PhysicalPlan::DropTable(PhysicalDropTable::new(name.clone(), *if_exists))
             }
             LogicalPlan::DropIndex(DropIndex {
                 name,

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -2,6 +2,7 @@ pub mod analysis;
 pub mod control_file;
 pub mod recovery_manager;
 pub mod redo;
+pub mod resource_manager;
 pub mod undo;
 pub mod wal;
 pub mod wal_record;
@@ -13,6 +14,6 @@ pub use wal::{
     Lsn, WalAppendContext, WalAppendResult, WalManager, WalReader, WalRecord, WalWriterHandle,
 };
 pub use wal_record::{
-    decode_frame, CheckpointPayload, PageWritePayload, TransactionPayload, TransactionRecordKind,
-    WalFrame, WalRecordPayload,
+    decode_frame, CheckpointPayload, PageWritePayload, ResourceManagerId, TransactionPayload,
+    TransactionRecordKind, WalFrame, WalRecordPayload,
 };

--- a/src/recovery/resource_manager.rs
+++ b/src/recovery/resource_manager.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use once_cell::sync::Lazy;
+use std::sync::OnceLock;
+
+use crate::buffer::BufferManager;
+use crate::error::{QuillSQLError, QuillSQLResult};
+use crate::recovery::wal_record::{
+    decode_page_delta, decode_page_write, ResourceManagerId, WalFrame,
+};
+use crate::recovery::Lsn;
+use crate::storage::disk_scheduler::DiskScheduler;
+
+#[derive(Clone)]
+pub struct RedoContext {
+    pub disk_scheduler: Arc<DiskScheduler>,
+    pub buffer_pool: Option<Arc<BufferManager>>,
+}
+
+#[derive(Clone)]
+pub struct UndoContext {
+    pub disk_scheduler: Arc<DiskScheduler>,
+    pub buffer_pool: Option<Arc<BufferManager>>,
+}
+
+pub trait ResourceManager: Send + Sync {
+    fn redo(&self, frame: &WalFrame, ctx: &RedoContext) -> QuillSQLResult<usize>;
+    fn undo(&self, frame: &WalFrame, ctx: &UndoContext) -> QuillSQLResult<()>;
+
+    fn transaction_id(&self, _frame: &WalFrame) -> Option<u64> {
+        None
+    }
+}
+
+static REGISTRY: Lazy<RwLock<HashMap<ResourceManagerId, Arc<dyn ResourceManager>>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+pub fn register_resource_manager(id: ResourceManagerId, manager: Arc<dyn ResourceManager>) {
+    let mut guard = REGISTRY
+        .write()
+        .expect("resource manager registry poisoned");
+    guard.insert(id, manager);
+}
+
+pub fn get_resource_manager(id: ResourceManagerId) -> Option<Arc<dyn ResourceManager>> {
+    let guard = REGISTRY.read().expect("resource manager registry poisoned");
+    guard.get(&id).cloned()
+}
+
+#[derive(Default)]
+struct PageResourceManager;
+
+impl PageResourceManager {
+    fn page_requires_redo(
+        &self,
+        ctx: &RedoContext,
+        page_id: u32,
+        record_lsn: Lsn,
+    ) -> QuillSQLResult<bool> {
+        if let Some(bpm) = &ctx.buffer_pool {
+            match bpm.fetch_page_read(page_id) {
+                Ok(guard) => Ok(guard.lsn() < record_lsn),
+                Err(_) => Ok(true),
+            }
+        } else {
+            Ok(true)
+        }
+    }
+
+    fn redo_page_write(
+        &self,
+        ctx: &RedoContext,
+        payload: crate::recovery::wal_record::PageWritePayload,
+    ) -> QuillSQLResult<()> {
+        debug_assert_eq!(payload.page_image.len(), crate::buffer::PAGE_SIZE);
+        let bytes = bytes::Bytes::from(payload.page_image);
+        let rx = ctx.disk_scheduler.schedule_write(payload.page_id, bytes)?;
+        rx.recv().map_err(|e| {
+            QuillSQLError::Internal(format!("WAL recovery write recv failed: {}", e))
+        })??;
+        Ok(())
+    }
+
+    fn redo_page_delta(
+        &self,
+        ctx: &RedoContext,
+        payload: crate::recovery::wal_record::PageDeltaPayload,
+    ) -> QuillSQLResult<()> {
+        let rx = ctx.disk_scheduler.schedule_read(payload.page_id)?;
+        let buf: bytes::BytesMut = rx.recv().map_err(|e| {
+            QuillSQLError::Internal(format!("WAL recovery read recv failed: {}", e))
+        })??;
+        if buf.len() != crate::buffer::PAGE_SIZE {
+            return Err(QuillSQLError::Internal(format!(
+                "Unexpected page size {} while applying delta",
+                buf.len()
+            )));
+        }
+        let mut page_bytes = buf.to_vec();
+        let start = payload.offset as usize;
+        if start >= crate::buffer::PAGE_SIZE {
+            return Err(QuillSQLError::Internal(format!(
+                "PageDelta start out of bounds: offset={} page_size={}",
+                start,
+                crate::buffer::PAGE_SIZE
+            )));
+        }
+        let end = match start.checked_add(payload.data.len()) {
+            Some(e) if e <= crate::buffer::PAGE_SIZE => e,
+            _ => {
+                return Err(QuillSQLError::Internal(format!(
+                    "PageDelta out of bounds: offset={} len={} page_size={}",
+                    start,
+                    payload.data.len(),
+                    crate::buffer::PAGE_SIZE
+                )))
+            }
+        };
+        page_bytes[start..end].copy_from_slice(&payload.data);
+        let rxw = ctx
+            .disk_scheduler
+            .schedule_write(payload.page_id, bytes::Bytes::from(page_bytes))?;
+        rxw.recv().map_err(|e| {
+            QuillSQLError::Internal(format!("WAL recovery write recv failed: {}", e))
+        })??;
+        Ok(())
+    }
+}
+
+impl ResourceManager for PageResourceManager {
+    fn redo(&self, frame: &WalFrame, ctx: &RedoContext) -> QuillSQLResult<usize> {
+        match frame.info {
+            0 => {
+                let payload = decode_page_write(&frame.body)?;
+                if !self.page_requires_redo(ctx, payload.page_id, frame.lsn)? {
+                    return Ok(0);
+                }
+                self.redo_page_write(ctx, payload)?;
+                Ok(1)
+            }
+            1 => {
+                let payload = decode_page_delta(&frame.body)?;
+                if !self.page_requires_redo(ctx, payload.page_id, frame.lsn)? {
+                    return Ok(0);
+                }
+                self.redo_page_delta(ctx, payload)?;
+                Ok(1)
+            }
+            other => Err(QuillSQLError::Internal(format!(
+                "Unknown Page info kind: {}",
+                other
+            ))),
+        }
+    }
+
+    fn undo(&self, _frame: &WalFrame, _ctx: &UndoContext) -> QuillSQLResult<()> {
+        Ok(())
+    }
+}
+
+static DEFAULT_RESOURCE_MANAGERS: OnceLock<()> = OnceLock::new();
+
+pub fn ensure_default_resource_managers_registered() {
+    DEFAULT_RESOURCE_MANAGERS.get_or_init(|| {
+        register_resource_manager(
+            ResourceManagerId::Page,
+            Arc::new(PageResourceManager::default()),
+        );
+        crate::storage::heap_recovery::ensure_heap_resource_manager_registered();
+    });
+}

--- a/src/recovery/undo.rs
+++ b/src/recovery/undo.rs
@@ -1,22 +1,22 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use bytes::{Bytes, BytesMut};
-
-use crate::buffer::{BufferManager, PAGE_SIZE};
+use crate::buffer::BufferManager;
 use crate::error::QuillSQLResult;
+use crate::recovery::resource_manager::{
+    ensure_default_resource_managers_registered, get_resource_manager, UndoContext,
+};
 use crate::recovery::wal_record::{
-    ClrPayload, HeapRecordPayload, TransactionRecordKind, WalFrame, WalRecordPayload,
+    decode_clr, decode_transaction, ClrPayload, ResourceManagerId, TransactionRecordKind, WalFrame,
+    WalRecordPayload,
 };
 use crate::recovery::{Lsn, WalManager};
-use crate::storage::codec::TablePageHeaderCodec;
 use crate::storage::disk_scheduler::DiskScheduler;
-use crate::storage::table_heap::TableHeap;
 
 #[derive(Default)]
 struct UndoRecord {
     next: Option<Lsn>,
-    payload: Option<HeapRecordPayload>,
+    payload: Option<WalFrame>,
 }
 
 #[derive(Default)]
@@ -27,22 +27,10 @@ struct UndoIndex {
 }
 
 impl UndoIndex {
-    fn observe(&mut self, frame: &WalFrame) {
-        match &frame.payload {
-            WalRecordPayload::Heap(rec) => {
-                let txn_id = heap_txn_id(rec);
-                let prev = self.head_for(txn_id);
-                self.entries.insert(
-                    frame.lsn,
-                    UndoRecord {
-                        next: prev,
-                        payload: Some(rec.clone()),
-                    },
-                );
-                self.heads.insert(txn_id, Some(frame.lsn));
-                self.active.insert(txn_id);
-            }
-            WalRecordPayload::Clr(clr) => {
+    fn observe(&mut self, frame: &WalFrame) -> QuillSQLResult<()> {
+        match frame.rmid {
+            ResourceManagerId::Clr => {
+                let clr = decode_clr(&frame.body)?;
                 let next = if clr.undo_next_lsn == 0 {
                     None
                 } else {
@@ -58,18 +46,37 @@ impl UndoIndex {
                 self.heads.insert(clr.txn_id, next);
                 self.active.insert(clr.txn_id);
             }
-            WalRecordPayload::Transaction(tx) => match tx.marker {
-                TransactionRecordKind::Begin => {
-                    self.active.insert(tx.txn_id);
-                    self.heads.entry(tx.txn_id).or_insert(None);
+            ResourceManagerId::Transaction => {
+                let tx = decode_transaction(&frame.body, frame.info)?;
+                match tx.marker {
+                    TransactionRecordKind::Begin => {
+                        self.active.insert(tx.txn_id);
+                        self.heads.entry(tx.txn_id).or_insert(None);
+                    }
+                    TransactionRecordKind::Commit | TransactionRecordKind::Abort => {
+                        self.active.remove(&tx.txn_id);
+                        self.heads.insert(tx.txn_id, None);
+                    }
                 }
-                TransactionRecordKind::Commit | TransactionRecordKind::Abort => {
-                    self.active.remove(&tx.txn_id);
-                    self.heads.insert(tx.txn_id, None);
+            }
+            _ => {
+                if let Some(manager) = get_resource_manager(frame.rmid) {
+                    if let Some(txn_id) = manager.transaction_id(frame) {
+                        let prev = self.head_for(txn_id);
+                        self.entries.insert(
+                            frame.lsn,
+                            UndoRecord {
+                                next: prev,
+                                payload: Some(frame.clone()),
+                            },
+                        );
+                        self.heads.insert(txn_id, Some(frame.lsn));
+                        self.active.insert(txn_id);
+                    }
                 }
-            },
-            _ => {}
+            }
         }
+        Ok(())
     }
 
     fn head_for(&self, txn_id: u64) -> Option<Lsn> {
@@ -106,6 +113,7 @@ impl UndoExecutor {
         disk_scheduler: Arc<DiskScheduler>,
         buffer_pool: Option<Arc<BufferManager>>,
     ) -> Self {
+        ensure_default_resource_managers_registered();
         Self {
             wal,
             disk_scheduler,
@@ -114,8 +122,8 @@ impl UndoExecutor {
         }
     }
 
-    pub fn observe(&mut self, frame: &WalFrame) {
-        self.index.observe(frame);
+    pub fn observe(&mut self, frame: &WalFrame) -> QuillSQLResult<()> {
+        self.index.observe(frame)
     }
 
     pub fn finalize(self) -> QuillSQLResult<UndoOutcome> {
@@ -129,7 +137,13 @@ impl UndoExecutor {
                     break;
                 };
                 if let Some(rec) = &entry.payload {
-                    self.undo_heap_record(rec)?;
+                    if let Some(manager) = get_resource_manager(rec.rmid) {
+                        let ctx = UndoContext {
+                            disk_scheduler: self.disk_scheduler.clone(),
+                            buffer_pool: self.buffer_pool.clone(),
+                        };
+                        manager.undo(rec, &ctx)?;
+                    }
                     let undo_next = entry.next.unwrap_or(0);
                     let clr = self.wal.append_record_with(|_| {
                         WalRecordPayload::Clr(ClrPayload {
@@ -150,131 +164,5 @@ impl UndoExecutor {
             loser_transactions: losers,
             max_clr_lsn,
         })
-    }
-
-    fn undo_heap_record(&self, rec: &HeapRecordPayload) -> QuillSQLResult<()> {
-        match rec {
-            HeapRecordPayload::Insert(body) => {
-                self.apply_tuple_meta_flag(body.page_id, body.slot_id as usize, true)
-            }
-            HeapRecordPayload::Update(body) => {
-                if let (Some(old_meta), Some(old_bytes)) =
-                    (&body.old_tuple_meta, &body.old_tuple_data)
-                {
-                    self.restore_tuple(body.page_id, body.slot_id as usize, *old_meta, old_bytes)
-                } else {
-                    Ok(())
-                }
-            }
-            HeapRecordPayload::Delete(body) => {
-                if let Some(old_bytes) = &body.old_tuple_data {
-                    self.restore_tuple(
-                        body.page_id,
-                        body.slot_id as usize,
-                        body.old_tuple_meta,
-                        old_bytes,
-                    )
-                } else {
-                    self.apply_tuple_meta_flag(body.page_id, body.slot_id as usize, false)
-                }
-            }
-        }
-    }
-
-    fn apply_tuple_meta_flag(
-        &self,
-        page_id: u32,
-        slot_idx: usize,
-        deleted: bool,
-    ) -> QuillSQLResult<()> {
-        if let Some(bpm) = &self.buffer_pool {
-            let rid = crate::storage::page::RecordId::new(page_id, slot_idx as u32);
-            let guard = bpm.fetch_page_read(page_id)?;
-            let (header, _hdr_len) = TablePageHeaderCodec::decode(guard.data())?;
-            drop(guard);
-            if slot_idx >= header.tuple_infos.len() {
-                return Ok(());
-            }
-            let mut new_meta = header.tuple_infos[slot_idx].meta;
-            new_meta.is_deleted = deleted;
-            let heap = TableHeap::recovery_view(bpm.clone());
-            let _ = heap.recover_set_tuple_meta(rid, new_meta);
-            let _ = bpm.flush_page(page_id);
-            return Ok(());
-        }
-        Ok(())
-    }
-
-    fn restore_tuple(
-        &self,
-        page_id: u32,
-        slot_idx: usize,
-        old_meta: crate::recovery::wal_record::TupleMetaRepr,
-        old_bytes: &[u8],
-    ) -> QuillSQLResult<()> {
-        if let Some(bpm) = &self.buffer_pool {
-            let heap = TableHeap::recovery_view(bpm.clone());
-            let rid = crate::storage::page::RecordId::new(page_id, slot_idx as u32);
-            let _ = heap.recover_set_tuple_bytes(rid, old_bytes);
-            let restored_meta: crate::storage::page::TupleMeta = old_meta.into();
-            let _ = heap.recover_set_tuple_meta(rid, restored_meta);
-            let _ = bpm.flush_page(page_id);
-            return Ok(());
-        }
-        let rx = self.disk_scheduler.schedule_read(page_id)?;
-        let buf: BytesMut = rx.recv().map_err(|e| {
-            crate::error::QuillSQLError::Internal(format!("WAL recovery read recv failed: {}", e))
-        })??;
-        let page_bytes = buf.to_vec();
-        let (mut header, _hdr_len) = TablePageHeaderCodec::decode(&page_bytes)?;
-        if slot_idx >= header.tuple_infos.len() {
-            return Ok(());
-        }
-        let tuple_count = header.tuple_infos.len();
-        let mut tuples_bytes: Vec<Vec<u8>> = Vec::with_capacity(tuple_count);
-        for i in 0..tuple_count {
-            let info = &header.tuple_infos[i];
-            let slice = &page_bytes[info.offset as usize..(info.offset + info.size) as usize];
-            if i == slot_idx {
-                tuples_bytes.push(old_bytes.to_vec());
-            } else {
-                tuples_bytes.push(slice.to_vec());
-            }
-        }
-        let mut tail = PAGE_SIZE;
-        for i in 0..tuple_count {
-            let size = tuples_bytes[i].len();
-            tail = tail.saturating_sub(size);
-            header.tuple_infos[i].offset = tail as u16;
-            header.tuple_infos[i].size = size as u16;
-        }
-        let restored_meta: crate::storage::page::TupleMeta = old_meta.into();
-        header.tuple_infos[slot_idx].meta = restored_meta;
-        let new_header_bytes = TablePageHeaderCodec::encode(&header);
-        let mut new_page = vec![0u8; PAGE_SIZE];
-        let max_hdr = std::cmp::min(new_header_bytes.len(), PAGE_SIZE);
-        new_page[0..max_hdr].copy_from_slice(&new_header_bytes[..max_hdr]);
-        for i in 0..tuple_count {
-            let off = header.tuple_infos[i].offset as usize;
-            let sz = header.tuple_infos[i].size as usize;
-            if off + sz <= PAGE_SIZE {
-                new_page[off..off + sz].copy_from_slice(&tuples_bytes[i][..sz]);
-            }
-        }
-        let rxw = self
-            .disk_scheduler
-            .schedule_write(page_id, Bytes::from(new_page))?;
-        rxw.recv().map_err(|e| {
-            crate::error::QuillSQLError::Internal(format!("WAL recovery write recv failed: {}", e))
-        })??;
-        Ok(())
-    }
-}
-
-fn heap_txn_id(rec: &HeapRecordPayload) -> u64 {
-    match rec {
-        HeapRecordPayload::Insert(p) => p.op_txn_id,
-        HeapRecordPayload::Update(p) => p.op_txn_id,
-        HeapRecordPayload::Delete(p) => p.op_txn_id,
     }
 }

--- a/src/storage/heap_recovery.rs
+++ b/src/storage/heap_recovery.rs
@@ -1,0 +1,184 @@
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
+
+use crate::buffer::PAGE_SIZE;
+use crate::error::QuillSQLResult;
+use crate::recovery::resource_manager::{
+    register_resource_manager, RedoContext, ResourceManager, UndoContext,
+};
+use crate::recovery::wal_record::{
+    decode_heap, HeapRecordPayload, ResourceManagerId, TupleMetaRepr, WalFrame,
+};
+use crate::storage::codec::TablePageHeaderCodec;
+use crate::storage::page::{RecordId, TupleMeta};
+use crate::storage::table_heap::TableHeap;
+use std::sync::OnceLock;
+
+#[derive(Default)]
+struct HeapResourceManager;
+
+impl HeapResourceManager {
+    fn decode_payload(&self, frame: &WalFrame) -> QuillSQLResult<HeapRecordPayload> {
+        decode_heap(&frame.body, frame.info)
+    }
+
+    fn heap_txn_id(payload: &HeapRecordPayload) -> u64 {
+        match payload {
+            HeapRecordPayload::Insert(p) => p.op_txn_id,
+            HeapRecordPayload::Update(p) => p.op_txn_id,
+            HeapRecordPayload::Delete(p) => p.op_txn_id,
+        }
+    }
+
+    fn apply_tuple_meta_flag(
+        &self,
+        ctx: &UndoContext,
+        page_id: u32,
+        slot_idx: usize,
+        deleted: bool,
+    ) -> QuillSQLResult<()> {
+        if let Some(bpm) = &ctx.buffer_pool {
+            let rid = RecordId::new(page_id, slot_idx as u32);
+            let guard = bpm.fetch_page_read(page_id)?;
+            let (header, _hdr_len) = TablePageHeaderCodec::decode(guard.data())?;
+            drop(guard);
+            if slot_idx >= header.tuple_infos.len() {
+                return Ok(());
+            }
+            let mut new_meta = header.tuple_infos[slot_idx].meta;
+            new_meta.is_deleted = deleted;
+            let heap = TableHeap::recovery_view(bpm.clone());
+            let _ = heap.recover_set_tuple_meta(rid, new_meta);
+            let _ = bpm.flush_page(page_id);
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    fn restore_tuple(
+        &self,
+        ctx: &UndoContext,
+        page_id: u32,
+        slot_idx: usize,
+        old_meta: TupleMetaRepr,
+        old_bytes: &[u8],
+    ) -> QuillSQLResult<()> {
+        if let Some(bpm) = &ctx.buffer_pool {
+            let heap = TableHeap::recovery_view(bpm.clone());
+            let rid = RecordId::new(page_id, slot_idx as u32);
+            let _ = heap.recover_set_tuple_bytes(rid, old_bytes);
+            let restored_meta: TupleMeta = old_meta.into();
+            let _ = heap.recover_set_tuple_meta(rid, restored_meta);
+            let _ = bpm.flush_page(page_id);
+            return Ok(());
+        }
+
+        let rx = ctx.disk_scheduler.schedule_read(page_id)?;
+        let buf: BytesMut = rx.recv().map_err(|e| {
+            crate::error::QuillSQLError::Internal(format!("WAL recovery read recv failed: {}", e))
+        })??;
+        let page_bytes = buf.to_vec();
+        let (mut header, _hdr_len) = TablePageHeaderCodec::decode(&page_bytes)?;
+        if slot_idx >= header.tuple_infos.len() {
+            return Ok(());
+        }
+        let tuple_count = header.tuple_infos.len();
+        let mut tuples_bytes: Vec<Vec<u8>> = Vec::with_capacity(tuple_count);
+        for i in 0..tuple_count {
+            let info = &header.tuple_infos[i];
+            let slice = &page_bytes[info.offset as usize..(info.offset + info.size) as usize];
+            if i == slot_idx {
+                tuples_bytes.push(old_bytes.to_vec());
+            } else {
+                tuples_bytes.push(slice.to_vec());
+            }
+        }
+        let mut tail = PAGE_SIZE;
+        for i in 0..tuple_count {
+            let size = tuples_bytes[i].len();
+            tail = tail.saturating_sub(size);
+            header.tuple_infos[i].offset = tail as u16;
+            header.tuple_infos[i].size = size as u16;
+        }
+        let restored_meta: TupleMeta = old_meta.into();
+        header.tuple_infos[slot_idx].meta = restored_meta;
+        let new_header_bytes = TablePageHeaderCodec::encode(&header);
+        let mut new_page = vec![0u8; PAGE_SIZE];
+        let max_hdr = std::cmp::min(new_header_bytes.len(), PAGE_SIZE);
+        new_page[0..max_hdr].copy_from_slice(&new_header_bytes[..max_hdr]);
+        for i in 0..tuple_count {
+            let off = header.tuple_infos[i].offset as usize;
+            let sz = header.tuple_infos[i].size as usize;
+            if off + sz <= PAGE_SIZE {
+                new_page[off..off + sz].copy_from_slice(&tuples_bytes[i][..sz]);
+            }
+        }
+        let rxw = ctx
+            .disk_scheduler
+            .schedule_write(page_id, Bytes::from(new_page))?;
+        rxw.recv().map_err(|e| {
+            crate::error::QuillSQLError::Internal(format!("WAL recovery write recv failed: {}", e))
+        })??;
+        Ok(())
+    }
+}
+
+impl ResourceManager for HeapResourceManager {
+    fn redo(&self, _frame: &WalFrame, _ctx: &RedoContext) -> QuillSQLResult<usize> {
+        Ok(0)
+    }
+
+    fn undo(&self, frame: &WalFrame, ctx: &UndoContext) -> QuillSQLResult<()> {
+        let payload = self.decode_payload(frame)?;
+        match payload {
+            HeapRecordPayload::Insert(body) => {
+                self.apply_tuple_meta_flag(ctx, body.page_id, body.slot_id as usize, true)
+            }
+            HeapRecordPayload::Update(body) => {
+                if let (Some(old_meta), Some(old_bytes)) =
+                    (body.old_tuple_meta, body.old_tuple_data.as_deref())
+                {
+                    self.restore_tuple(
+                        ctx,
+                        body.page_id,
+                        body.slot_id as usize,
+                        old_meta,
+                        old_bytes,
+                    )
+                } else {
+                    Ok(())
+                }
+            }
+            HeapRecordPayload::Delete(body) => {
+                if let Some(old_bytes) = body.old_tuple_data.as_deref() {
+                    self.restore_tuple(
+                        ctx,
+                        body.page_id,
+                        body.slot_id as usize,
+                        body.old_tuple_meta,
+                        old_bytes,
+                    )
+                } else {
+                    self.apply_tuple_meta_flag(ctx, body.page_id, body.slot_id as usize, false)
+                }
+            }
+        }
+    }
+
+    fn transaction_id(&self, frame: &WalFrame) -> Option<u64> {
+        let payload = self.decode_payload(frame).ok()?;
+        Some(Self::heap_txn_id(&payload))
+    }
+}
+
+static REGISTER: OnceLock<()> = OnceLock::new();
+
+pub fn ensure_heap_resource_manager_registered() {
+    REGISTER.get_or_init(|| {
+        register_resource_manager(
+            ResourceManagerId::Heap,
+            Arc::new(HeapResourceManager::default()),
+        );
+    });
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,7 @@
 pub mod codec;
 pub mod disk_manager;
 pub mod disk_scheduler;
+pub mod heap_recovery;
 pub mod index;
 pub mod io;
 pub mod page;


### PR DESCRIPTION
## Summary
- introduce a resource manager registry and contexts so redo/undo dispatch through registered handlers
- implement heap recovery logic as a ResourceManager and decode WAL frames lazily with raw payloads
- update analysis/redo/undo pipelines and add a regression test covering heap tuple restoration

## Testing
- cargo test recovery::recovery_manager::tests::replay_heap_update_restores_old_bytes

------
https://chatgpt.com/codex/tasks/task_e_68e0d9b54d908330a27cf43676376122