### PR TITLE
feat(router): SLO-aware, session-affine routing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mode runs one chosen combination in front of real engines.
 | Axis | Trait / type | Available | Planned |
 | --- | --- | --- | --- |
 | Inference engine / connector | `EngineEndpoint` + KV events | vLLM (OpenAI-compatible + KV events) | SGLang, LMCache events |
-| Routing policy | `quillcache_core` → `quillcache_router::RoutingPolicy` | `LeastLoadedRouter` (baseline), `GreedyStatePlaneRouter` (cache-aware) | SLO-aware, session/DAG-aware |
+| Routing policy | `quillcache_core` → `quillcache_router::RoutingPolicy` | `LeastLoadedRouter` (baseline), `GreedyStatePlaneRouter` (cache-aware), `PrefixAffinityRouter`, `RoundRobinRouter`, **`SloAwareRouter`** (SLO as a near-hard constraint, session-affine within it) | session/DAG-aware |
 | Index backend | `quillcache_core::IndexBackend` | `MemoryIndex` (reference), **Holt** (ART), **RocksDB** (LSM) | filesystem |
 
 ## Two "KV"s, two "backends" (read this first)
@@ -265,7 +265,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ **Closed online residency loop**: the gateway records inferred placement from its own routing decisions and derives prefix blocks from the prompt, so cache-aware routing works end-to-end without a KV-events bridge (verified live: a 2nd request sharing a system prompt routes to the same engine with a real local hit). KV events (Tier 2) upgrade inferred residency to ground truth.
 - ✅ Vendor-neutral `/v1/kv-events` ingest (vLLM BlockStored / BlockRemoved / AllBlocksCleared shape).
 - ✅ Single `IndexBackend` seam with an in-memory reference backend + identity-aware prefix scan.
-- ✅ Pluggable `RoutingPolicy` with a load-only baseline and a cache-aware policy.
+- ✅ Pluggable `RoutingPolicy`: load-only baseline, cache-aware greedy, prefix-affinity, round-robin, and SLO-aware (SLO as a near-hard constraint, session-affine within it).
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.
 - ✅ Eviction-churn benchmark + O(matches) `remove_block` via a secondary block_hash index (100–300× faster eviction on the persistent backends).
@@ -275,7 +275,7 @@ exact block hashes while keeping the upstream request clean. See
 ## Roadmap
 
 1. ✅ Holt (ART) + RocksDB (LSM) `IndexBackend`s + ART-vs-LSM benchmark + eviction churn (O(matches) `remove_block`) — done; next: true write-amplification, Holt compaction/on-disk, larger traces.
-2. SLO-aware and session/DAG-aware routing policies.
+2. ✅ SLO-aware routing (`SloAwareRouter`: SLO as a near-hard constraint, keeps a session local until load threatens the SLO, then spills) — done; next: session/DAG-aware policies.
 3. Real vLLM/SGLang KV-event connectors end-to-end; chat / RAG / agent traces.
 4. Tiered placement and eviction across HBM / DRAM / SSD / remote.
 5. ✅ Identity-governed safe reuse: refuse unsafe reuse and quantify its cost (`safe-reuse`) — done; next: enforce it inline in the gateway and add cross-model/tokenizer/quant axes.

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -11,7 +11,7 @@ use quillcache_core::{
 };
 use quillcache_router::{
     GreedyStatePlaneRouter, LeastLoadedRouter, PrefixAffinityRouter, RoundRobinRouter,
-    RoutingPolicy,
+    RoutingPolicy, SloAwareRouter,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,8 @@ pub struct GatewayConfig {
     pub bind: SocketAddr,
     pub engines: Vec<EngineEndpoint>,
     /// Routing policy: "prefix-affinity" (cache-affine across the fleet),
-    /// "round-robin" (spread baseline), "least-loaded", or "greedy" (default).
+    /// "round-robin" (spread baseline), "least-loaded", "slo-aware" (SLO as a
+    /// near-hard constraint, cache-affine within it), or "greedy" (default).
     #[serde(default)]
     pub policy: Option<String>,
 }
@@ -135,6 +136,7 @@ fn build_policy(name: Option<&str>) -> Box<dyn RoutingPolicy> {
         "prefix-affinity" | "affinity" => Box::new(PrefixAffinityRouter::default()),
         "round-robin" | "roundrobin" => Box::new(RoundRobinRouter::default()),
         "least-loaded" | "load" => Box::new(LeastLoadedRouter::default()),
+        "slo-aware" | "slo" => Box::new(SloAwareRouter::default()),
         _ => Box::new(GreedyStatePlaneRouter::default()),
     }
 }

