### PR TITLE
feat(bench): eviction-churn dimension + p999 in the index benchmark

### DIFF
--- a/crates/quillcache-sim/src/index_bench.rs
+++ b/crates/quillcache-sim/src/index_bench.rs
@@ -1,11 +1,14 @@
 //! Index-backend micro-benchmark — the rig behind the ART-vs-LSM study.
 //!
-//! It drives any [`IndexBackend`] with a KV-cache-shaped workload (a shared
-//! prefix reused across many requests, plus per-request unique suffixes) and
-//! measures the two operations that dominate a residency / prefix index:
-//! ingest (`put`, on KV `BlockStored` events) and prefix lookup (`prefix_scan`,
-//! on every request). It is backend-agnostic, so memory / Holt (ART) /
-//! RocksDB (LSM) run the exact same workload for an apples-to-apples comparison.
+//! Drives any [`IndexBackend`] with a KV-cache-shaped workload and measures the
+//! three operations that dominate a residency / prefix index:
+//! - **ingest** (`put`, on KV `BlockStored` events),
+//! - **churn** (`remove_block` + `put`, simulating eviction + recompute under
+//!   cache pressure — what a real KV-cache index sees once HBM fills),
+//! - **prefix lookup** (`prefix_scan`, on every request).
+//!
+//! Backend-agnostic, so memory / Holt (ART) / RocksDB (LSM) run the exact same
+//! workload for an apples-to-apples comparison.
 
 use quillcache_core::{CacheResidency, IdentityScope, IndexBackend, IndexMetrics, KvBlockKey};
 use serde::{Deserialize, Serialize};
@@ -25,6 +28,10 @@ pub struct IndexBenchConfig {
     pub block_bytes: u64,
     /// Number of `prefix_scan` queries in the read phase.
     pub scan_queries: u32,
+    /// Eviction-churn cycles after ingest: each cycle evicts one request's unique
+    /// blocks (`remove_block`) and re-inserts them (`put`), exercising the
+    /// insert+evict path a real KV-cache index sees under pressure. 0 = no churn.
+    pub churn_ops: u32,
 }
 
 impl Default for IndexBenchConfig {
@@ -36,6 +43,7 @@ impl Default for IndexBenchConfig {
             block_tokens: 64,
             block_bytes: 4 * 1024 * 1024,
             scan_queries: 20_000,
+            churn_ops: 0,
         }
     }
 }
