### PR TITLE
feat(index): Holt (ART) backend + 3-way ART-vs-LSM benchmark (M2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: test
         run: cargo test --workspace --exclude quillcache-index-rocksdb
 
+      - name: build CLI with holt feature
+        run: cargo build -p quillcache --features holt
+
   rocksdb:
     name: rocksdb backend (LSM)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +435,12 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -406,6 +450,20 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "holt"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576f0d0563f9bbf7f00c99d07ce45ac92496462cddf9a29f12ec5286b7f5f69f"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "dashmap",
+ "io-uring",
+ "libc",
+ "smallvec",
+]
 
 [[package]]
 name = "http"
@@ -622,7 +680,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -745,6 +814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +920,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +984,7 @@ dependencies = [
  "clap",
  "quillcache-core",
  "quillcache-gateway",
+ "quillcache-index-holt",
  "quillcache-index-rocksdb",
  "quillcache-router",
  "quillcache-sim",
@@ -933,6 +1025,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "quillcache-index-holt"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "holt",
+ "quillcache-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -1061,6 +1162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1212,6 +1322,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/quillcache-router",
     "crates/quillcache-sim",
     "crates/quillcache-index-rocksdb",
+    "crates/quillcache-index-holt",
 ]
 default-members = [
     ".",
@@ -15,6 +16,7 @@ default-members = [
     "crates/quillcache-gateway",
     "crates/quillcache-router",
     "crates/quillcache-sim",
+    "crates/quillcache-index-holt",
 ]
 resolver = "2"
 
@@ -48,6 +50,7 @@ quillcache-gateway = { version = "1.0.0-alpha.1", path = "crates/quillcache-gate
 quillcache-router = { version = "1.0.0-alpha.1", path = "crates/quillcache-router" }
 quillcache-sim = { version = "1.0.0-alpha.1", path = "crates/quillcache-sim" }
 quillcache-index-rocksdb = { version = "1.0.0-alpha.1", path = "crates/quillcache-index-rocksdb", optional = true }
+quillcache-index-holt = { version = "1.0.0-alpha.1", path = "crates/quillcache-index-holt", optional = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -56,3 +59,6 @@ tracing-subscriber = { workspace = true }
 # Optional RocksDB (LSM) index backend. Off by default so `cargo install
 # quillcache` stays light and the core CI job needs no C++/libclang toolchain.
 rocksdb = ["dep:quillcache-index-rocksdb"]
+# Optional Holt (persistent ART) index backend. Pure Rust; off by default to keep
+# the installed binary minimal.
+holt = ["dep:quillcache-index-holt"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mode runs one chosen combination in front of real engines.
 | --- | --- | --- | --- |
 | Inference engine / connector | `EngineEndpoint` + KV events | vLLM (OpenAI-compatible + KV events) | SGLang, LMCache events |
 | Routing policy | `quillcache_core` → `quillcache_router::RoutingPolicy` | `LeastLoadedRouter` (baseline), `GreedyStatePlaneRouter` (cache-aware) | SLO-aware, session/DAG-aware |
-| Index backend | `quillcache_core::IndexBackend` | `MemoryIndex` (reference) | **Holt** (ART), **RocksDB** (LSM), filesystem |
+| Index backend | `quillcache_core::IndexBackend` | `MemoryIndex` (reference), **Holt** (ART), **RocksDB** (LSM) | filesystem |
 
 ## Two "KV"s, two "backends" (read this first)
 
@@ -103,6 +103,27 @@ point-lookup p50/p99, ingest throughput, restart recovery time, on-disk size. A
 recently published RocksDB/LSM approach left write amplification unanalyzed —
 that gap is the first measurable result.
 
+### First results
+
+Same workload (2000 requests, 8016 resident blocks, 20k `prefix_scan` queries),
+same `IndexBackend` trait, via `quillcache bench-index`:
+
+| backend | ingest (puts/s) | prefix_scan p50 | prefix_scan p99 | recovery | on-disk |
+| --- | --- | --- | --- | --- | --- |
+| memory (flat map) | 706k | 494 µs | 1685 µs | — | 0 |
+| rocksdb (LSM) | 56k | 16.8 µs | 29.6 µs | 4.1 ms | 500 KB |
+| **holt (ART)** | 55k | **9.96 µs** | **13.7 µs** | **2.6 ms** | 8.4 MB |
+
+For the prefix-heavy residency workload, **ART (Holt) gives the lowest
+prefix-scan latency** (~1.7× faster than LSM at p50, ~2.2× at p99; ~50× faster
+than the flat in-memory map's O(N) scan) and the fastest recovery. **LSM
+(RocksDB) is far more space-efficient on disk** (compression + compaction).
+Ingest is comparable between the two persistent backends and ~13× slower than
+in-memory — the cost of durability. So pick ART when prefix-scan latency and
+recovery dominate (the common case for a residency index queried per request),
+pick LSM when on-disk footprint is the constraint. Numbers are from one machine;
+reproduce with `cargo run --features "rocksdb holt" -- bench-index --backend <b>`.
+
 ## Packages
 
 | Package | Role |
@@ -113,6 +134,8 @@ that gap is the first measurable result.
 | `quillcache-control` | `ControlPlane` and the backend-agnostic `ingest_batch` (KV events → residency). |
 | `quillcache-gateway` | OpenAI-compatible proxy + `/v1/kv-events` ingest + `/v1/state`. |
 | `quillcache-sim` | Experiment-mode harness: replay a trace over any policy × any backend. |
+| `quillcache-index-rocksdb` | RocksDB (LSM) `IndexBackend` (optional `rocksdb` feature; needs a C++ toolchain). |
+| `quillcache-index-holt` | Holt (persistent ART) `IndexBackend` (optional `holt` feature; pure Rust). |
 
 ## Quick start
 
@@ -122,6 +145,11 @@ that gap is the first measurable result.
 cargo run -- simulate
 cargo run -- simulate --requests 64 --workers 4 --shared-prefix-blocks 12
 cargo run -- simulate --json
+
+# Compare index storage engines (memory vs LSM vs ART) on one trace.
+cargo run --features "rocksdb holt" -- bench-index --backend memory
+cargo run --features "rocksdb holt" -- bench-index --backend rocksdb
+cargo run --features "rocksdb holt" -- bench-index --backend holt
 
 # Print the research plan / build order.
 cargo run -- plan
@@ -156,12 +184,12 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ Single `IndexBackend` seam with an in-memory reference backend + identity-aware prefix scan.
 - ✅ Pluggable `RoutingPolicy` with a load-only baseline and a cache-aware policy.
 - ✅ Experiment harness comparing policies × backends on one trace.
-- ⏳ Holt (ART) and RocksDB (LSM) index backends + ART-vs-LSM benchmark.
+- ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.
 - ⏳ vLLM ZMQ/msgpack KV-event bridge wired end-to-end; SGLang connector.
 
 ## Roadmap
 
-1. Holt (ART) and RocksDB (LSM) `IndexBackend`s; run the ART-vs-LSM benchmark.
+1. ✅ Holt (ART) + RocksDB (LSM) `IndexBackend`s + ART-vs-LSM benchmark — done; next: deepen it (true write-amplification, Holt compaction/on-disk, larger traces).
 2. SLO-aware and session/DAG-aware routing policies.
 3. Real vLLM/SGLang KV-event connectors end-to-end; chat / RAG / agent traces.
 4. Tiered placement and eviction across HBM / DRAM / SSD / remote.

--- a/crates/quillcache-index-holt/Cargo.toml
+++ b/crates/quillcache-index-holt/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quillcache-index-holt"
+version = "1.0.0-alpha.1"
+edition = "2021"
+description = "Holt (persistent adaptive-radix-tree) residency-index backend for QuillCache"
+license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
+
+[dependencies]
+quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
+holt = "0.5.4"
+serde_json = { workspace = true }

--- a/crates/quillcache-index-holt/src/lib.rs
+++ b/crates/quillcache-index-holt/src/lib.rs
@@ -1,0 +1,310 @@
+//! Holt (persistent ART) residency-index backend — the ART arm of the
+//! ART-vs-LSM study.
+//!
+//! Holt is an adaptive-radix-tree store for **path-shaped keys** with crash-safe
+//! (WAL) persistence, so an identity-scoped `prefix_scan` maps directly onto
+//! `Tree::scan(prefix)` and is prefix-native (no full-table scan, no LSM
+//! compaction). Keys use the same path-shaped encoding as the RocksDB backend:
+//!
+//! ```text
+//! model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0 block_hash \0
+//!   block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
+//! ```
+
+use holt::{Durability, RangeEntry, Tree, TreeBuilder};
+use quillcache_core::{CacheResidency, IdentityScope, IndexBackend, IndexMetrics, KvBlockKey};
+use std::path::{Path, PathBuf};
+
+const SEP: u8 = 0x00;
+
+/// A persistent residency index backed by Holt (an adaptive radix tree).
+pub struct HoltIndex {
+    tree: Tree,
+    dir: PathBuf,
+}
+
+impl std::fmt::Debug for HoltIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HoltIndex").field("dir", &self.dir).finish()
+    }
+}
+
+impl HoltIndex {
+    /// Open (creating if missing) a Holt-backed index under directory `dir`.
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self, holt::Error> {
+        let dir = dir.as_ref().to_path_buf();
+        let _ = std::fs::create_dir_all(&dir);
+        let tree = TreeBuilder::new(dir.join("index.holt"))
+            .durability(Durability::Wal { sync: false })
+            .open()?;
+        Ok(Self { tree, dir })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Checkpoint the WAL so on-disk state reflects all writes.
+    pub fn flush(&self) {
+        let _ = self.tree.checkpoint();
+    }
+
+    /// On-disk footprint (sum of files under the index directory), in bytes.
+    pub fn on_disk_bytes(&self) -> u64 {
+        fn dir_size(path: &Path) -> u64 {
+            let mut total = 0;
+            if let Ok(entries) = std::fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    match entry.metadata() {
+                        Ok(meta) if meta.is_dir() => total += dir_size(&entry.path()),
+                        Ok(meta) => total += meta.len(),
+                        Err(_) => {}
+                    }
+                }
+            }
+            total
+        }
+        dir_size(&self.dir)
+    }
+
+    fn enc_scope(
+        buf: &mut Vec<u8>,
+        model: &str,
+        tokenizer: &str,
+        adapter: Option<&str>,
+        tenant: &str,
+    ) {
+        buf.extend_from_slice(model.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(tokenizer.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(adapter.unwrap_or("").as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(tenant.as_bytes());
+        buf.push(SEP);
+    }
+
+    fn scope_prefix(scope: &IdentityScope) -> Vec<u8> {
+        let mut buf = Vec::new();
+        Self::enc_scope(
+            &mut buf,
+            &scope.model_id,
+            &scope.tokenizer_id,
+            scope.adapter_id.as_deref(),
+            &scope.tenant_id,
+        );
+        buf
+    }
+
+    fn key_for(residency: &CacheResidency) -> Vec<u8> {
+        let k = &residency.key;
+        let mut buf = Vec::new();
+        Self::enc_scope(
+            &mut buf,
+            &k.model_id,
+            &k.tokenizer_id,
+            k.adapter_id.as_deref(),
+            &k.tenant_id,
+        );
+        buf.extend_from_slice(k.prefix_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(k.block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(&k.block_index.to_be_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.worker_id.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf
+    }
+
+    fn scan_prefix(&self, prefix: &[u8]) -> Vec<CacheResidency> {
+        let mut out = Vec::new();
+        for entry in self.tree.scan(prefix) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => break,
+            };
+            if let RangeEntry::Key { value, .. } = entry {
+                if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
+                    out.push(residency);
+                }
+            }
+        }
+        out
+    }
+}
+
+impl IndexBackend for HoltIndex {
+    fn name(&self) -> &str {
+        "holt"
+    }
+
+    fn put(&mut self, residency: CacheResidency) {
+        let key = Self::key_for(&residency);
+        if let Ok(value) = serde_json::to_vec(&residency) {
+            let _ = self.tree.put(&key, &value);
+        }
+    }
+
+    fn locate(&self, key: &KvBlockKey) -> Vec<CacheResidency> {
+        let mut prefix = Self::scope_prefix(&IdentityScope::from_key(key));
+        prefix.extend_from_slice(key.prefix_hash.as_bytes());
+        prefix.push(SEP);
+        prefix.extend_from_slice(key.block_hash.as_bytes());
+        prefix.push(SEP);
+        prefix.extend_from_slice(&key.block_index.to_be_bytes());
+        prefix.push(SEP);
+        self.scan_prefix(&prefix)
+    }
+
+    fn prefix_scan(&self, scope: &IdentityScope, prefix_hash: &str) -> Vec<CacheResidency> {
+        let mut prefix = Self::scope_prefix(scope);
+        prefix.extend_from_slice(prefix_hash.as_bytes());
+        prefix.push(SEP);
+        self.scan_prefix(&prefix)
+    }
+
+    fn remove_block(&mut self, scope: &IdentityScope, worker_id: &str, block_hash: &str) -> usize {
+        let prefix = Self::scope_prefix(scope);
+        let mut to_delete: Vec<Vec<u8>> = Vec::new();
+        for entry in self.tree.scan(&prefix) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => break,
+            };
+            if let RangeEntry::Key { key, value, .. } = entry {
+                if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
+                    if residency.key.block_hash == block_hash && residency.worker_id == worker_id {
+                        to_delete.push(key.to_vec());
+                    }
+                }
+            }
+        }
+        let mut removed = 0;
+        for key in to_delete {
+            if self.tree.delete(key.as_slice()).unwrap_or(false) {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    fn clear_worker(&mut self, worker_id: &str) {
+        let mut to_delete: Vec<Vec<u8>> = Vec::new();
+        for entry in self.tree.range() {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => break,
+            };
+            if let RangeEntry::Key { key, value, .. } = entry {
+                if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
+                    if residency.worker_id == worker_id {
+                        to_delete.push(key.to_vec());
+                    }
+                }
+            }
+        }
+        for key in to_delete {
+            let _ = self.tree.delete(key.as_slice());
+        }
+    }
+
+    fn clear(&mut self) {
+        let mut to_delete: Vec<Vec<u8>> = Vec::new();
+        for entry in self.tree.range() {
+            if let Ok(RangeEntry::Key { key, .. }) = entry {
+                to_delete.push(key.to_vec());
+            }
+        }
+        for key in to_delete {
+            let _ = self.tree.delete(key.as_slice());
+        }
+    }
+
+    fn snapshot(&self) -> Vec<CacheResidency> {
+        let mut out = Vec::new();
+        for entry in self.tree.range() {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => break,
+            };
+            if let RangeEntry::Key { value, .. } = entry {
+                if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
+                    out.push(residency);
+                }
+            }
+        }
+        out
+    }
+
+    fn len(&self) -> usize {
+        self.tree.range().into_iter().filter_map(Result::ok).count()
+    }
+
+    fn persistent(&self) -> bool {
+        true
+    }
+
+    fn metrics(&self) -> IndexMetrics {
+        let snapshot = self.snapshot();
+        IndexMetrics {
+            resident_blocks: snapshot.len() as u64,
+            resident_bytes: snapshot.iter().map(|residency| residency.bytes).sum(),
+            bytes_written: self.on_disk_bytes(),
+            ..IndexMetrics::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quillcache_core::KvBlockKey;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("quillcache-holt-{}-{}", tag, std::process::id()))
+    }
+
+    fn scope() -> IdentityScope {
+        IdentityScope {
+            model_id: "m".to_string(),
+            tokenizer_id: "t".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+        }
+    }
+
+    fn block(prefix: &str, hash: &str, idx: u32) -> KvBlockKey {
+        KvBlockKey::new("m", "t", "tenant-a", prefix, hash, idx, 64)
+    }
+
+    #[test]
+    fn put_scan_remove_and_persist_across_reopen() {
+        let dir = temp_dir("roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let mut idx = HoltIndex::open(&dir).unwrap();
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w0", block("b0", "b1", 1), 1024));
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+            let other = IdentityScope {
+                tenant_id: "tenant-b".to_string(),
+                ..scope()
+            };
+            assert!(idx.prefix_scan(&other, "root").is_empty());
+            assert_eq!(idx.len(), 2);
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
+            assert_eq!(idx.len(), 1);
+            idx.flush();
+        }
+        {
+            let idx = HoltIndex::open(&dir).unwrap();
+            assert!(idx.persistent());
+            assert_eq!(idx.len(), 1);
+            assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/docs/index-backends.md
+++ b/docs/index-backends.md
@@ -42,8 +42,8 @@ make stronger safety claims.
 | Backend | Status | Purpose |
 | --- | --- | --- |
 | Memory | v0.1 implemented | Fast smoke tests, routing experiments, and local gateway demos. |
-| Holt ART | planned | Persistent prefix/residency index with prefix-native lookups and crash recovery. |
-| RocksDB/LSM | planned baseline | Compare write amplification, recovery, and prefix-scan behavior against ART. |
+| Holt ART | implemented | Persistent prefix/residency index with prefix-native lookups and crash recovery (`quillcache-index-holt`). |
+| RocksDB/LSM | implemented | LSM baseline for write amplification, recovery, and prefix-scan vs ART (`quillcache-index-rocksdb`). |
 | Filesystem catalog | planned baseline | Emulate simple block catalog designs used by file-backed KV offload systems. |
 
 ## Holt Integration Shape

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "memory" => bench_index(&mut MemoryIndex::new(), config),
                 #[cfg(feature = "rocksdb")]
                 "rocksdb" => bench_rocksdb(config)?,
+                #[cfg(feature = "holt")]
+                "holt" => bench_holt(config)?,
                 other => {
                     return Err(format!(
-                        "unknown index backend '{other}' (available: memory, rocksdb [build with --features rocksdb]; holt lands in M2)"
+                        "unknown index backend '{other}' (available: memory, rocksdb, holt — build with --features rocksdb,holt)"
                     )
                     .into())
                 }
@@ -181,6 +183,35 @@ fn bench_rocksdb(
     // Recovery: reopen the index from disk and time it.
     let started = std::time::Instant::now();
     let reopened = RocksIndex::open(&dir)?;
+    let recovery_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    let _ = reopened.len();
+    drop(reopened);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    report.recovery_ms = Some(recovery_ms);
+    Ok(report)
+}
+
+#[cfg(feature = "holt")]
+fn bench_holt(
+    config: IndexBenchConfig,
+) -> Result<quillcache_sim::IndexBenchReport, Box<dyn std::error::Error>> {
+    use quillcache_core::IndexBackend;
+    use quillcache_index_holt::HoltIndex;
+
+    let dir = std::env::temp_dir().join(format!("quillcache-bench-holt-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let mut index = HoltIndex::open(&dir).map_err(|e| format!("holt open: {e:?}"))?;
+    let mut report = bench_index(&mut index, config);
+    // Checkpoint the WAL so the reported on-disk size reflects all writes.
+    index.flush();
+    report.metrics = index.metrics();
+    drop(index);
+
+    // Recovery: reopen the index from disk (WAL replay) and time it.
+    let started = std::time::Instant::now();
+    let reopened = HoltIndex::open(&dir).map_err(|e| format!("holt reopen: {e:?}"))?;
     let recovery_ms = started.elapsed().as_secs_f64() * 1_000.0;
     let _ = reopened.len();
     drop(reopened);


### PR DESCRIPTION
The headline of the index-engine study: the **ART arm**, and the three-way comparison.

## What
- New crate **`quillcache-index-holt`**: a persistent `IndexBackend` over [Holt](https://crates.io/crates/holt) v0.5.4 (adaptive radix tree, crash-safe WAL). Path-shaped key encoding ⇒ `prefix_scan` is a native ART prefix walk; `get`/`delete`/`scan` map directly; recovery = WAL replay on reopen.
- CLI: `quillcache bench-index --backend holt` behind an optional **`holt`** feature (pure Rust → builds in the **core** CI job; only the C++ `rocksdb` backend needs the separate job).
- README + `docs/index-backends.md` updated with the results table; backends marked implemented.

## Three-way result (2000 req · 8016 resident · 20k prefix scans, one trace, one trait)
| backend | ingest | prefix_scan p50 | p99 | recovery | on-disk |
| --- | --- | --- | --- | --- | --- |
| memory (flat map) | 706k/s | 494 µs | 1685 µs | — | 0 |
| rocksdb (LSM) | 56k/s | 16.8 µs | 29.6 µs | 4.1 ms | 500 KB |
| **holt (ART)** | 55k/s | **9.96 µs** | **13.7 µs** | **2.6 ms** | 8.4 MB |

**ART (Holt) wins prefix-scan latency** (~1.7× vs LSM p50, ~2.2× p99; ~50× vs the flat map's O(N) scan) **and recovery**. **LSM (RocksDB) wins on-disk space** (compression + compaction). Ingest is comparable between the persistent backends (~13× slower than memory — durability cost). A real trade-off, not a one-sided win.

## Verification
Core path (incl. holt crate + `--features holt`): `fmt --check` · `clippy --workspace --exclude quillcache-index-rocksdb -D warnings` · build · test — green. RocksDB path covered by its own job. `typos` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Holt (Adaptive Radix Tree) as an optional persistent index backend.
  * Added benchmarking support for Holt to compare performance against other storage engines.

* **Documentation**
  * Updated documentation with backend availability status and performance comparisons.
  * Added quickstart commands to benchmark different index storage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->