### PR TITLE
feat(safe-reuse): identity-governed reuse guard + cross-identity experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
 QuillCache is a **vendor-neutral KV cache control plane and evaluation platform**
 for LLM inference. It does not run models and it does not move KV tensors. It
 sits in front of / beside real engines (vLLM, SGLang) and the KV data plane
-(LMCache, NVIDIA Dynamo KVBM) and owns the *metadata and the decisions*: block
-identity, residency, routing, and reuse / transfer / recompute / evict policy.
+(LMCache, NVIDIA Dynamo KVBM, Tencent FlexKV) and owns the *metadata and the
+decisions*: block identity, residency, routing, and reuse / transfer / recompute
+/ evict policy. Those data planes move and store KV tensors; QuillCache is the
+neutral layer **above** them — it can drive and compare them, and it enforces the
+one thing they leave implicit: **identity-governed safe reuse** (below).
 
 It is built as a **research instrument**: engines, routing policies, and index
 backends are all pluggable, so you can replay one workload across many
@@ -21,7 +24,7 @@ combinations and measure them apples-to-apples.
 | It IS | It is NOT |
 | --- | --- |
 | a gateway in front of real engines | a new vLLM / SGLang (no kernels, no model execution) |
-| a residency index fed by real KV events | a new LMCache (not a KV **tensor** data plane) |
+| a residency index fed by real KV events | a new LMCache / FlexKV (not a KV **tensor** data plane) |
 | a policy engine (route / reuse / recompute / pin / evict) | a new Dynamo KVBM (not a distributed block memory manager) |
 | a research instrument comparing policies **and** index backends | a paper-only simulator (it connects to real engines) |
 | the experiment substrate for Holt / RocksDB / Memory / FS indexes | a store for large KV **tensors** |
@@ -29,11 +32,11 @@ combinations and measure them apples-to-apples.
 ## Layering
 
 ```text
-vLLM / SGLang     = inference engines (run the model, own live KV tensors)
-LMCache / KVBM    = KV tensor data plane / offload backend
-QuillCache        = control plane + research platform   <-- this repo
-Holt              = persistent ART index backend
-RocksDB           = LSM index baseline
+vLLM / SGLang        = inference engines (run the model, own live KV tensors)
+LMCache/KVBM/FlexKV  = KV tensor data plane / offload backend
+QuillCache           = control plane + research platform   <-- this repo
+Holt                 = persistent ART index backend
+RocksDB              = LSM index baseline
 ```
 
 QuillCache holds **identity + residency metadata** and makes **decisions**. The
@@ -82,6 +85,41 @@ mode runs one chosen combination in front of real engines.
 
 The ART-vs-LSM line below is about the **index backend**, not the data plane.
 Holt stores the *catalog/index*, not the KV tensors.
