### PR TITLE
feat(router): prefix-affinity + round-robin policies; configurable gateway policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "axum",
  "quillcache-control",
  "quillcache-core",
+ "quillcache-router",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/quillcache-control/src/lib.rs
+++ b/crates/quillcache-control/src/lib.rs
@@ -3,7 +3,7 @@ use quillcache_core::{
     ExternalKvBlockKey, IdentityScope, IndexBackend, KvBlockKey, KvEvent, KvEventBatch,
     MemoryIndex, RequestShape, WorkerState,
 };
-use quillcache_router::{GreedyStatePlaneRouter, RouteDecision, RouterError};
+use quillcache_router::{GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use thiserror::Error;
@@ -158,7 +158,7 @@ fn apply_removed(
 pub struct ControlPlane {
     engines: Vec<EngineEndpoint>,
     workers: Vec<WorkerState>,
-    router: GreedyStatePlaneRouter,
+    router: Box<dyn RoutingPolicy>,
     residency: Box<dyn IndexBackend>,
 }
 
@@ -169,9 +169,23 @@ impl ControlPlane {
     }
 
     /// New control plane with a specific index backend (memory, Holt/ART,
-    /// RocksDB/LSM, filesystem). This is the runtime seam for Online mode to
-    /// pick a backend by config and for Experiment mode to compare them.
+    /// RocksDB/LSM, filesystem) and the default cache-aware router.
     pub fn with_index(engines: Vec<EngineEndpoint>, residency: Box<dyn IndexBackend>) -> Self {
+        Self::with_index_and_policy(
+            engines,
+            residency,
+            Box::new(GreedyStatePlaneRouter::default()),
+        )
+    }
+
+    /// New control plane with a specific index backend and routing policy — the
+    /// runtime seam for Online mode to pick both by config (e.g. prefix-affinity
+    /// vs round-robin across a real engine fleet).
+    pub fn with_index_and_policy(
+        engines: Vec<EngineEndpoint>,
+        residency: Box<dyn IndexBackend>,
+        router: Box<dyn RoutingPolicy>,
+    ) -> Self {
         let workers = engines
             .iter()
             .map(EngineEndpoint::worker_state)
@@ -179,7 +193,7 @@ impl ControlPlane {
         Self {
             engines,
             workers,
-            router: GreedyStatePlaneRouter::default(),
+            router,
             residency,
         }
     }

--- a/crates/quillcache-gateway/Cargo.toml
+++ b/crates/quillcache-gateway/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/feichai0017/quillcache"
 axum = { workspace = true }
 quillcache-control = { path = "../quillcache-control", version = "1.0.0-alpha.1" }
 quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
+quillcache-router = { path = "../quillcache-router", version = "1.0.0-alpha.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -6,8 +6,12 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use quillcache_control::{ControlPlane, IngestSummary};
 use quillcache_core::{
-    EngineEndpoint, ExternalKvBlockKey, KvBlockKey, KvEventBatch, RequestKvHints, RequestShape,
-    SloTarget,
+    EngineEndpoint, ExternalKvBlockKey, KvBlockKey, KvEventBatch, MemoryIndex, RequestKvHints,
+    RequestShape, SloTarget,
+};
+use quillcache_router::{
+    GreedyStatePlaneRouter, LeastLoadedRouter, PrefixAffinityRouter, RoundRobinRouter,
+    RoutingPolicy,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -50,6 +54,10 @@ pub enum GatewayError {
 pub struct GatewayConfig {
     pub bind: SocketAddr,
     pub engines: Vec<EngineEndpoint>,
+    /// Routing policy: "prefix-affinity" (cache-affine across the fleet),
+    /// "round-robin" (spread baseline), "least-loaded", or "greedy" (default).
+    #[serde(default)]
+    pub policy: Option<String>,
 }
 
 impl GatewayConfig {
@@ -95,8 +103,13 @@ pub async fn run_from_config_path(path: impl AsRef<Path>) -> Result<(), GatewayE
 }
 
 pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
+    let policy = build_policy(config.policy.as_deref());
+    let policy_name = policy.name().to_string();
+    let control =
+        ControlPlane::with_index_and_policy(config.engines, Box::new(MemoryIndex::new()), policy);
+    tracing::info!(policy = %policy_name, "routing policy selected");
     let state = GatewayState {
-        control: Arc::new(RwLock::new(ControlPlane::new(config.engines))),
+        control: Arc::new(RwLock::new(control)),
         client: Client::new(),
     };
     let app = router(state);
@@ -111,6 +124,16 @@ pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
     axum::serve(listener, app)
         .await
         .map_err(GatewayError::Serve)
+}
+
+/// Build a routing policy from its config name (default: cache-aware greedy).
+fn build_policy(name: Option<&str>) -> Box<dyn RoutingPolicy> {
+    match name.unwrap_or("greedy") {
+        "prefix-affinity" | "affinity" => Box::new(PrefixAffinityRouter::default()),
+        "round-robin" | "roundrobin" => Box::new(RoundRobinRouter::default()),
+        "least-loaded" | "load" => Box::new(LeastLoadedRouter::default()),
+        _ => Box::new(GreedyStatePlaneRouter::default()),
+    }
 }
 
 fn router(state: GatewayState) -> Router {

--- a/crates/quillcache-router/src/lib.rs
+++ b/crates/quillcache-router/src/lib.rs
@@ -2,7 +2,10 @@ use quillcache_core::{
     CacheResidency, CacheTier, CostModel, KvBlockKey, RequestShape, WorkerState,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -52,7 +55,7 @@ impl RouteDecision {
 /// Policies differ only in *which* worker they select; per-worker cost
 /// accounting is shared via [`plan_for_worker`], so comparisons stay apples to
 /// apples.
-pub trait RoutingPolicy {
+pub trait RoutingPolicy: std::fmt::Debug + Send + Sync {
     /// Stable policy name for reports (for example "greedy-state-plane").
     fn name(&self) -> &str;
 
@@ -240,6 +243,108 @@ impl RoutingPolicy for LeastLoadedRouter {
                 u64::from(worker.queued_prefill_tokens) + u64::from(worker.running_decodes) * 1_000
             })
             .ok_or(RouterError::NoWorkers)?;
+        let worker_by_id: HashMap<&str, &WorkerState> = workers
+            .iter()
+            .map(|worker| (worker.id.as_str(), worker))
+            .collect();
+        Ok(plan_for_worker(
+            &self.cost_model,
+            request,
+            target,
+            &worker_by_id,
+            residency,
+        ))
+    }
+}
+
+/// Cache-affine policy ("approximate" prefix-aware routing): hash the request's
+/// shared prefix to a worker, so every request carrying the same prefix lands on
+/// the same engine and reuses its prefix cache — no KV events required. This is
+/// the routing the cache-aware story rests on for a real multi-engine fleet.
+#[derive(Debug, Clone, Default)]
+pub struct PrefixAffinityRouter {
+    cost_model: CostModel,
+}
+
+impl PrefixAffinityRouter {
+    pub fn new(cost_model: CostModel) -> Self {
+        Self { cost_model }
+    }
+}
+
+impl RoutingPolicy for PrefixAffinityRouter {
+    fn name(&self) -> &str {
+        "prefix-affinity"
+    }
+
+    fn route(
+        &self,
+        request: &RequestShape,
+        workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, RouterError> {
+        if workers.is_empty() {
+            return Err(RouterError::NoWorkers);
+        }
+        // Hash the longest shared prefix (the first block's prefix_hash) so that
+        // requests sharing a system prompt / session map to the same worker.
+        let affinity_key = request
+            .blocks
+            .first()
+            .map(|block| block.prefix_hash.as_str())
+            .unwrap_or(request.id.as_str());
+        let mut hasher = DefaultHasher::new();
+        affinity_key.hash(&mut hasher);
+        let idx = (hasher.finish() % workers.len() as u64) as usize;
+        let target = &workers[idx];
+        let worker_by_id: HashMap<&str, &WorkerState> = workers
+            .iter()
+            .map(|worker| (worker.id.as_str(), worker))
+            .collect();
+        Ok(plan_for_worker(
+            &self.cost_model,
+            request,
+            target,
+            &worker_by_id,
+            residency,
+        ))
+    }
+}
+
+/// Spread baseline: round-robin across workers, ignoring prefix and cache — a
+/// fair "no affinity" comparison for [`PrefixAffinityRouter`]. The same prefix is
+/// scattered across the fleet, so each engine recomputes it.
+#[derive(Debug, Default)]
+pub struct RoundRobinRouter {
+    cost_model: CostModel,
+    next: AtomicUsize,
+}
+
+impl RoundRobinRouter {
+    pub fn new(cost_model: CostModel) -> Self {
+        Self {
+            cost_model,
+            next: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl RoutingPolicy for RoundRobinRouter {
+    fn name(&self) -> &str {
+        "round-robin"
+    }
+
+    fn route(
+        &self,
+        request: &RequestShape,
+        workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, RouterError> {
+        if workers.is_empty() {
+            return Err(RouterError::NoWorkers);
+        }
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % workers.len();
+        let target = &workers[idx];
         let worker_by_id: HashMap<&str, &WorkerState> = workers
             .iter()
             .map(|worker| (worker.id.as_str(), worker))


### PR DESCRIPTION
Routing machinery for the cache-aware fleet demo (#2).

## What
- **PrefixAffinityRouter**: hash the request's shared prefix → a worker, so same-prefix requests land on one engine and reuse its prefix cache (approximate prefix-aware routing; no KV events). The cache-aware policy.
- **RoundRobinRouter**: spread baseline (AtomicUsize) that scatters the same prefix across engines.
- RoutingPolicy gains Debug + Send + Sync → ControlPlane holds Box<dyn RoutingPolicy> (with_index_and_policy).
- Gateway picks the policy from config (`policy:` = prefix-affinity | round-robin | least-loaded | greedy, default greedy).

Sets up the live A/B: prefix-affinity (cache reuse → lower TTFT) vs round-robin (spread) across 2 real vLLM instances.

## Verified
fmt --check, clippy --workspace --exclude quillcache-index-rocksdb -D warnings, test — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gateway now supports configurable routing policies for request distribution across the fleet, with options including greedy (default), prefix-affinity, round-robin, and least-loaded strategies.
  * Routing policy can be selected and customized via gateway configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->