### PR TITLE
chore: release v1.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "clap",
  "quillcache-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-control"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "quillcache-router",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-core"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "serde",
  "thiserror",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-gateway"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "axum",
  "quillcache-control",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-router"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "serde",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "quillcache-sim"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 dependencies = [
  "quillcache-core",
  "quillcache-router",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [package]
 name = "quillcache"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "Vendor-neutral KV cache control plane and evaluation platform for LLM serving"
 license = "MIT"
@@ -42,10 +42,10 @@ categories = ["caching", "development-tools"]
 
 [dependencies]
 clap = { workspace = true }
-quillcache-core = { version = "0.1.0-alpha.1", path = "crates/quillcache-core" }
-quillcache-gateway = { version = "0.1.0-alpha.1", path = "crates/quillcache-gateway" }
-quillcache-router = { version = "0.1.0-alpha.1", path = "crates/quillcache-router" }
-quillcache-sim = { version = "0.1.0-alpha.1", path = "crates/quillcache-sim" }
+quillcache-core = { version = "1.0.0-alpha.1", path = "crates/quillcache-core" }
+quillcache-gateway = { version = "1.0.0-alpha.1", path = "crates/quillcache-gateway" }
+quillcache-router = { version = "1.0.0-alpha.1", path = "crates/quillcache-router" }
+quillcache-sim = { version = "1.0.0-alpha.1", path = "crates/quillcache-sim" }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/quillcache-control/Cargo.toml
+++ b/crates/quillcache-control/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "quillcache-control"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "Control-plane state and policy service for QuillCache"
 license = "MIT"
 repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
-quillcache-router = { path = "../quillcache-router", version = "0.1.0-alpha.1" }
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
+quillcache-router = { path = "../quillcache-router", version = "1.0.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quillcache-core/Cargo.toml
+++ b/crates/quillcache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quillcache-core"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "Core data model and cost model for QuillCache"
 license = "MIT"

--- a/crates/quillcache-gateway/Cargo.toml
+++ b/crates/quillcache-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quillcache-gateway"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "OpenAI-compatible gateway and event ingest service for QuillCache"
 license = "MIT"
@@ -8,8 +8,8 @@ repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
 axum = { workspace = true }
-quillcache-control = { path = "../quillcache-control", version = "0.1.0-alpha.1" }
-quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
+quillcache-control = { path = "../quillcache-control", version = "1.0.0-alpha.1" }
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/quillcache-router/Cargo.toml
+++ b/crates/quillcache-router/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "quillcache-router"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "Routing policies for QuillCache"
 license = "MIT"
 repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quillcache-sim/Cargo.toml
+++ b/crates/quillcache-sim/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "quillcache-sim"
-version = "0.1.0-alpha.1"
+version = "1.0.0-alpha.1"
 edition = "2021"
 description = "Simulation harness for QuillCache research"
 license = "MIT"
 repository = "https://github.com/feichai0017/quillcache"
 
 [dependencies]
-quillcache-core = { path = "../quillcache-core", version = "0.1.0-alpha.1" }
-quillcache-router = { path = "../quillcache-router", version = "0.1.0-alpha.1" }
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
+quillcache-router = { path = "../quillcache-router", version = "1.0.0-alpha.1" }
 serde = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Corrects the alpha version from `0.1.0-alpha.1` to **`1.0.0-alpha.1`** across all workspace crates and inter-crate dependency requirements.

Follow-up after merge: tag `v1.0.0-alpha.1`, publish the crates to crates.io, yank the `0.1.0-alpha.1` versions, and recreate the GitHub Release as `v1.0.0-alpha.1` (the old `v0.1.0-alpha.1` tag/release are deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all project components from version 0.1.0-alpha.1 to 1.0.0-alpha.1 to maintain consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->