+
+## Identity-governed safe reuse (the spike)
+
+A KV block's **content hash** is computed from its tokens, so the same tokens
+produce the same hash — *regardless of which tenant sent them, which LoRA adapter
+is active, or which model/tokenizer version is loaded*. But the KV **tensors**
+depend on all of those. So a cache that reuses on content hash alone — which is
+what data-plane caches (FlexKV / LMCache / KVBM) key on — will serve blocks it
+must not:
+
+- across **tenants** → a **privacy leak** (one tenant's cached state served to another),
+- across **adapters / models / tokenizers** → a **correctness error** (numerically wrong KV).
+
+QuillCache makes the reuse contract explicit: every block carries an
+`IdentityScope` (model · tokenizer · adapter · tenant), and reuse is allowed only
+when it matches (`quillcache_core::ReuseViolation` classifies why it doesn't).
+The `safe-reuse` experiment quantifies the gap on a collision-heavy workload —
+one popular prefix shared across many identities, i.e. the multi-tenant
+shared-system-prompt / shared-RAG-doc case:
+
+```
+quillcache safe-reuse           # 12 identities share each prefix
+```
+
+| policy | content-hash hits | unsafe served | of which | safe reuse kept |
+| --- | --- | --- | --- | --- |
+| naive (content hash only) | 9200 | **8800 (95.7%)** | 5600 cross-tenant leaks + 3200 cross-adapter errors | — |
+| **QuillCache (identity guard)** | — | **0** | — | 4800 |
+
+The guard eliminates **all** unsafe reuse while preserving safe same-identity
+reuse, at a measured cost (here ~12.7 s of prefill recompute to avoid 8800 unsafe
+serves). Push it to a privacy-heavy mix (`--tenants 32 --adapters 0`) and **98.4%**
+of the naive cache's hits are cross-tenant leaks. This is the contract the
+production data planes leave implicit; here it is explicit, enforced, and
+measurable.
 
 ## Why ART (Holt) vs RocksDB (LSM)
 
@@ -152,12 +190,12 @@ fix.
 
 | Package | Role |
 | --- | --- |
-| `quillcache` | CLI: `simulate`, `plan`, `gateway`. |
+| `quillcache` | CLI: `simulate`, `bench-index`, `safe-reuse`, `plan`, `gateway`. |
 | `quillcache-core` | `KvBlockKey` identity, `CacheResidency`, cost model, and the `IndexBackend` trait + `MemoryIndex` reference backend. |
 | `quillcache-router` | `RoutingPolicy` trait; `GreedyStatePlaneRouter` (cache-aware) and `LeastLoadedRouter` (baseline). |
 | `quillcache-control` | `ControlPlane` and the backend-agnostic `ingest_batch` (KV events → residency). |
 | `quillcache-gateway` | OpenAI-compatible proxy + `/v1/kv-events` ingest + `/v1/state`. |
-| `quillcache-sim` | Experiment-mode harness: replay a trace over any policy × any backend. |
+| `quillcache-sim` | Experiment-mode harness: replay a trace over any policy × any backend; `bench-index` and `safe-reuse` experiments. |
 | `quillcache-index-rocksdb` | RocksDB (LSM) `IndexBackend` (optional `rocksdb` feature; needs a C++ toolchain). |
 | `quillcache-index-holt` | Holt (persistent ART) `IndexBackend` (optional `holt` feature; pure Rust). |
 
@@ -174,6 +212,10 @@ cargo run -- simulate --json
 cargo run --features "rocksdb holt" -- bench-index --backend memory
 cargo run --features "rocksdb holt" -- bench-index --backend rocksdb
 cargo run --features "rocksdb holt" -- bench-index --backend holt
+
+# Identity-governed safe reuse: naive content-hash reuse vs the identity guard.
+cargo run -- safe-reuse
+cargo run -- safe-reuse --tenants 32 --adapters 0   # privacy-heavy mix
 
 # Print the research plan / build order.
 cargo run -- plan
@@ -211,6 +253,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.
 - ✅ Eviction-churn benchmark + O(matches) `remove_block` via a secondary block_hash index (100–300× faster eviction on the persistent backends).
+- ✅ Identity-governed safe reuse: `ReuseViolation` classifier + `safe-reuse` experiment quantifying the cross-tenant / cross-adapter unsafe reuse a content-hash cache would serve (and that the guard eliminates).
 - ⏳ Real-vLLM connect (M3): Modal deploy + KV-events bridge + trace runner written (`deploy/` · `bridge/` · `bench/` · `docs/m3-real-vllm.md`); live run pending a cloud GPU. SGLang connector later.
 
 ## Roadmap
@@ -219,7 +262,7 @@ exact block hashes while keeping the upstream request clean. See
 2. SLO-aware and session/DAG-aware routing policies.
 3. Real vLLM/SGLang KV-event connectors end-to-end; chat / RAG / agent traces.
 4. Tiered placement and eviction across HBM / DRAM / SSD / remote.
-5. Identity-governed safe reuse: refuse unsafe reuse and quantify its cost.
+5. ✅ Identity-governed safe reuse: refuse unsafe reuse and quantify its cost (`safe-reuse`) — done; next: enforce it inline in the gateway and add cross-model/tokenizer/quant axes.
 6. Baselines: engine-local prefix caching, LMCache-style cache, Mooncake-style pool.
 
 ## Non-goals

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -434,10 +434,69 @@ impl IdentityScope {
     /// exactly (including absence): a LoRA-adapted block is not reusable by a
     /// base-model request, and vice versa.
     pub fn matches(&self, key: &KvBlockKey) -> bool {
-        self.model_id == key.model_id
-            && self.tokenizer_id == key.tokenizer_id
-            && self.adapter_id == key.adapter_id
-            && self.tenant_id == key.tenant_id
+        self.reuse_violation(key).is_none()
+    }
+
+    /// Classify why a *content-matching* block (same `block_hash`) is unsafe to
+    /// reuse for a request in this scope, or `None` when identity agrees and
+    /// reuse is safe. Content hashes collide across identities — the same tokens
+    /// produce the same `block_hash` — but the KV tensors do not, so a control
+    /// plane that reuses on content alone serves wrong or leaked state. Checked
+    /// in priority order (a block can violate on several axes at once).
+    pub fn reuse_violation(&self, key: &KvBlockKey) -> Option<ReuseViolation> {
+        if self.model_id != key.model_id {
+            Some(ReuseViolation::Model)
+        } else if self.tokenizer_id != key.tokenizer_id {
+            Some(ReuseViolation::Tokenizer)
+        } else if self.adapter_id != key.adapter_id {
+            Some(ReuseViolation::Adapter)
+        } else if self.tenant_id != key.tenant_id {
+            Some(ReuseViolation::Tenant)
+        } else {
+            None
+        }
+    }
+}
+
+/// Why a content-hash-matching KV block is unsafe to reuse across an identity
+/// boundary. The first three are **correctness** violations (the cached KV is
+/// numerically wrong for the request); `Tenant` is a **privacy** violation (the
+/// KV is valid but belongs to another tenant, so serving it leaks their state).
+/// This is the contract data-plane caches (FlexKV / LMCache / KVBM) leave
+/// implicit; QuillCache makes it explicit and measurable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReuseViolation {
+    /// Different model weights — attention output, and thus KV, differs.
+    Model,
+    /// Different tokenizer — the same text can tokenize differently, so the
+    /// "same" prefix is not actually the same token sequence.
+    Tokenizer,
+    /// Different LoRA adapter — adapted attention changes the KV tensors even
+    /// for identical tokens and base weights.
+    Adapter,
+    /// Different tenant — the KV is numerically valid but reusing it serves one
+    /// tenant's cached state to another (a prefix-cache privacy leak).
+    Tenant,
+}
+
+impl ReuseViolation {
+    /// A correctness violation yields *wrong* output; a privacy violation yields
+    /// *leaked* output. They are mitigated and measured differently.
+    pub fn is_correctness(self) -> bool {
+        matches!(self, Self::Model | Self::Tokenizer | Self::Adapter)
+    }
+
+    pub fn is_privacy(self) -> bool {
+        matches!(self, Self::Tenant)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Model => "cross_model",
+            Self::Tokenizer => "cross_tokenizer",
+            Self::Adapter => "cross_adapter",
+            Self::Tenant => "cross_tenant",
+        }
     }
 }
 
