### PR TITLE
feat(gateway): stream the upstream response (real TTFT through QuillCache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +418,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1211,6 +1238,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1230,12 +1258,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1602,6 +1632,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1889,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 [workspace.dependencies]
 axum = "0.8"
 clap = { version = "4.5.23", features = ["derive"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -240,9 +240,12 @@ async fn proxy_openai_path(
             "x-quillcache-estimated-ttft-us",
             trace.estimated_ttft_us.to_string(),
         );
-    let bytes = upstream.bytes().await?;
+    // Stream the upstream body straight through (SSE chunks forwarded as they
+    // arrive) instead of buffering it, so the client's time-to-first-token
+    // reflects the real engine — QuillCache's decision headers are already set
+    // above and flush with the response head, before the first token.
     response
-        .body(axum::body::Body::from(bytes))
+        .body(axum::body::Body::from_stream(upstream.bytes_stream()))
         .map_err(GatewayHttpError::BuildResponse)
 }
 


### PR DESCRIPTION
The v0.1 gateway buffered the upstream body before returning, so time-to-first-token through QuillCache measured the *full* response, not the engine's real first token.

## Change
- Stream the upstream body through: `Body::from_stream(upstream.bytes_stream())` (reqwest `stream` feature) instead of `upstream.bytes().await`.
- `x-quillcache-*` decision headers flush with the response head; SSE tokens then forward as they arrive.

## Verified live (Modal vLLM, Qwen2.5-0.5B)
Through the gateway, 16/16 ok: **TTFT p50 452 ms < total p50 522 ms** (streaming) — vs the previous TTFT ≈ total when buffered. Decision headers still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented real-time response streaming to deliver data immediately to clients as it arrives, eliminating buffering delays. This enhancement significantly improves responsiveness for Server-Sent Events and tokenized outputs, reducing latency in streaming scenarios and enabling faster, more responsive data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->