--- a/crates/quillcache-router/src/lib.rs
+++ b/crates/quillcache-router/src/lib.rs
@@ -2,6 +2,7 @@ use quillcache_core::{
     CacheResidency, CacheTier, CostModel, KvBlockKey, RequestShape, WorkerState,
 };
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -359,6 +360,82 @@ impl RoutingPolicy for RoundRobinRouter {
     }
 }
 
+/// SLO-aware, cache/session-affine policy: treat the TTFT/TPOT SLO as a
+/// near-hard constraint. Among workers that **meet** the SLO budget, pick the one
+/// with the most **local** cache hits — KV already resident in that engine's HBM
+/// (true session affinity, no transfer), which with the closed residency loop is
+/// the engine that already served this session — tie-breaking on latency. Only
+/// when **no** worker can meet the SLO does it fall back to the least-violating.
+///
+/// This differs from [`GreedyStatePlaneRouter`], which blends latency and reuse
+/// into one additive score and will pull a session's KV across engines (a cheap
+/// intra-domain transfer) to chase marginally lower latency, even while the
+/// engine holding it locally was meeting the SLO. SLO-aware keeps the session on
+/// its warm engine — no KV movement, higher fleet-wide local hit rate — until
+/// load actually threatens the SLO, then spills to protect tail latency.
+#[derive(Debug, Clone, Default)]
+pub struct SloAwareRouter {
+    cost_model: CostModel,
+}
+
+impl SloAwareRouter {
+    pub fn new(cost_model: CostModel) -> Self {
+        Self { cost_model }
+    }
+}
+
+impl RoutingPolicy for SloAwareRouter {
+    fn name(&self) -> &str {
+        "slo-aware"
+    }
+
+    fn route(
+        &self,
+        request: &RequestShape,
+        workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, RouterError> {
+        if workers.is_empty() {
+            return Err(RouterError::NoWorkers);
+        }
+        let worker_by_id: HashMap<&str, &WorkerState> = workers
+            .iter()
+            .map(|worker| (worker.id.as_str(), worker))
+            .collect();
+        let plans: Vec<RouteDecision> = workers
+            .iter()
+            .map(|worker| {
+                plan_for_worker(&self.cost_model, request, worker, &worker_by_id, residency)
+            })
+            .collect();
+
+        // Among SLO-feasible workers, maximize *local* cache hits — KV already in
+        // that engine's HBM (true session affinity, zero transfer), not blocks it
+        // would pull over the network — tie-breaking on lowest TTFT.
+        let feasible = plans
+            .iter()
+            .filter(|decision| decision.slo_violation_us == 0)
+            .max_by_key(|decision| {
+                (
+                    decision.local_hits.len(),
+                    Reverse(decision.estimated_ttft_us),
+                )
+            });
+
+        // If none can meet the SLO, take the least-violating (tie-break: most local hits).
+        let chosen = feasible.or_else(|| {
+            plans.iter().min_by_key(|decision| {
+                (
+                    decision.slo_violation_us,
+                    Reverse(decision.local_hits.len()),
+                )
+            })
+        });
+
+        Ok(chosen.expect("plans is non-empty").clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -456,5 +533,59 @@ mod tests {
                 .worker_id,
             "w1"
         );
+    }
+
+    #[test]
+    fn slo_aware_keeps_affinity_while_greedy_chases_latency() {
+        // w0 is cold but fast; w1 holds the session's block but carries modest
+        // queue load, making it marginally slower — yet still within the SLO.
+        let request = request_with_shared_block();
+        let workers = vec![
+            WorkerState::new("w0", "rack-a"),
+            WorkerState::new("w1", "rack-a").with_load(2_000, 0),
+        ];
+        let residency = vec![CacheResidency::hbm(
+            "w1",
+            request.blocks[0].clone(),
+            4 * 1024 * 1024,
+        )];
+
+        // SLO-aware keeps the session local on the warm engine (both meet the
+        // SLO; w1 has the KV in HBM, zero transfer)...
+        let slo = SloAwareRouter::default()
+            .route(&request, &workers, &residency)
+            .unwrap();
+        assert_eq!(slo.worker_id, "w1");
+        assert_eq!(slo.local_hits.len(), 1);
+
+        // ...while greedy pulls the KV to the faster cold engine (cheap
+        // intra-domain transfer), moving the session off its warm engine.
+        let greedy = GreedyStatePlaneRouter::default()
+            .route(&request, &workers, &residency)
+            .unwrap();
+        assert_eq!(greedy.worker_id, "w0");
+        assert_eq!(greedy.transfers.len(), 1);
+    }
+
+    #[test]
+    fn slo_aware_spills_off_a_warm_engine_that_would_violate_slo() {
+        // w1 holds the block but is badly overloaded — its queue blows the TTFT
+        // SLO — so the guard must spill to the cold-but-feasible w0.
+        let request = request_with_shared_block();
+        let workers = vec![
+            WorkerState::new("w0", "rack-a"),
+            WorkerState::new("w1", "rack-a").with_load(250_000, 0),
+        ];
+        let residency = vec![CacheResidency::hbm(
+            "w1",
+            request.blocks[0].clone(),
+            4 * 1024 * 1024,
+        )];
+
+        let decision = SloAwareRouter::default()
+            .route(&request, &workers, &residency)
+            .unwrap();
+        assert_eq!(decision.worker_id, "w0");
+        assert!(decision.recomputes.len() == 1 || !decision.transfers.is_empty());
     }
 }


### PR DESCRIPTION
Adds **`SloAwareRouter`** — the SLO/session-aware policy. Treats the TTFT/TPOT SLO as a **near-hard constraint**: among workers that meet the SLO budget, pick the one with the most **local** cache hits (KV already in that engine's HBM = true session affinity, zero transfer); only when **no** worker can meet the SLO does it fall back to the least-violating one.

## Why it's different from greedy
`GreedyStatePlaneRouter` blends latency + reuse into one additive score, so it will pull a session's KV across engines (a cheap intra-domain transfer) to shave marginal latency — moving the session off the engine that already holds it. `SloAwareRouter` keeps the session **local** (no KV movement, higher fleet-wide local hit rate) until load actually threatens the SLO, then spills to protect tail latency.

| scenario | greedy | slo-aware |
| --- | --- | --- |
| warm engine slightly slower but **meets SLO** | moves session (transfer to cold engine) | **keeps it local** |
| warm engine **overloaded, violates SLO** | spills | **spills** |

## What
- `SloAwareRouter` in `quillcache-router`; wired into the gateway (`policy: slo-aware`).
- Tests: `slo_aware_keeps_affinity_while_greedy_chases_latency` (greedy transfers the KV, slo-aware keeps it local), `slo_aware_spills_off_a_warm_engine_that_would_violate_slo`.

fmt · clippy -D warnings (core + rocksdb) · test (router 5) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `slo-aware` routing policy option that evaluates workers based on SLO metrics and cache performance. Selects workers meeting SLO targets while maintaining session affinity, with automatic fallback to the least SLO-violating worker when necessary.

* **Documentation**
  * Updated documentation to describe the new SLO-aware routing policy and its behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->