@@ -44,14 +52,20 @@ impl Default for IndexBenchConfig {
 pub struct IndexBenchReport {
     pub backend: String,
     pub persistent: bool,
-    /// Total residency records written (`put` calls).
+    /// Total residency records written (`put` calls) during ingest.
     pub blocks_ingested: u64,
     pub ingest_secs: f64,
     pub ingest_puts_per_sec: f64,
+    /// Eviction-churn cycles run (0 if `--churn-ops` was 0).
+    pub churn_ops: u64,
+    pub churn_secs: f64,
+    /// remove_block + put throughput during the churn phase (ops/sec).
+    pub churn_ops_per_sec: f64,
     pub scan_queries: u64,
     pub scan_mean_us: f64,
     pub scan_p50_us: f64,
     pub scan_p99_us: f64,
+    pub scan_p999_us: f64,
     /// Reopen-from-disk time for persistent backends; `None` for in-memory.
     pub recovery_ms: Option<f64>,
     pub metrics: IndexMetrics,
@@ -83,13 +97,17 @@ fn shared_block(i: u32, tokens: u32) -> KvBlockKey {
     )
 }
 
+fn unique_block_hash(req: u32, j: u32) -> String {
+    format!("uniq-{req}-{j}")
+}
+
 fn unique_block(req: u32, j: u32, idx: u32, tokens: u32) -> KvBlockKey {
     KvBlockKey::new(
         "bench-model",
         "bench-tok",
         "bench-tenant",
         format!("uq-{req}-{j}"),
-        format!("uniq-{req}-{j}"),
+        unique_block_hash(req, j),
         idx,
         tokens,
     )
@@ -131,6 +149,27 @@ pub fn bench_index<B: IndexBackend + ?Sized>(
     }
     let ingest_secs = ingest_start.elapsed().as_secs_f64();
 
+    // ---- churn phase: evict + recompute one request's unique blocks per cycle ----
+    let requests = config.requests.max(1);
+    let churn_start = Instant::now();
+    for c in 0..config.churn_ops {
+        let req = c % requests;
+        for j in 0..config.unique_blocks_per_request {
+            backend.remove_block(&scope, worker, &unique_block_hash(req, j));
+        }
+        for j in 0..config.unique_blocks_per_request {
+            let idx = config.shared_prefix_blocks + j;
+            backend.put(CacheResidency::hbm(
+                worker,
+                unique_block(req, j, idx, config.block_tokens),
+                config.block_bytes,
+            ));
+        }
+    }
+    let churn_secs = churn_start.elapsed().as_secs_f64();
+    let churn_block_ops =
+        u64::from(config.churn_ops) * u64::from(config.unique_blocks_per_request) * 2;
+
     // ---- query phase: prefix_scan against the populated index ----
     let mut samples_ns: Vec<u64> = Vec::with_capacity(config.scan_queries as usize);
     for q in 0..config.scan_queries {
@@ -141,7 +180,7 @@ pub fn bench_index<B: IndexBackend + ?Sized>(
         std::hint::black_box(hits.len());
         samples_ns.push(elapsed);
     }
-    let (scan_mean_us, scan_p50_us, scan_p99_us) = summarize_us(&mut samples_ns);
+    let (scan_mean_us, scan_p50_us, scan_p99_us, scan_p999_us) = summarize_us(&mut samples_ns);
 
     IndexBenchReport {
         backend: backend.name().to_string(),
@@ -153,18 +192,26 @@ pub fn bench_index<B: IndexBackend + ?Sized>(
         } else {
             0.0
         },
+        churn_ops: u64::from(config.churn_ops),
+        churn_secs,
+        churn_ops_per_sec: if churn_secs > 0.0 {
+            churn_block_ops as f64 / churn_secs
+        } else {
+            0.0
+        },
         scan_queries: u64::from(config.scan_queries),
         scan_mean_us,
         scan_p50_us,
         scan_p99_us,
+        scan_p999_us,
         recovery_ms: None,
         metrics: backend.metrics(),
     }
 }
 
-fn summarize_us(samples_ns: &mut [u64]) -> (f64, f64, f64) {
+fn summarize_us(samples_ns: &mut [u64]) -> (f64, f64, f64, f64) {
     if samples_ns.is_empty() {
-        return (0.0, 0.0, 0.0);
+        return (0.0, 0.0, 0.0, 0.0);
     }
     let mean_us =
         samples_ns.iter().map(|&n| n as f64).sum::<f64>() / samples_ns.len() as f64 / 1_000.0;
@@ -173,7 +220,7 @@ fn summarize_us(samples_ns: &mut [u64]) -> (f64, f64, f64) {
         let idx = ((samples_ns.len() as f64 - 1.0) * p).round() as usize;
         samples_ns[idx] as f64 / 1_000.0
     };
-    (mean_us, pick(0.50), pick(0.99))
+    (mean_us, pick(0.50), pick(0.99), pick(0.999))
 }
 
 #[cfg(test)]
@@ -193,6 +240,7 @@ mod tests {
                 block_tokens: 32,
                 block_bytes: 1024,
                 scan_queries: 200,
+                churn_ops: 0,
             },
         );
 
@@ -203,6 +251,31 @@ mod tests {
         // Distinct residencies: 4 shared + 50*2 unique = 104.
         assert_eq!(report.metrics.resident_blocks, 104);
         assert_eq!(report.scan_queries, 200);
+        assert_eq!(report.churn_ops, 0);
+        assert!(report.scan_p999_us >= report.scan_p99_us);
         assert!(report.scan_p99_us >= report.scan_p50_us);
+    }
+
+    #[test]
+    fn churn_keeps_the_resident_set_bounded() {
+        let mut idx = MemoryIndex::new();
+        let report = bench_index(
+            &mut idx,
+            IndexBenchConfig {
+                requests: 20,
+                shared_prefix_blocks: 2,
+                unique_blocks_per_request: 2,
+                block_tokens: 32,
+                block_bytes: 1024,
+                scan_queries: 50,
+                churn_ops: 100,
+            },
+        );
+
+        // Churn evicts then re-inserts the *same* keys, so the resident set does
+        // not grow: 2 shared + 20*2 unique = 42.
+        assert_eq!(report.metrics.resident_blocks, 42);
+        assert_eq!(report.churn_ops, 100);
+        assert!(report.churn_ops_per_sec > 0.0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ enum Command {
         block_bytes: u64,
         #[arg(long, default_value_t = 20000)]
         scan_queries: u32,
+        #[arg(long, default_value_t = 0)]
+        churn_ops: u32,
         #[arg(long)]
         json: bool,
     },
@@ -109,6 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             block_tokens,
             block_bytes,
             scan_queries,
+            churn_ops,
             json,
         } => {
             let config = IndexBenchConfig {
@@ -118,6 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 block_tokens,
                 block_bytes,
                 scan_queries,
+                churn_ops,
             };
             let report = match backend.as_str() {
                 "memory" => bench_index(&mut MemoryIndex::new(), config),
@@ -143,12 +147,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     report.ingest_puts_per_sec, report.ingest_secs
                 );
                 println!(
-                    "prefix_scan: p50 {:.2} us · p99 {:.2} us · mean {:.2} us ({} queries)",
+                    "prefix_scan: p50 {:.2} · p99 {:.2} · p999 {:.2} · mean {:.2} us ({} queries)",
                     report.scan_p50_us,
                     report.scan_p99_us,
+                    report.scan_p999_us,
                     report.scan_mean_us,
                     report.scan_queries
                 );
+                if report.churn_ops > 0 {
+                    println!(
+                        "churn: {:.0} ops/sec ({} cycles, {:.3}s)",
+                        report.churn_ops_per_sec, report.churn_ops, report.churn_secs
+                    );
+                }
                 println!(
                     "resident blocks: {} · bytes_written (on-disk): {}",
                     report.metrics.resident_blocks, report.metrics.bytes_written


### PR DESCRIPTION
Deepens the ART-vs-LSM evaluation: adds an **eviction-churn** phase (remove_block + put per cycle, simulating eviction + recompute under HBM pressure) and **p999**. CLI: `bench-index --churn-ops N`.

## 3-way under churn (1000 req · 2008 resident · 10k scans · 500 churn cycles)
| backend | ingest | scan p50/p99/p999 | churn ops/s | on-disk |
| --- | --- | --- | --- | --- |
| memory | 735k/s | 123 / 151 / 297 µs | 19594 | 0 |
| **holt (ART)** | 54k/s | **9.6 / 14.7 / 38.3 µs** | 137 | 4.2 MB |
| rocksdb (LSM) | 57k/s | 15.5 / 22.0 / 53.0 µs | 153 | **119 KB** |

ART keeps the lowest scan latency at every percentile; LSM stays most space-efficient. **New finding:** `remove_block` is O(scope) (scans + deserializes the identity scope to find a block by hash), so eviction churn is ~150 ops/s on the persistent backends — a secondary `block_hash` index is the clear next optimization.

## Verified
fmt · clippy -D warnings · test (sim: 4 incl. new churn test) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark support for measuring eviction and reinsertion cycles in cache operations.
  * Extended latency metrics to include p999 percentile alongside p50 and p99 measurements.

* **Chores**
  * Added `--churn-ops` parameter to benchmark configuration for controlling eviction-reinsert iterations.
  * Updated benchmark reports to capture churn throughput and timing statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->