### PR TITLE
feat(index): RocksDB (LSM) backend + Memory-vs-LSM benchmark (M1b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,35 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude quillcache-index-rocksdb --all-targets -- -D warnings
 
       - name: build
-        run: cargo build --workspace
+        run: cargo build --workspace --exclude quillcache-index-rocksdb
 
       - name: test
-        run: cargo test --workspace
+        run: cargo test --workspace --exclude quillcache-index-rocksdb
+
+  rocksdb:
+    name: rocksdb backend (LSM)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang/libclang (librocksdb-sys bindgen)
+        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: clippy
+        run: cargo clippy -p quillcache-index-rocksdb --all-targets -- -D warnings
+
+      - name: test
+        run: cargo test -p quillcache-index-rocksdb
+
+      - name: build CLI with rocksdb feature
+        run: cargo build -p quillcache --features rocksdb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,13 +182,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -164,6 +223,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -223,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -312,6 +388,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -556,10 +638,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -580,10 +690,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen 0.69.5",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "litemap"
@@ -602,6 +755,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -631,6 +794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,12 +811,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -673,6 +852,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -708,6 +893,7 @@ dependencies = [
  "clap",
  "quillcache-core",
  "quillcache-gateway",
+ "quillcache-index-rocksdb",
  "quillcache-router",
  "quillcache-sim",
  "serde_json",
@@ -750,6 +936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillcache-index-rocksdb"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "quillcache-core",
+ "rocksdb",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "quillcache-router"
 version = "1.0.0-alpha.1"
 dependencies = [
@@ -779,7 +975,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror",
@@ -799,7 +995,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -865,6 +1061,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -935,6 +1143,22 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1079,6 +1303,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -1112,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1416,6 +1646,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
@@ -1800,4 +2036,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/quillcache-gateway",
     "crates/quillcache-router",
     "crates/quillcache-sim",
+    "crates/quillcache-index-rocksdb",
 ]
 default-members = [
     ".",
@@ -46,6 +47,12 @@ quillcache-core = { version = "1.0.0-alpha.1", path = "crates/quillcache-core" }
 quillcache-gateway = { version = "1.0.0-alpha.1", path = "crates/quillcache-gateway" }
 quillcache-router = { version = "1.0.0-alpha.1", path = "crates/quillcache-router" }
 quillcache-sim = { version = "1.0.0-alpha.1", path = "crates/quillcache-sim" }
+quillcache-index-rocksdb = { version = "1.0.0-alpha.1", path = "crates/quillcache-index-rocksdb", optional = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[features]
+# Optional RocksDB (LSM) index backend. Off by default so `cargo install
+# quillcache` stays light and the core CI job needs no C++/libclang toolchain.
+rocksdb = ["dep:quillcache-index-rocksdb"]

--- a/crates/quillcache-index-rocksdb/Cargo.toml
+++ b/crates/quillcache-index-rocksdb/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quillcache-index-rocksdb"
+version = "1.0.0-alpha.1"
+edition = "2021"
+description = "RocksDB (LSM) residency-index backend for QuillCache"
+license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
+
+[dependencies]
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
+rocksdb = "0.22"
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/quillcache-index-rocksdb/src/lib.rs
+++ b/crates/quillcache-index-rocksdb/src/lib.rs
@@ -1,0 +1,316 @@
+//! RocksDB (LSM) residency-index backend for QuillCache — the LSM baseline in
+//! the ART-vs-LSM study.
+//!
+//! Keys are encoded so that an identity-scoped `prefix_scan` becomes a RocksDB
+//! range scan:
+//!
+//! ```text
+//! model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0 block_hash \0
+//!   block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
+//! ```
+//!
+//! `put` is a single write (no read-modify-write), so the store behaves like a
+//! real LSM under ingest. The value is one [`CacheResidency`]; a block resident
+//! on several workers/tiers maps to several keys sharing a block prefix.
+
+use quillcache_core::{CacheResidency, IdentityScope, IndexBackend, IndexMetrics, KvBlockKey};
+use rocksdb::{Direction, IteratorMode, Options, DB};
+use std::path::{Path, PathBuf};
+
+const SEP: u8 = 0x00;
+
+/// A persistent residency index backed by RocksDB (an LSM-tree store).
+pub struct RocksIndex {
+    db: DB,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for RocksIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksIndex")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl RocksIndex {
+    /// Open (creating if missing) a RocksDB-backed index at `path`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, rocksdb::Error> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, path.as_ref())?;
+        Ok(Self {
+            db,
+            path: path.as_ref().to_path_buf(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Force a full compaction so on-disk size reflects the merged state.
+    pub fn compact(&self) {
+        self.db.compact_range(None::<&[u8]>, None::<&[u8]>);
+    }
+
+    /// Total size of the on-disk SST files, in bytes.
+    pub fn on_disk_bytes(&self) -> u64 {
+        self.db
+            .property_int_value("rocksdb.total-sst-files-size")
+            .ok()
+            .flatten()
+            .unwrap_or(0)
+    }
+
+    fn enc_scope(
+        buf: &mut Vec<u8>,
+        model: &str,
+        tokenizer: &str,
+        adapter: Option<&str>,
+        tenant: &str,
+    ) {
+        buf.extend_from_slice(model.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(tokenizer.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(adapter.unwrap_or("").as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(tenant.as_bytes());
+        buf.push(SEP);
+    }
+
+    fn scope_prefix(scope: &IdentityScope) -> Vec<u8> {
+        let mut buf = Vec::new();
+        Self::enc_scope(
+            &mut buf,
+            &scope.model_id,
+            &scope.tokenizer_id,
+            scope.adapter_id.as_deref(),
+            &scope.tenant_id,
+        );
+        buf
+    }
+
+    fn key_for(residency: &CacheResidency) -> Vec<u8> {
+        let k = &residency.key;
+        let mut buf = Vec::new();
+        Self::enc_scope(
+            &mut buf,
+            &k.model_id,
+            &k.tokenizer_id,
+            k.adapter_id.as_deref(),
+            &k.tenant_id,
+        );
+        buf.extend_from_slice(k.prefix_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(k.block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(&k.block_index.to_be_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.worker_id.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf
+    }
+
+    fn scan_prefix(&self, prefix: &[u8]) -> Vec<CacheResidency> {
+        let mut out = Vec::new();
+        for item in self
+            .db
+            .iterator(IteratorMode::From(prefix, Direction::Forward))
+        {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(_) => break,
+            };
+            if !k.starts_with(prefix) {
+                break;
+            }
+            if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
+                out.push(residency);
+            }
+        }
+        out
+    }
+}
+
+impl IndexBackend for RocksIndex {
+    fn name(&self) -> &str {
+        "rocksdb"
+    }
+
+    fn put(&mut self, residency: CacheResidency) {
+        let key = Self::key_for(&residency);
+        if let Ok(value) = serde_json::to_vec(&residency) {
+            let _ = self.db.put(key, value);
+        }
+    }
+
+    fn locate(&self, key: &KvBlockKey) -> Vec<CacheResidency> {
+        let mut prefix = Self::scope_prefix(&IdentityScope::from_key(key));
+        prefix.extend_from_slice(key.prefix_hash.as_bytes());
+        prefix.push(SEP);
+        prefix.extend_from_slice(key.block_hash.as_bytes());
+        prefix.push(SEP);
+        prefix.extend_from_slice(&key.block_index.to_be_bytes());
+        prefix.push(SEP);
+        self.scan_prefix(&prefix)
+    }
+
+    fn prefix_scan(&self, scope: &IdentityScope, prefix_hash: &str) -> Vec<CacheResidency> {
+        let mut prefix = Self::scope_prefix(scope);
+        prefix.extend_from_slice(prefix_hash.as_bytes());
+        prefix.push(SEP);
+        self.scan_prefix(&prefix)
+    }
+
+    fn remove_block(&mut self, scope: &IdentityScope, worker_id: &str, block_hash: &str) -> usize {
+        let prefix = Self::scope_prefix(scope);
+        let mut to_delete = Vec::new();
+        for item in self
+            .db
+            .iterator(IteratorMode::From(prefix.as_slice(), Direction::Forward))
+        {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(_) => break,
+            };
+            if !k.starts_with(prefix.as_slice()) {
+                break;
+            }
+            if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
+                if residency.key.block_hash == block_hash && residency.worker_id == worker_id {
+                    to_delete.push(k);
+                }
+            }
+        }
+        let mut removed = 0;
+        for k in to_delete {
+            if self.db.delete(&k).is_ok() {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    fn clear_worker(&mut self, worker_id: &str) {
+        let mut to_delete = Vec::new();
+        for item in self.db.iterator(IteratorMode::Start) {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(_) => break,
+            };
+            if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
+                if residency.worker_id == worker_id {
+                    to_delete.push(k);
+                }
+            }
+        }
+        for k in to_delete {
+            let _ = self.db.delete(&k);
+        }
+    }
+
+    fn clear(&mut self) {
+        let keys: Vec<_> = self
+            .db
+            .iterator(IteratorMode::Start)
+            .filter_map(Result::ok)
+            .map(|(k, _)| k)
+            .collect();
+        for k in keys {
+            let _ = self.db.delete(&k);
+        }
+    }
+
+    fn snapshot(&self) -> Vec<CacheResidency> {
+        let mut out = Vec::new();
+        for item in self.db.iterator(IteratorMode::Start) {
+            let (_, v) = match item {
+                Ok(kv) => kv,
+                Err(_) => break,
+            };
+            if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
+                out.push(residency);
+            }
+        }
+        out
+    }
+
+    fn len(&self) -> usize {
+        self.db
+            .iterator(IteratorMode::Start)
+            .filter_map(Result::ok)
+            .count()
+    }
+
+    fn persistent(&self) -> bool {
+        true
+    }
+
+    fn metrics(&self) -> IndexMetrics {
+        let snapshot = self.snapshot();
+        IndexMetrics {
+            resident_blocks: snapshot.len() as u64,
+            resident_bytes: snapshot.iter().map(|residency| residency.bytes).sum(),
+            bytes_written: self.on_disk_bytes(),
+            ..IndexMetrics::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quillcache_core::KvBlockKey;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("quillcache-rocks-{}-{}", tag, std::process::id()))
+    }
+
+    fn scope() -> IdentityScope {
+        IdentityScope {
+            model_id: "m".to_string(),
+            tokenizer_id: "t".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+        }
+    }
+
+    fn block(prefix: &str, hash: &str, idx: u32) -> KvBlockKey {
+        KvBlockKey::new("m", "t", "tenant-a", prefix, hash, idx, 64)
+    }
+
+    #[test]
+    fn put_scan_remove_and_persist_across_reopen() {
+        let dir = temp_dir("roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let mut idx = RocksIndex::open(&dir).unwrap();
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w0", block("b0", "b1", 1), 1024));
+            // prefix_scan is identity-scoped and prefix-addressed.
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+            // a different tenant with the same prefix must not match.
+            let other = IdentityScope {
+                tenant_id: "tenant-b".to_string(),
+                ..scope()
+            };
+            assert!(idx.prefix_scan(&other, "root").is_empty());
+            assert_eq!(idx.len(), 2);
+            // remove one block.
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
+            assert_eq!(idx.len(), 1);
+        }
+        // reopen: state survives (persistence).
+        {
+            let idx = RocksIndex::open(&dir).unwrap();
+            assert!(idx.persistent());
+            assert_eq!(idx.len(), 1);
+            assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/quillcache-sim/src/index_bench.rs
+++ b/crates/quillcache-sim/src/index_bench.rs
@@ -52,6 +52,8 @@ pub struct IndexBenchReport {
     pub scan_mean_us: f64,
     pub scan_p50_us: f64,
     pub scan_p99_us: f64,
+    /// Reopen-from-disk time for persistent backends; `None` for in-memory.
+    pub recovery_ms: Option<f64>,
     pub metrics: IndexMetrics,
 }
 
@@ -155,6 +157,7 @@ pub fn bench_index<B: IndexBackend + ?Sized>(
         scan_mean_us,
         scan_p50_us,
         scan_p99_us,
+        recovery_ms: None,
         metrics: backend.metrics(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             let report = match backend.as_str() {
                 "memory" => bench_index(&mut MemoryIndex::new(), config),
+                #[cfg(feature = "rocksdb")]
+                "rocksdb" => bench_rocksdb(config)?,
                 other => {
                     return Err(format!(
-                        "unknown index backend '{other}' (available: memory; rocksdb/holt land in M1b/M2)"
+                        "unknown index backend '{other}' (available: memory, rocksdb [build with --features rocksdb]; holt lands in M2)"
                     )
                     .into())
                 }
@@ -146,14 +148,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     report.scan_queries
                 );
                 println!(
-                    "resident blocks: {} · bytes_written: {}",
+                    "resident blocks: {} · bytes_written (on-disk): {}",
                     report.metrics.resident_blocks, report.metrics.bytes_written
                 );
+                if let Some(ms) = report.recovery_ms {
+                    println!("recovery (reopen from disk): {:.2} ms", ms);
+                }
             }
         }
     }
 
     Ok(())
+}
+
+#[cfg(feature = "rocksdb")]
+fn bench_rocksdb(
+    config: IndexBenchConfig,
+) -> Result<quillcache_sim::IndexBenchReport, Box<dyn std::error::Error>> {
+    use quillcache_core::IndexBackend;
+    use quillcache_index_rocksdb::RocksIndex;
+
+    let dir = std::env::temp_dir().join(format!("quillcache-bench-rocksdb-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let mut index = RocksIndex::open(&dir)?;
+    let mut report = bench_index(&mut index, config);
+    // Merge to one level so the reported on-disk size reflects the compacted state.
+    index.compact();
+    report.metrics = index.metrics();
+    drop(index);
+
+    // Recovery: reopen the index from disk and time it.
+    let started = std::time::Instant::now();
+    let reopened = RocksIndex::open(&dir)?;
+    let recovery_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    let _ = reopened.len();
+    drop(reopened);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    report.recovery_ms = Some(recovery_ms);
+    Ok(report)
 }
 
 fn print_plan() {


### PR DESCRIPTION
Second step of the ART-vs-LSM study: the **LSM baseline**.

## What
- New crate **`quillcache-index-rocksdb`**: a persistent `IndexBackend` over RocksDB. Keys are encoded so identity-scoped `prefix_scan` is a RocksDB range scan; `put` is a single write; `metrics.bytes_written` reports on-disk SST size; recovery is measured by reopening from disk.
- CLI: `quillcache bench-index --backend rocksdb` (behind an optional **`rocksdb`** feature — off by default so `cargo install quillcache` and the core CI job stay light and need no C++/libclang toolchain).
- `IndexBenchReport` gains `recovery_ms`.
- CI: core job now excludes the rocksdb crate; a dedicated **`rocksdb`** job installs clang/libclang and builds + tests the crate and the `--features rocksdb` CLI.

## First comparison (40k puts · 8016 resident · 20k prefix scans)
| metric | memory | rocksdb |
| --- | --- | --- |
| ingest | 725k puts/s | 57k puts/s |
| prefix_scan p50 | 494 µs | **17 µs** |
| prefix_scan p99 | 519 µs | **22 µs** |
| persistent / recovery | no | yes / 3.8 ms |
| on-disk | 0 | 500 KB |

The flat in-memory map does **O(N)** prefix scans; the ordered LSM is **~30× faster on prefix_scan** but ~13× slower on ingest. M2 (Holt/ART) targets best-of-both: prefix-native reads *and* fast writes, persistent, no compaction write-amplification.

## Verification
Core path: `fmt --check` · `clippy --workspace --exclude quillcache-index-rocksdb -D warnings` · build · test — green.
RocksDB path: `clippy -p quillcache-index-rocksdb -D warnings` · `test -p quillcache-index-rocksdb` (open/put/scan/remove/persist-reopen) · `build -p quillcache --features rocksdb` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RocksDB-backed index storage backend now available as an optional feature, enabling persistent cache residency management and efficient lookups.
  * Benchmarking tools expanded with RocksDB backend support, including recovery time measurement capabilities.

* **Chores**
  * CI workflows updated for comprehensive testing and validation of the new RocksDB backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->