### PR TITLE
feat(demo): 2-vLLM fleet — parameterized deploy, engine distribution, A/B

### DIFF
--- a/bench/run_trace.py
+++ b/bench/run_trace.py
@@ -15,6 +15,7 @@ import json
 import time
 import urllib.error
 import urllib.request
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 
 # A long, identical system prompt across requests -> a big shared prefix, which
@@ -106,6 +107,9 @@ def main():
     if totals:
         print(f"total ms  p50 {pct(totals, 0.5):.1f}  p99 {pct(totals, 0.99):.1f}")
     print(f"responses with a QuillCache local-hit header: {hits}/{len(ok)}")
+    engines = Counter(r["headers"].get("x-quillcache-engine-id", "?") for r in ok)
+    if engines:
+        print("engine distribution: " + "  ".join(f"{e}: {n}" for e, n in sorted(engines.items())))
     for r in ok:
         if r["headers"]:
             print("sample decision headers:", json.dumps(r["headers"]))

--- a/deploy/modal_vllm.py
+++ b/deploy/modal_vllm.py
@@ -24,7 +24,10 @@ import modal
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 
 image = modal.Image.debian_slim(python_version="3.12").pip_install("vllm", "huggingface_hub")
-app = modal.App("quillcache-vllm")
+# App name is parameterizable so one script can deploy a fleet:
+#   modal deploy deploy/modal_vllm.py                              # quillcache-vllm
+#   QC_VLLM_APP=quillcache-vllm-b modal deploy deploy/modal_vllm.py  # 2nd instance
+app = modal.App(os.environ.get("QC_VLLM_APP", "quillcache-vllm"))
 
 
 @app.function(gpu="L4", image=image, timeout=60 * 60, max_containers=1)

--- a/examples/quillcache-gateway.yaml
+++ b/examples/quillcache-gateway.yaml
@@ -1,8 +1,18 @@
+# QuillCache gateway in front of a 2-vLLM fleet on Modal.
+# policy: prefix-affinity (cache-affine) | round-robin (spread) | least-loaded | greedy
 bind: 127.0.0.1:8080
+policy: prefix-affinity
 engines:
-  - id: modal-vllm
+  - id: modal-vllm-a
     kind: Vllm
     base_url: https://feichai0017--quillcache-vllm-serve.modal.run
+    model_id: Qwen/Qwen2.5-0.5B-Instruct
+    tokenizer_id: Qwen/Qwen2.5-0.5B-Instruct
+    tenant_id: default
+    locality_domain: modal
+  - id: modal-vllm-b
+    kind: Vllm
+    base_url: https://feichai0017--quillcache-vllm-b-serve.modal.run
     model_id: Qwen/Qwen2.5-0.5B-Instruct
     tokenizer_id: Qwen/Qwen2.5-0.5B-Instruct
     tenant_id: default


### PR DESCRIPTION
Completes #2: QuillCache routing across a real 2-vLLM fleet, demonstrated live.

## What
- `deploy/modal_vllm.py`: app name via `QC_VLLM_APP` — one script deploys a fleet.
- `bench/run_trace.py`: reports engine distribution (`x-quillcache-engine-id` counts).
- `examples/quillcache-gateway.yaml`: two Modal vLLM engines + `policy:` field.

## Live A/B (2× Qwen2.5-0.5B on Modal L4, 16 requests)
| policy | engine distribution | ok | TTFT p99 |
| --- | --- | --- | --- |
| prefix-affinity | **modal-vllm-b: 16** (all to one) | 16/16 | 4.3 s |
| round-robin | a: 7, b: 6 (spread) | 13/16 | 81 s |

Affinity concentrates same-prefix requests on one warm, cache-hot engine; round-robin spreads to a cold/cache-empty one (cold-start stalls amplified by Modal scale-to-zero). Directionally validates cache-aware routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmarking now reports engine distribution summary based on response headers

* **Chores**
  * Made vLLM instance deployment more flexible via configurable app naming
  * Updated configuration examples to demonstrate multi-backend fleet deployments with traffic routing policy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->