### PR TITLE
perf(index): O(matches) remove_block via a secondary block_hash index

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ recovery dominate (the common case for a residency index queried per request),
 pick LSM when on-disk footprint is the constraint. Numbers are from one machine;
 reproduce with `cargo run --features "rocksdb holt" -- bench-index --backend <b>`.
 
+### Eviction churn (and a bottleneck the benchmark caught)
+
+A residency index under HBM pressure does not just ingest and scan — it
+*evicts*. Adding a churn phase (`--churn-ops`: `remove_block` + `put` per cycle)
+surfaced that `remove_block` was **O(scope)**: given a block hash but not its
+prefix, every backend scanned and deserialized the whole identity scope to find
+one block. Eviction collapsed to ~1.4k ops/s on the persistent backends. The fix
+is a secondary `block_hash → primary key` index so eviction is an O(matches)
+seek. Same workload (1000 requests, 2008 resident, 10k scans, **500 churn
+cycles**), before vs after:
+
+| backend | churn ops/s before | churn ops/s after | speedup | on-disk after |
+| --- | --- | --- | --- | --- |
+| memory (flat map) | 69k | **1.15M** | ~17× | 0 |
+| rocksdb (LSM) | 1.4k | **154k** | ~106× | 175 KB |
+| **holt (ART)** | 1.4k | **403k** | **~295×** | 8.4 MB |
+
+The reverse index trades **~2× ingest throughput and a second key per residency
+on disk** for **two-to-three-orders-of-magnitude faster eviction** — the right
+trade for a control plane that evicts continuously. prefix-scan latency is
+unchanged. This is the benchmark working as intended: it is a research
+instrument, not a victory-lap table — it found the bottleneck, then measured the
+fix.
+
 ## Packages
 
 | Package | Role |
@@ -186,11 +210,12 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ Pluggable `RoutingPolicy` with a load-only baseline and a cache-aware policy.
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.
+- ✅ Eviction-churn benchmark + O(matches) `remove_block` via a secondary block_hash index (100–300× faster eviction on the persistent backends).
 - ⏳ Real-vLLM connect (M3): Modal deploy + KV-events bridge + trace runner written (`deploy/` · `bridge/` · `bench/` · `docs/m3-real-vllm.md`); live run pending a cloud GPU. SGLang connector later.
 
 ## Roadmap
 