@@ -700,6 +759,51 @@ mod tests {
 
     fn mem_block(prefix: &str, hash: &str, idx: u32) -> KvBlockKey {
         KvBlockKey::new("m", "t", "ten", prefix, hash, idx, 64)
+    }
+
+    #[test]
+    fn reuse_violation_classifies_identity_mismatch() {
+        let scope = IdentityScope {
+            model_id: "m".into(),
+            tokenizer_id: "t".into(),
+            adapter_id: Some("lora-a".into()),
+            tenant_id: "tenant-1".into(),
+        };
+        let same = KvBlockKey {
+            adapter_id: Some("lora-a".into()),
+            ..KvBlockKey::new("m", "t", "tenant-1", "p", "b", 0, 64)
+        };
+        assert_eq!(scope.reuse_violation(&same), None); // identical identity: safe
+        assert!(scope.matches(&same));
+
+        // Same content (block hash) but a different tenant: a privacy leak.
+        let other_tenant = KvBlockKey {
+            adapter_id: Some("lora-a".into()),
+            ..KvBlockKey::new("m", "t", "tenant-2", "p", "b", 0, 64)
+        };
+        assert_eq!(
+            scope.reuse_violation(&other_tenant),
+            Some(ReuseViolation::Tenant)
+        );
+        assert!(scope.reuse_violation(&other_tenant).unwrap().is_privacy());
+
+        // Different adapter: a correctness error (priority over tenant).
+        let other_adapter = KvBlockKey::new("m", "t", "tenant-2", "p", "b", 0, 64); // adapter None
+        assert_eq!(
+            scope.reuse_violation(&other_adapter),
+            Some(ReuseViolation::Adapter)
+        );
+        assert!(scope
+            .reuse_violation(&other_adapter)
+            .unwrap()
+            .is_correctness());
+
+        // Different model outranks everything else.
+        let other_model = KvBlockKey::new("m2", "t", "tenant-1", "p", "b", 0, 64);
+        assert_eq!(
+            scope.reuse_violation(&other_model),
+            Some(ReuseViolation::Model)
+        );
     }
 
     #[test]

--- a/crates/quillcache-sim/src/lib.rs
+++ b/crates/quillcache-sim/src/lib.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 pub mod index_bench;
 pub use index_bench::{bench_index, IndexBenchConfig, IndexBenchReport};
 
+pub mod safe_reuse;
+pub use safe_reuse::{run_safe_reuse, SafeReuseConfig, SafeReuseReport};
+
 #[derive(Debug, Error)]
 pub enum SimError {
     #[error(transparent)]

--- a/crates/quillcache-sim/src/safe_reuse.rs
+++ b/crates/quillcache-sim/src/safe_reuse.rs
@@ -1,0 +1,274 @@
+//! Safe-reuse experiment — QuillCache's identity-governed reuse spike.
+//!
+//! Data-plane KV caches (FlexKV / LMCache / KVBM) reuse a block when its
+//! **content hash** matches. But content hashes collide across identities — the
+//! same tokens produce the same `block_hash` regardless of which tenant sent
+//! them or which LoRA adapter is active — while the KV *tensors* do not. So
+//! content-only reuse serves blocks it must not:
+//! - across **tenants**: a privacy leak (one tenant's cached state served to
+//!   another),
+//! - across **adapters / models / tokenizers**: a correctness error (the cached
+//!   KV is numerically wrong for the request).
+//!
+//! This experiment replays a workload where one popular prefix is requested by
+//! many identities (the collision), and compares two reuse policies on the
+//! *same* trace:
+//! - **naive**: reuse on `block_hash` alone (what a data-plane cache keys on),
+//! - **identity-guarded**: QuillCache's [`IdentityScope`]-checked reuse.
+//!
+//! It reports how many unsafe blocks the naive policy serves (split into privacy
+//! leaks vs correctness errors), that the guard serves zero, and the cost of the
+//! guard: the recomputes it forces — while still preserving safe, same-identity
+//! reuse.
+
+use quillcache_core::{CostModel, IdentityScope, KvBlockKey, ReuseViolation};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeReuseConfig {
+    /// Distinct popular prefixes (e.g. shared system prompts / RAG docs).
+    pub distinct_prefixes: u32,
+    /// Blocks per prefix.
+    pub prefix_blocks: u32,
+    /// Tenants that each send the shared prefix (the cross-tenant / privacy axis).
+    pub tenants: u32,
+    /// Extra LoRA adapters beyond the base model on tenant 0 (the cross-adapter /
+    /// correctness axis).
+    pub adapters: u32,
+    /// Requests per identity. `>= 2` exercises safe same-identity reuse so the
+    /// guard is shown to be *precise*, not just restrictive.
+    pub repeats: u32,
+    /// Tokens per block (drives the recompute cost of the guard).
+    pub block_tokens: u32,
+}
+
+impl Default for SafeReuseConfig {
+    fn default() -> Self {
+        Self {
+            distinct_prefixes: 50,
+            prefix_blocks: 8,
+            tenants: 8,
+            adapters: 4,
+            repeats: 2,
+            block_tokens: 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SafeReuseReport {
+    pub identities: u64,
+    pub blocks_evaluated: u64,
+    /// Content-hash hits a naive (data-plane-style) cache would serve.
+    pub naive_reuses: u64,
+    /// Of those, how many cross an identity boundary and are unsafe.
+    pub naive_unsafe: u64,
+    /// Privacy leaks: same content, different tenant.
+    pub unsafe_cross_tenant: u64,
+    /// Correctness errors: same content, different adapter.
+    pub unsafe_cross_adapter: u64,
+    pub unsafe_cross_model: u64,
+    pub unsafe_cross_tokenizer: u64,
+    /// Token-blocks of state the naive policy serves unsafely.
+    pub unsafe_tokens_served_by_naive: u64,
+    /// Identity-guarded reuses (QuillCache): every one is safe.
+    pub safe_reuses: u64,
+    /// Recomputes the guard forces by refusing a cross-identity content hit —
+    /// the cost of safety.
+    pub guard_recomputes: u64,
+    /// Unsafe serves the guard eliminates (it serves zero unsafe). Equals
+    /// `naive_unsafe`.
+    pub unsafe_blocks_avoided: u64,
+    /// Prefill cost of the guard's forced recomputes, in milliseconds.
+    pub guard_recompute_ms: f64,
+}
+
+fn identity(model: &str, tok: &str, adapter: Option<String>, tenant: String) -> IdentityScope {
+    IdentityScope {
+        model_id: model.to_string(),
+        tokenizer_id: tok.to_string(),
+        adapter_id: adapter,
+        tenant_id: tenant,
+    }
+}
+
+fn block_key(scope: &IdentityScope, content: &str, block_index: u32, tokens: u32) -> KvBlockKey {
+    KvBlockKey {
+        model_id: scope.model_id.clone(),
+        tokenizer_id: scope.tokenizer_id.clone(),
+        adapter_id: scope.adapter_id.clone(),
+        tenant_id: scope.tenant_id.clone(),
+        prefix_hash: content.to_string(),
+        block_hash: content.to_string(),
+        block_index,
+        token_count: tokens,
+    }
+}
+
+/// Run the safe-reuse experiment: naive content reuse vs identity-guarded reuse
+/// on the same cross-identity workload.
+pub fn run_safe_reuse(config: SafeReuseConfig) -> SafeReuseReport {
+    let cost = CostModel::default();
+    let (model, tok) = ("bench-model", "bench-tok");
+
+    // Distinct identities that all request the same content:
+    //   - one base-model identity per tenant (the cross-tenant axis), and
+    //   - extra LoRA adapters on tenant 0 (the cross-adapter axis).
+    // Tenant 0 / base is listed first, so it is the cache's first writer and
+    // every other identity collides against it.
+    let mut identities: Vec<IdentityScope> = Vec::new();
+    for t in 0..config.tenants.max(1) {
+        identities.push(identity(model, tok, None, format!("tenant-{t}")));
+    }
+    for a in 1..=config.adapters {
+        identities.push(identity(
+            model,
+            tok,
+            Some(format!("lora-{a}")),
+            "tenant-0".to_string(),
+        ));
+    }
+
+    // Naive cache: content hash -> the (full-identity) block of its first writer.
+    let mut naive_cache: HashMap<String, KvBlockKey> = HashMap::new();
+    // Identity-guarded cache: (scope, content) presence.
+    let mut safe_cache: HashSet<(IdentityScope, String)> = HashSet::new();
+
+    let mut r = SafeReuseReport {
+        identities: identities.len() as u64,
+        blocks_evaluated: 0,
+        naive_reuses: 0,
+        naive_unsafe: 0,
+        unsafe_cross_tenant: 0,
+        unsafe_cross_adapter: 0,
+        unsafe_cross_model: 0,
+        unsafe_cross_tokenizer: 0,
+        unsafe_tokens_served_by_naive: 0,
+        safe_reuses: 0,
+        guard_recomputes: 0,
+        unsafe_blocks_avoided: 0,
+        guard_recompute_ms: 0.0,
+    };
+
+    let repeats = config.repeats.max(1);
+    for p in 0..config.distinct_prefixes {
+        for block in 0..config.prefix_blocks {
+            let content = format!("pfx{p}-blk{block}");
+            for scope in &identities {
+                for _ in 0..repeats {
+                    r.blocks_evaluated += 1;
+
+                    // --- naive content-hash reuse ---
+                    match naive_cache.get(&content) {
+                        Some(owner) => {
+                            r.naive_reuses += 1;
+                            if let Some(violation) = scope.reuse_violation(owner) {
+                                r.naive_unsafe += 1;
+                                r.unsafe_tokens_served_by_naive += u64::from(config.block_tokens);
+                                match violation {
+                                    ReuseViolation::Tenant => r.unsafe_cross_tenant += 1,
+                                    ReuseViolation::Adapter => r.unsafe_cross_adapter += 1,
+                                    ReuseViolation::Model => r.unsafe_cross_model += 1,
+                                    ReuseViolation::Tokenizer => r.unsafe_cross_tokenizer += 1,
+                                }
+                            }
+                        }
+                        None => {
+                            naive_cache.insert(
+                                content.clone(),
+                                block_key(scope, &content, block, config.block_tokens),
+                            );
+                        }
+                    }
+
+                    // --- identity-guarded reuse (QuillCache) ---
+                    let safe_key = (scope.clone(), content.clone());
+                    if safe_cache.contains(&safe_key) {
+                        r.safe_reuses += 1;
+                    } else {
+                        // First time this identity sees this content. If the naive
+                        // cache holds it under a *different* identity, the guard
+                        // just turned a (would-be) reuse into a recompute.
+                        if let Some(owner) = naive_cache.get(&content) {
+                            if scope.reuse_violation(owner).is_some() {
+                                r.guard_recomputes += 1;
+                            }
+                        }
+                        safe_cache.insert(safe_key);
+                    }
+                }
+            }
+        }
+    }
+
+    r.unsafe_blocks_avoided = r.naive_unsafe;
+    r.guard_recompute_ms =
+        r.guard_recomputes as f64 * cost.prefill_cost_us(config.block_tokens) as f64 / 1_000.0;
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn naive_reuse_serves_unsafe_blocks_the_guard_eliminates() {
+        let config = SafeReuseConfig {
+            distinct_prefixes: 50,
+            prefix_blocks: 8,
+            tenants: 8,
+            adapters: 4,
+            repeats: 2,
+            block_tokens: 64,
+        };
+        let r = run_safe_reuse(config);
+
+        let units = config.prefix_blocks * config.distinct_prefixes; // 8 * 50
+        let units = u64::from(units);
+        let repeats = u64::from(config.repeats);
+        let identities = u64::from(config.tenants + config.adapters); // 8 + 4 = 12
+        let cross_tenant = u64::from(config.tenants - 1); // collide against tenant 0
+        let cross_adapter = u64::from(config.adapters);
+        let unsafe_per = cross_tenant + cross_adapter; // 11 unsafe identities per block
+
+        assert_eq!(r.identities, identities);
+        assert_eq!(r.blocks_evaluated, identities * repeats * units);
+
+        // Each unsafe identity serves once per repeat.
+        assert_eq!(r.unsafe_cross_tenant, repeats * cross_tenant * units);
+        assert_eq!(r.unsafe_cross_adapter, repeats * cross_adapter * units);
+        assert_eq!(r.naive_unsafe, repeats * unsafe_per * units);
+        assert_eq!(r.unsafe_cross_model, 0);
+
+        // The guard serves zero unsafe, forcing one recompute per first
+        // cross-identity occurrence, and avoids every unsafe serve.
+        assert_eq!(r.guard_recomputes, unsafe_per * units);
+        assert_eq!(r.unsafe_blocks_avoided, r.naive_unsafe);
+        assert!(r.guard_recompute_ms > 0.0);
+
+        // The guard is precise: same-identity repeats still reuse safely.
+        assert_eq!(r.safe_reuses, identities * (repeats - 1) * units);
+    }
+
+    #[test]
+    fn single_identity_has_no_unsafe_reuse() {
+        let config = SafeReuseConfig {
+            distinct_prefixes: 4,
+            prefix_blocks: 4,
+            tenants: 1,
+            adapters: 0,
+            repeats: 3,
+            block_tokens: 32,
+        };
+        let r = run_safe_reuse(config);
+        // One identity, no collisions: nothing unsafe, nothing for the guard to
+        // recompute — but safe self-reuse still happens.
+        assert_eq!(r.identities, 1);
+        assert_eq!(r.naive_unsafe, 0);
+        assert_eq!(r.guard_recomputes, 0);
+        assert_eq!(r.guard_recompute_ms, 0.0);
+        let units = u64::from(config.prefix_blocks * config.distinct_prefixes);
+        assert_eq!(r.safe_reuses, u64::from(config.repeats - 1) * units);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use clap::{Parser, Subcommand};
 use quillcache_core::MemoryIndex;
 use quillcache_gateway::run_from_config_path;
-use quillcache_sim::{bench_index, run_synthetic, IndexBenchConfig, SyntheticWorkloadConfig};
+use quillcache_sim::{
+    bench_index, run_safe_reuse, run_synthetic, IndexBenchConfig, SafeReuseConfig,
+    SyntheticWorkloadConfig,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "quillcache")]
@@ -55,6 +58,24 @@ enum Command {
         scan_queries: u32,
         #[arg(long, default_value_t = 0)]
         churn_ops: u32,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Identity-governed safe-reuse experiment: naive content-hash reuse vs
+    /// QuillCache's identity guard on a cross-identity workload.
+    SafeReuse {
+        #[arg(long, default_value_t = 50)]
+        prefixes: u32,
+        #[arg(long, default_value_t = 8)]
+        prefix_blocks: u32,
+        #[arg(long, default_value_t = 8)]
+        tenants: u32,
+        #[arg(long, default_value_t = 4)]
+        adapters: u32,
+        #[arg(long, default_value_t = 2)]
+        repeats: u32,
+        #[arg(long, default_value_t = 64)]
+        block_tokens: u32,
         #[arg(long)]
         json: bool,
     },
@@ -167,6 +188,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ms) = report.recovery_ms {
                     println!("recovery (reopen from disk): {:.2} ms", ms);
                 }
+            }
+        }
+        Command::SafeReuse {
+            prefixes,
+            prefix_blocks,
+            tenants,
+            adapters,
+            repeats,
+            block_tokens,
+            json,
+        } => {
+            let report = run_safe_reuse(SafeReuseConfig {
+                distinct_prefixes: prefixes,
+                prefix_blocks,
+                tenants,
+                adapters,
+                repeats,
+                block_tokens,
+            });
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                let naive_unsafe_pct = if report.naive_reuses > 0 {
+                    100.0 * report.naive_unsafe as f64 / report.naive_reuses as f64
+                } else {
+                    0.0
+                };
+                println!("QuillCache safe-reuse experiment");
+                println!("identities sharing each prefix: {}", report.identities);
+                println!("blocks evaluated: {}", report.blocks_evaluated);
+                println!(
+                    "naive content reuse: {} hits, of which {} UNSAFE ({:.1}%)",
+                    report.naive_reuses, report.naive_unsafe, naive_unsafe_pct
+                );
+                println!(
+                    "  unsafe: {} cross-tenant (privacy leak) · {} cross-adapter (correctness error)",
+                    report.unsafe_cross_tenant, report.unsafe_cross_adapter
+                );
+                println!(
+                    "identity guard: {} unsafe served · {} safe reuses preserved · {} recomputes forced",
+                    0, report.safe_reuses, report.guard_recomputes
+                );
+                println!(
+                    "cost of safety: {:.1} ms prefill to avoid {} unsafe serves",
+                    report.guard_recompute_ms, report.unsafe_blocks_avoided
+                );
             }
         }
     }


### PR DESCRIPTION
Locks QuillCache's **novel spike**: identity-governed safe reuse — the reuse contract data-plane caches (**FlexKV** / LMCache / KVBM) leave implicit.

## Why
A KV block's content hash is computed from its tokens, so the same tokens collide across identities — different tenant, LoRA adapter, model, or tokenizer version — while the KV **tensors** do not. A cache that reuses on content hash alone (what data planes key on) serves blocks it must not:
- across **tenants** → privacy leak
- across **adapters / models / tokenizers** → correctness error

## What
- **core**: `ReuseViolation` (`Model`/`Tokenizer`/`Adapter` = correctness, `Tenant` = privacy) + `IdentityScope::reuse_violation`; `matches` now delegates to it.
- **sim**: `safe_reuse` experiment — naive content-hash reuse vs QuillCache's identity guard on a collision-heavy workload (one popular prefix shared across many identities = the multi-tenant shared-system-prompt / shared-RAG case).
- **cli**: `quillcache safe-reuse [--tenants N --adapters M --repeats R ...]`.
- **docs**: README positions QuillCache as the neutral control plane **above** the data planes (FlexKV named explicitly), with safe reuse as the spike.

## Result — default workload (12 identities share each prefix)
| policy | content-hash hits | unsafe served | of which | safe reuse kept |
| --- | --- | --- | --- | --- |
| naive (content hash only) | 9200 | **8800 (95.7%)** | 5600 cross-tenant leaks + 3200 cross-adapter errors | — |
| **QuillCache (identity guard)** | — | **0** | — | 4800 |

Privacy-heavy mix (`--tenants 32 --adapters 0`): **98.4%** of naive hits are cross-tenant leaks. The guard eliminates all unsafe reuse while preserving safe same-identity reuse, at a measured prefill cost.

## Verified
New tests: `reuse_violation` classification (priority order, privacy vs correctness) + the experiment's exact counts on two configs. fmt · clippy -D warnings (core + rocksdb) · test — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "safe-reuse" experiment to evaluate identity-governed block reuse safety and measure naive content-hash reuse violations across tenants, adapters, and models.
  * New CLI command with configurable workload parameters (`--prefixes`, `--tenants`, `--adapters`, etc.) and JSON output support.
  * Reuse violation detection and categorization (correctness vs privacy impact).

* **Documentation**
  * Updated README with identity-governed safe reuse overview, experiment results table, quick-start commands, and roadmap updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->