### PR TITLE
chore: release v0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "clap",
  "quillcache-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-control"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "quillcache-router",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-core"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "serde",
  "thiserror",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-gateway"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "axum",
  "quillcache-control",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-router"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "serde",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-sim"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "quillcache-router",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,21 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [package]
 name = "quillcache"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
-description = "Research prototype for an inference state plane and distributed KV cache manager"
+description = "Vendor-neutral KV cache control plane and evaluation platform for LLM serving"
 license = "MIT"
 repository = "https://github.com/feichai0017/quillcache"
 readme = "README.md"
+keywords = ["llm", "kv-cache", "inference", "serving", "control-plane"]
+categories = ["caching", "development-tools"]
 
 [dependencies]
 clap = { workspace = true }
-quillcache-core = { version = "0.1.0", path = "crates/quillcache-core" }
-quillcache-gateway = { version = "0.1.0", path = "crates/quillcache-gateway" }
-quillcache-router = { version = "0.1.0", path = "crates/quillcache-router" }
-quillcache-sim = { version = "0.1.0", path = "crates/quillcache-sim" }
+quillcache-core = { version = "0.1.0-alpha.1", path = "crates/quillcache-core" }
+quillcache-gateway = { version = "0.1.0-alpha.1", path = "crates/quillcache-gateway" }
+quillcache-router = { version = "0.1.0-alpha.1", path = "crates/quillcache-router" }
+quillcache-sim = { version = "0.1.0-alpha.1", path = "crates/quillcache-sim" }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/quillcache-control/Cargo.toml
+++ b/crates/quillcache-control/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "quillcache-control"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "Control-plane state and policy service for QuillCache"
 license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0" }
-quillcache-router = { path = "../quillcache-router", version = "0.1.0" }
+quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
+quillcache-router = { path = "../quillcache-router", version = "0.1.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quillcache-core/Cargo.toml
+++ b/crates/quillcache-core/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "quillcache-core"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "Core data model and cost model for QuillCache"
 license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/quillcache-gateway/Cargo.toml
+++ b/crates/quillcache-gateway/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "quillcache-gateway"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "OpenAI-compatible gateway and event ingest service for QuillCache"
 license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
 axum = { workspace = true }
-quillcache-control = { path = "../quillcache-control", version = "0.1.0" }
-quillcache-core = { path = "../quillcache-core", version = "0.1.0" }
+quillcache-control = { path = "../quillcache-control", version = "0.1.0-alpha.1" }
+quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/quillcache-router/Cargo.toml
+++ b/crates/quillcache-router/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "quillcache-router"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "Routing policies for QuillCache"
 license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0" }
+quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quillcache-sim/Cargo.toml
+++ b/crates/quillcache-sim/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "quillcache-sim"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "Simulation harness for QuillCache research"
 license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0" }
-quillcache-router = { path = "../quillcache-router", version = "0.1.0" }
+quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
+quillcache-router = { path = "../quillcache-router", version = "0.1.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Release prep for the first alpha.

- Bump all workspace crates to **0.1.0-alpha.1**.
- Complete crates.io metadata: `repository` on every crate; `keywords` + `categories` + the positioning description on the root crate.
- `cargo publish -p quillcache-core --dry-run` packages and verifies cleanly.

Follow-up after merge: tag `v0.1.0-alpha.1`, create the GitHub Release (prerelease), and publish the crates to crates.io in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.0-alpha.1, marking the project as a pre-release.
  * All internal package dependencies were synchronized with the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->