-1. ✅ Holt (ART) + RocksDB (LSM) `IndexBackend`s + ART-vs-LSM benchmark — done; next: deepen it (true write-amplification, Holt compaction/on-disk, larger traces).
+1. ✅ Holt (ART) + RocksDB (LSM) `IndexBackend`s + ART-vs-LSM benchmark + eviction churn (O(matches) `remove_block`) — done; next: true write-amplification, Holt compaction/on-disk, larger traces.
 2. SLO-aware and session/DAG-aware routing policies.
 3. Real vLLM/SGLang KV-event connectors end-to-end; chat / RAG / agent traces.
 4. Tiered placement and eviction across HBM / DRAM / SSD / remote.

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
@@ -540,6 +540,12 @@ pub trait IndexBackend: std::fmt::Debug + Send + Sync {
 #[derive(Debug, Default)]
 pub struct MemoryIndex {
     entries: HashMap<KvBlockKey, Vec<CacheResidency>>,
+    /// Secondary reverse index: `(identity scope, block_hash) -> the set of full
+    /// keys carrying that content hash`. `remove_block` is given a block hash but
+    /// not its prefix, so without this it would scan the whole map; the reverse
+    /// index turns eviction into an O(matches) lookup. This mirrors the
+    /// secondary-namespace reverse index the persistent backends keep on disk.
+    by_hash: HashMap<(IdentityScope, String), HashSet<KvBlockKey>>,
     puts: u64,
     removes: u64,
 }
@@ -556,11 +562,16 @@ impl IndexBackend for MemoryIndex {
     }
 
     fn put(&mut self, residency: CacheResidency) {
-        let entries = self.entries.entry(residency.key.clone()).or_default();
+        let key = residency.key.clone();
+        let entries = self.entries.entry(key.clone()).or_default();
         entries.retain(|entry| {
             !(entry.worker_id == residency.worker_id && entry.tier == residency.tier)
         });
         entries.push(residency);
+        self.by_hash
+            .entry((IdentityScope::from_key(&key), key.block_hash.clone()))
+            .or_default()
+            .insert(key);
         self.puts += 1;
     }
 
@@ -577,28 +588,64 @@ impl IndexBackend for MemoryIndex {
     }
 
     fn remove_block(&mut self, scope: &IdentityScope, worker_id: &str, block_hash: &str) -> usize {
+        let map_key = (scope.clone(), block_hash.to_string());
+        let Some(keys) = self.by_hash.get(&map_key) else {
+            return 0;
+        };
+        // Snapshot the candidate keys so we can mutate `entries` while iterating.
+        let candidates: Vec<KvBlockKey> = keys.iter().cloned().collect();
         let mut removed = 0;
-        self.entries.retain(|key, entries| {
-            if scope.matches(key) && key.block_hash == block_hash {
+        let mut emptied: Vec<KvBlockKey> = Vec::new();
+        for key in candidates {
+            if let Some(entries) = self.entries.get_mut(&key) {
                 let before = entries.len();
                 entries.retain(|entry| entry.worker_id != worker_id);
                 removed += before - entries.len();
+                if entries.is_empty() {
+                    self.entries.remove(&key);
+                    emptied.push(key);
+                }
             }
-            !entries.is_empty()
-        });
+        }
+        if !emptied.is_empty() {
+            if let Some(set) = self.by_hash.get_mut(&map_key) {
+                for key in &emptied {
+                    set.remove(key);
+                }
+                if set.is_empty() {
+                    self.by_hash.remove(&map_key);
+                }
+            }
+        }
         self.removes += removed as u64;
         removed
     }
 
     fn clear_worker(&mut self, worker_id: &str) {
-        self.entries.retain(|_, entries| {
+        let mut emptied: Vec<KvBlockKey> = Vec::new();
+        self.entries.retain(|key, entries| {
             entries.retain(|entry| entry.worker_id != worker_id);
-            !entries.is_empty()
+            if entries.is_empty() {
+                emptied.push(key.clone());
+                false
+            } else {
+                true
+            }
         });
+        for key in emptied {
+            let map_key = (IdentityScope::from_key(&key), key.block_hash.clone());
+            if let Some(set) = self.by_hash.get_mut(&map_key) {
+                set.remove(&key);
+                if set.is_empty() {
+                    self.by_hash.remove(&map_key);
+                }
+            }
+        }
     }
 
     fn clear(&mut self) {
         self.entries.clear();
+        self.by_hash.clear();
     }
 
     fn snapshot(&self) -> Vec<CacheResidency> {
@@ -640,5 +687,47 @@ mod tests {
             cost.transfer_cost_us(CacheTier::Hbm, 4 * 1024 * 1024, true, true)
                 < cost.prefill_cost_us(64)
         );
+    }
+
+    fn mem_scope() -> IdentityScope {
+        IdentityScope {
+            model_id: "m".to_string(),
+            tokenizer_id: "t".to_string(),
+            adapter_id: None,
+            tenant_id: "ten".to_string(),
+        }
+    }
+
+    fn mem_block(prefix: &str, hash: &str, idx: u32) -> KvBlockKey {
+        KvBlockKey::new("m", "t", "ten", prefix, hash, idx, 64)
+    }
+
+    #[test]
+    fn remove_block_uses_the_reverse_index_and_stays_consistent() {
+        let mut idx = MemoryIndex::new();
+        idx.put(CacheResidency::hbm("w0", mem_block("root", "b0", 0), 1024));
+        idx.put(CacheResidency::hbm("w0", mem_block("b0", "b1", 1), 1024));
+        // Same block hash resident on a second worker: remove("w0", b0) must drop
+        // only w0's copy and keep w1's, and the reverse-index entry must survive.
+        idx.put(CacheResidency::hbm("w1", mem_block("root", "b0", 0), 1024));
+        assert_eq!(idx.len(), 3);
+
+        assert_eq!(idx.remove_block(&mem_scope(), "w0", "b0"), 1);
+        assert_eq!(idx.len(), 2);
+        assert_eq!(idx.prefix_scan(&mem_scope(), "root").len(), 1); // w1 still there
+        assert_eq!(idx.locate(&mem_block("root", "b0", 0)).len(), 1);
+
+        // Removing the last copy drops the reverse-index bucket; a re-put rebuilds
+        // it and the block is findable again (the eviction -> recompute cycle).
+        assert_eq!(idx.remove_block(&mem_scope(), "w1", "b0"), 1);
+        assert!(idx.prefix_scan(&mem_scope(), "root").is_empty());
+        assert_eq!(idx.remove_block(&mem_scope(), "w1", "b0"), 0); // idempotent
+        idx.put(CacheResidency::hbm("w0", mem_block("root", "b0", 0), 1024));
+        assert_eq!(idx.prefix_scan(&mem_scope(), "root").len(), 1);
+
+        // clear_worker must also prune the reverse index (no stale buckets).
+        idx.clear_worker("w0");
+        assert!(idx.prefix_scan(&mem_scope(), "root").is_empty());
+        assert_eq!(idx.remove_block(&mem_scope(), "w0", "b0"), 0);
     }
 }

--- a/crates/quillcache-index-holt/src/lib.rs
+++ b/crates/quillcache-index-holt/src/lib.rs
@@ -7,15 +7,32 @@
 //! compaction). Keys use the same path-shaped encoding as the RocksDB backend:
 //!
 //! ```text
-//! model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0 block_hash \0
-//!   block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
+//! PRIMARY \0 model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0
+//!   block_hash \0 block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
 //! ```
+//!
+//! A second, `SECONDARY`-tagged namespace is a reverse index that lets eviction
+//! seek straight to a block instead of scanning the whole identity scope:
+//!
+//! ```text
+//! SECONDARY \0 model \0 tokenizer \0 adapter \0 tenant \0 block_hash \0
+//!   worker \0 tier \0 prefix_hash \0 block_index(BE)   ->   the primary key
+//! ```
+//!
+//! `remove_block` is given a block hash but not its prefix, so against the
+//! primary order alone it would scan + deserialize the whole scope (the churn
+//! bottleneck the index benchmark surfaced). The reverse index makes it an
+//! O(matches) seek, at the cost of a second key per residency on disk.
 
 use holt::{Durability, RangeEntry, Tree, TreeBuilder};
 use quillcache_core::{CacheResidency, IdentityScope, IndexBackend, IndexMetrics, KvBlockKey};
 use std::path::{Path, PathBuf};
 
 const SEP: u8 = 0x00;
+/// Namespace tag for primary residency records (prefix-ordered).
+const PRIMARY: u8 = 0x01;
+/// Namespace tag for the reverse `block_hash -> primary key` index.
+const SECONDARY: u8 = 0x02;
 
 /// A persistent residency index backed by Holt (an adaptive radix tree).
 pub struct HoltIndex {
@@ -84,8 +101,10 @@ impl HoltIndex {
         buf.push(SEP);
     }
 
+    /// Primary scope prefix (`PRIMARY \0 scope`), the seek point for an
+    /// identity-scoped `prefix_scan`.
     fn scope_prefix(scope: &IdentityScope) -> Vec<u8> {
-        let mut buf = Vec::new();
+        let mut buf = vec![PRIMARY];
         Self::enc_scope(
             &mut buf,
             &scope.model_id,
@@ -96,9 +115,9 @@ impl HoltIndex {
         buf
     }
 
-    fn key_for(residency: &CacheResidency) -> Vec<u8> {
+    fn primary_key_for(residency: &CacheResidency) -> Vec<u8> {
         let k = &residency.key;
-        let mut buf = Vec::new();
+        let mut buf = vec![PRIMARY];
         Self::enc_scope(
             &mut buf,
             &k.model_id,
@@ -115,6 +134,49 @@ impl HoltIndex {
         buf.extend_from_slice(residency.worker_id.as_bytes());
         buf.push(SEP);
         buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf
+    }
+
+    /// Reverse-index key: `SECONDARY \0 scope \0 block_hash \0 worker \0 tier \0
+    /// prefix_hash \0 block_index`. Ordering block_hash + worker first is what
+    /// makes `remove_block` a bounded seek. The value is the primary key.
+    fn secondary_key_for(residency: &CacheResidency) -> Vec<u8> {
+        let k = &residency.key;
+        let mut buf = vec![SECONDARY];
+        Self::enc_scope(
+            &mut buf,
+            &k.model_id,
+            &k.tokenizer_id,
+            k.adapter_id.as_deref(),
+            &k.tenant_id,
+        );
+        buf.extend_from_slice(k.block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.worker_id.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(k.prefix_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(&k.block_index.to_be_bytes());
+        buf
+    }
+
+    /// Reverse-index seek prefix for evicting `(scope, worker, block_hash)`
+    /// across every tier / prefix / block index it is resident under.
+    fn remove_scan_prefix(scope: &IdentityScope, worker_id: &str, block_hash: &str) -> Vec<u8> {
+        let mut buf = vec![SECONDARY];
+        Self::enc_scope(
+            &mut buf,
+            &scope.model_id,
+            &scope.tokenizer_id,
+            scope.adapter_id.as_deref(),
+            &scope.tenant_id,
+        );
+        buf.extend_from_slice(block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(worker_id.as_bytes());
+        buf.push(SEP);
         buf
     }
 
@@ -141,9 +203,12 @@ impl IndexBackend for HoltIndex {
     }
 
     fn put(&mut self, residency: CacheResidency) {
-        let key = Self::key_for(&residency);
+        let primary = Self::primary_key_for(&residency);
         if let Ok(value) = serde_json::to_vec(&residency) {
-            let _ = self.tree.put(&key, &value);
+            let _ = self.tree.put(&primary, &value);
+            // Reverse index: block_hash -> primary key, for O(matches) eviction.
+            let secondary = Self::secondary_key_for(&residency);
+            let _ = self.tree.put(&secondary, &primary);
         }
     }
 
@@ -166,33 +231,33 @@ impl IndexBackend for HoltIndex {
     }
 
     fn remove_block(&mut self, scope: &IdentityScope, worker_id: &str, block_hash: &str) -> usize {
-        let prefix = Self::scope_prefix(scope);
-        let mut to_delete: Vec<Vec<u8>> = Vec::new();
+        // Seek the reverse index straight to this (scope, block_hash, worker)
+        // instead of scanning the whole identity scope. Each hit's value is the
+        // primary key to drop; we drop the reverse entry alongside it.
+        let prefix = Self::remove_scan_prefix(scope, worker_id, block_hash);
+        let mut pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
         for entry in self.tree.scan(&prefix) {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(_) => break,
             };
             if let RangeEntry::Key { key, value, .. } = entry {
-                if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
-                    if residency.key.block_hash == block_hash && residency.worker_id == worker_id {
-                        to_delete.push(key.to_vec());
-                    }
-                }
+                pairs.push((key.to_vec(), value.to_vec()));
             }
         }
         let mut removed = 0;
-        for key in to_delete {
-            if self.tree.delete(key.as_slice()).unwrap_or(false) {
+        for (secondary, primary) in pairs {
+            if self.tree.delete(primary.as_slice()).unwrap_or(false) {
                 removed += 1;
             }
+            let _ = self.tree.delete(secondary.as_slice());
         }
         removed
     }
 
     fn clear_worker(&mut self, worker_id: &str) {
-        let mut to_delete: Vec<Vec<u8>> = Vec::new();
-        for entry in self.tree.range() {
+        let mut to_delete: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for entry in self.tree.scan(&[PRIMARY]) {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(_) => break,
@@ -200,13 +265,14 @@ impl IndexBackend for HoltIndex {
             if let RangeEntry::Key { key, value, .. } = entry {
                 if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&value) {
                     if residency.worker_id == worker_id {
-                        to_delete.push(key.to_vec());
+                        to_delete.push((key.to_vec(), Self::secondary_key_for(&residency)));
                     }
                 }
             }
         }
-        for key in to_delete {
-            let _ = self.tree.delete(key.as_slice());
+        for (primary, secondary) in to_delete {
+            let _ = self.tree.delete(primary.as_slice());
+            let _ = self.tree.delete(secondary.as_slice());
         }
     }
 
@@ -224,7 +290,7 @@ impl IndexBackend for HoltIndex {
 
     fn snapshot(&self) -> Vec<CacheResidency> {
         let mut out = Vec::new();
-        for entry in self.tree.range() {
+        for entry in self.tree.scan(&[PRIMARY]) {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(_) => break,
@@ -239,7 +305,12 @@ impl IndexBackend for HoltIndex {
     }
 
     fn len(&self) -> usize {
-        self.tree.range().into_iter().filter_map(Result::ok).count()
+        // Count only primary residency records, not reverse-index entries.
+        self.tree
+            .scan(&[PRIMARY])
+            .into_iter()
+            .filter_map(Result::ok)
+            .count()
     }
 
     fn persistent(&self) -> bool {
@@ -304,6 +375,39 @@ mod tests {
             assert!(idx.persistent());
             assert_eq!(idx.len(), 1);
             assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reverse_index_remove_is_scoped_and_survives_reopen() {
+        let dir = temp_dir("reverse");
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let mut idx = HoltIndex::open(&dir).unwrap();
+            // Same block hash resident on two workers under the same prefix.
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w1", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w0", block("b0", "b1", 1), 1024));
+            assert_eq!(idx.len(), 3);
+
+            // Evict only w0's copy of b0; w1's copy and b1 remain.
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
+            assert_eq!(idx.len(), 2);
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 0); // idempotent
+            idx.flush();
+        }
+        {
+            // Reverse index persisted: eviction still seeks correctly after reopen.
+            let mut idx = HoltIndex::open(&dir).unwrap();
+            assert_eq!(idx.len(), 2);
+            assert_eq!(idx.remove_block(&scope(), "w1", "b0"), 1);
+            assert!(idx.prefix_scan(&scope(), "root").is_empty());
+            // Re-put rebuilds both namespaces (eviction -> recompute).
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
         }
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/quillcache-index-rocksdb/src/lib.rs
+++ b/crates/quillcache-index-rocksdb/src/lib.rs
@@ -5,19 +5,38 @@
 //! range scan:
 //!
 //! ```text
-//! model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0 block_hash \0
-//!   block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
+//! PRIMARY \0 model \0 tokenizer \0 adapter \0 tenant \0 prefix_hash \0
+//!   block_hash \0 block_index(BE) \0 worker \0 tier   ->   serialized CacheResidency
 //! ```
 //!
-//! `put` is a single write (no read-modify-write), so the store behaves like a
-//! real LSM under ingest. The value is one [`CacheResidency`]; a block resident
-//! on several workers/tiers maps to several keys sharing a block prefix.
+//! `put` writes the record above plus a `SECONDARY`-tagged reverse-index entry
+//! so eviction can seek straight to a block instead of scanning the scope:
+//!
+//! ```text
+//! SECONDARY \0 model \0 tokenizer \0 adapter \0 tenant \0 block_hash \0
+//!   worker \0 tier \0 prefix_hash \0 block_index(BE)   ->   the primary key
+//! ```
+//!
+//! Both are single writes (no read-modify-write), so the store still behaves
+//! like a real LSM under ingest. The value of a primary key is one
+//! [`CacheResidency`]; a block resident on several workers/tiers maps to several
+//! keys sharing a block prefix. `remove_block` is given a block hash but not its
+//! prefix, so without the reverse index it would scan + deserialize the whole
+//! scope (the churn bottleneck the index benchmark surfaced); with it, eviction
+//! is an O(matches) range seek, at the cost of a second key per residency.
 
 use quillcache_core::{CacheResidency, IdentityScope, IndexBackend, IndexMetrics, KvBlockKey};
 use rocksdb::{Direction, IteratorMode, Options, DB};
 use std::path::{Path, PathBuf};
 
 const SEP: u8 = 0x00;
+/// Namespace tag for primary residency records (prefix-ordered).
+const PRIMARY: u8 = 0x01;
+/// Namespace tag for the reverse `block_hash -> primary key` index.
+const SECONDARY: u8 = 0x02;
+
+/// An owned RocksDB key or value, as yielded by the iterator.
+type OwnedKey = Box<[u8]>;
 
 /// A persistent residency index backed by RocksDB (an LSM-tree store).
 pub struct RocksIndex {
@@ -80,8 +99,10 @@ impl RocksIndex {
         buf.push(SEP);
     }
 
+    /// Primary scope prefix (`PRIMARY \0 scope`), the seek point for an
+    /// identity-scoped `prefix_scan`.
     fn scope_prefix(scope: &IdentityScope) -> Vec<u8> {
-        let mut buf = Vec::new();
+        let mut buf = vec![PRIMARY];
         Self::enc_scope(
             &mut buf,
             &scope.model_id,
@@ -92,9 +113,9 @@ impl RocksIndex {
         buf
     }
 
-    fn key_for(residency: &CacheResidency) -> Vec<u8> {
+    fn primary_key_for(residency: &CacheResidency) -> Vec<u8> {
         let k = &residency.key;
-        let mut buf = Vec::new();
+        let mut buf = vec![PRIMARY];
         Self::enc_scope(
             &mut buf,
             &k.model_id,
@@ -111,6 +132,49 @@ impl RocksIndex {
         buf.extend_from_slice(residency.worker_id.as_bytes());
         buf.push(SEP);
         buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf
+    }
+
+    /// Reverse-index key: `SECONDARY \0 scope \0 block_hash \0 worker \0 tier \0
+    /// prefix_hash \0 block_index`. Ordering block_hash + worker first is what
+    /// makes `remove_block` a bounded range seek. The value is the primary key.
+    fn secondary_key_for(residency: &CacheResidency) -> Vec<u8> {
+        let k = &residency.key;
+        let mut buf = vec![SECONDARY];
+        Self::enc_scope(
+            &mut buf,
+            &k.model_id,
+            &k.tokenizer_id,
+            k.adapter_id.as_deref(),
+            &k.tenant_id,
+        );
+        buf.extend_from_slice(k.block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.worker_id.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(residency.tier.to_string().as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(k.prefix_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(&k.block_index.to_be_bytes());
+        buf
+    }
+
+    /// Reverse-index seek prefix for evicting `(scope, worker, block_hash)`
+    /// across every tier / prefix / block index it is resident under.
+    fn remove_scan_prefix(scope: &IdentityScope, worker_id: &str, block_hash: &str) -> Vec<u8> {
+        let mut buf = vec![SECONDARY];
+        Self::enc_scope(
+            &mut buf,
+            &scope.model_id,
+            &scope.tokenizer_id,
+            scope.adapter_id.as_deref(),
+            &scope.tenant_id,
+        );
+        buf.extend_from_slice(block_hash.as_bytes());
+        buf.push(SEP);
+        buf.extend_from_slice(worker_id.as_bytes());
+        buf.push(SEP);
         buf
     }
 
@@ -141,9 +205,12 @@ impl IndexBackend for RocksIndex {
     }
 
     fn put(&mut self, residency: CacheResidency) {
-        let key = Self::key_for(&residency);
+        let primary = Self::primary_key_for(&residency);
         if let Ok(value) = serde_json::to_vec(&residency) {
-            let _ = self.db.put(key, value);
+            let _ = self.db.put(&primary, value);
+            // Reverse index: block_hash -> primary key, for O(matches) eviction.
+            let secondary = Self::secondary_key_for(&residency);
+            let _ = self.db.put(&secondary, &primary);
         }
     }
 
@@ -166,49 +233,57 @@ impl IndexBackend for RocksIndex {
     }
 
     fn remove_block(&mut self, scope: &IdentityScope, worker_id: &str, block_hash: &str) -> usize {
-        let prefix = Self::scope_prefix(scope);
-        let mut to_delete = Vec::new();
+        // Seek the reverse index straight to this (scope, block_hash, worker)
+        // instead of scanning the whole identity scope. Each hit's value is the
+        // primary key to drop; we drop the reverse entry alongside it.
+        let prefix = Self::remove_scan_prefix(scope, worker_id, block_hash);
+        let mut pairs: Vec<(OwnedKey, OwnedKey)> = Vec::new();
         for item in self
             .db
             .iterator(IteratorMode::From(prefix.as_slice(), Direction::Forward))
         {
-            let (k, v) = match item {
+            let (sec_key, prim_key) = match item {
                 Ok(kv) => kv,
                 Err(_) => break,
             };
-            if !k.starts_with(prefix.as_slice()) {
+            if !sec_key.starts_with(prefix.as_slice()) {
                 break;
             }
-            if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
-                if residency.key.block_hash == block_hash && residency.worker_id == worker_id {
-                    to_delete.push(k);
-                }
-            }
+            pairs.push((sec_key, prim_key));
         }
         let mut removed = 0;
-        for k in to_delete {
-            if self.db.delete(&k).is_ok() {
+        for (sec_key, prim_key) in pairs {
+            if self.db.delete(&prim_key).is_ok() {
                 removed += 1;
             }
+            let _ = self.db.delete(&sec_key);
         }
         removed
     }
 
     fn clear_worker(&mut self, worker_id: &str) {
-        let mut to_delete = Vec::new();
-        for item in self.db.iterator(IteratorMode::Start) {
+        let prefix = [PRIMARY];
+        let mut to_delete: Vec<(OwnedKey, Vec<u8>)> = Vec::new();
+        for item in self
+            .db
+            .iterator(IteratorMode::From(&prefix, Direction::Forward))
+        {
             let (k, v) = match item {
                 Ok(kv) => kv,
                 Err(_) => break,
             };
+            if !k.starts_with(&prefix) {
+                break;
+            }
             if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
                 if residency.worker_id == worker_id {
-                    to_delete.push(k);
+                    to_delete.push((k, Self::secondary_key_for(&residency)));
                 }
             }
         }
-        for k in to_delete {
-            let _ = self.db.delete(&k);
+        for (primary, secondary) in to_delete {
+            let _ = self.db.delete(&primary);
+            let _ = self.db.delete(&secondary);
         }
     }
 
@@ -225,12 +300,19 @@ impl IndexBackend for RocksIndex {
     }
 
     fn snapshot(&self) -> Vec<CacheResidency> {
+        let prefix = [PRIMARY];
         let mut out = Vec::new();
-        for item in self.db.iterator(IteratorMode::Start) {
-            let (_, v) = match item {
+        for item in self
+            .db
+            .iterator(IteratorMode::From(&prefix, Direction::Forward))
+        {
+            let (k, v) = match item {
                 Ok(kv) => kv,
                 Err(_) => break,
             };
+            if !k.starts_with(&prefix) {
+                break;
+            }
             if let Ok(residency) = serde_json::from_slice::<CacheResidency>(&v) {
                 out.push(residency);
             }
@@ -239,10 +321,20 @@ impl IndexBackend for RocksIndex {
     }
 
     fn len(&self) -> usize {
-        self.db
-            .iterator(IteratorMode::Start)
-            .filter_map(Result::ok)
-            .count()
+        // Count only primary residency records, not reverse-index entries.
+        let prefix = [PRIMARY];
+        let mut n = 0;
+        for item in self
+            .db
+            .iterator(IteratorMode::From(&prefix, Direction::Forward))
+        {
+            let Ok((k, _)) = item else { break };
+            if !k.starts_with(&prefix) {
+                break;
+            }
+            n += 1;
+        }
+        n
     }
 
     fn persistent(&self) -> bool {
@@ -310,6 +402,38 @@ mod tests {
             assert!(idx.persistent());
             assert_eq!(idx.len(), 1);
             assert_eq!(idx.prefix_scan(&scope(), "b0").len(), 1);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reverse_index_remove_is_scoped_and_survives_reopen() {
+        let dir = temp_dir("reverse");
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let mut idx = RocksIndex::open(&dir).unwrap();
+            // Same block hash resident on two workers under the same prefix.
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w1", block("root", "b0", 0), 1024));
+            idx.put(CacheResidency::hbm("w0", block("b0", "b1", 1), 1024));
+            assert_eq!(idx.len(), 3);
+
+            // Evict only w0's copy of b0; w1's copy and b1 remain.
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
+            assert_eq!(idx.len(), 2);
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 0); // idempotent
+        }
+        {
+            // Reverse index persisted: eviction still seeks correctly after reopen.
+            let mut idx = RocksIndex::open(&dir).unwrap();
+            assert_eq!(idx.len(), 2);
+            assert_eq!(idx.remove_block(&scope(), "w1", "b0"), 1);
+            assert!(idx.prefix_scan(&scope(), "root").is_empty());
+            // Re-put rebuilds both namespaces (eviction -> recompute).
+            idx.put(CacheResidency::hbm("w0", block("root", "b0", 0), 1024));
+            assert_eq!(idx.prefix_scan(&scope(), "root").len(), 1);
+            assert_eq!(idx.remove_block(&scope(), "w0", "b0"), 1);
         }
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
The churn benchmark (#49) surfaced that `remove_block` was **O(scope)**: given `(scope, worker, block_hash)` but not the prefix, every backend scanned + deserialized the whole identity scope to find one block, so eviction collapsed to ~1.4k ops/s on the persistent backends.

## Fix
A secondary `block_hash → primary key` reverse index so eviction seeks straight to the block (O(matches)):
- **Holt / RocksDB**: a `SECONDARY`-tagged key namespace (value = the primary key); `PRIMARY`-tagged residency records are unchanged for `prefix_scan`. `snapshot`/`len` now iterate the primary namespace only; `clear_worker`/`remove_block` keep both namespaces in sync.
- **MemoryIndex**: a `by_hash` reverse map mirroring the same idea (the reference backend's `remove_block` was O(N)).

## Result — same workload, same machine (1000 req · 2008 resident · 10k scans · **500 churn cycles**)
| backend | churn ops/s before | churn ops/s after | speedup | on-disk after |
| --- | --- | --- | --- | --- |
| memory | 69k | **1.15M** | ~17× | 0 |
| rocksdb (LSM) | 1.4k | **154k** | ~106× | 175 KB |
| **holt (ART)** | 1.4k | **403k** | **~295×** | 8.4 MB |

**Honest tradeoff:** the reverse index costs **~2× ingest throughput** (a second write per `put`) and **a second key per residency on disk** (~2× Holt, ~1.5× Rocks), for **2–3 orders of magnitude faster eviction**. prefix-scan latency is unchanged. The right trade for a control plane that evicts continuously under HBM pressure.

## Verified
- New reverse-index consistency tests on all three backends: multi-worker scoping (evict one worker's copy, keep the other), idempotent re-remove, survives reopen (persistent backends).
- fmt · clippy -D warnings (core + rocksdb jobs) · test — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added eviction churn benchmarking analysis with before/after throughput metrics and performance comparisons across memory, RocksDB, and Holt backends.

* **Performance**
  * Optimized eviction operations across all index backends with faster, scoped block removal reducing computational complexity and delivering significant throughput improvements on persistent backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->