### PR TITLE
feat(gateway): back the online control plane with a persistent ART index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,8 @@ dependencies = [
  "axum",
  "quillcache-control",
  "quillcache-core",
+ "quillcache-index-holt",
+ "quillcache-index-rocksdb",
  "quillcache-router",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ tracing-subscriber = { workspace = true }
 [features]
 # Optional RocksDB (LSM) index backend. Off by default so `cargo install
 # quillcache` stays light and the core CI job needs no C++/libclang toolchain.
-rocksdb = ["dep:quillcache-index-rocksdb"]
+rocksdb = ["dep:quillcache-index-rocksdb", "quillcache-gateway/rocksdb"]
 # Optional Holt (persistent ART) index backend. Pure Rust; off by default to keep
-# the installed binary minimal.
-holt = ["dep:quillcache-index-holt"]
+# the installed binary minimal. Also lets the online gateway back its residency
+# index with Holt (`index: holt` in the gateway config).
+holt = ["dep:quillcache-index-holt", "quillcache-gateway/holt"]

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ cargo run -- plan
 
 # Online mode: OpenAI-compatible gateway in front of real vLLM/SGLang workers.
 cargo run -- gateway --config examples/quillcache-gateway.yaml
+# ...backed by a persistent ART (Holt) residency index that survives restarts:
+cargo run --features holt -- gateway --config examples/quillcache-gateway.yaml  # set index: holt
 
 # Tests
 cargo test --workspace
@@ -269,6 +271,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ **Closed online residency loop**: the gateway records inferred placement from its own routing decisions and derives prefix blocks from the prompt, so cache-aware routing works end-to-end without a KV-events bridge (verified live: a 2nd request sharing a system prompt routes to the same engine with a real local hit). KV events (Tier 2) upgrade inferred residency to ground truth.
 - ✅ Vendor-neutral `/v1/kv-events` ingest (vLLM BlockStored / BlockRemoved / AllBlocksCleared shape).
 - ✅ Single `IndexBackend` seam with an in-memory reference backend + identity-aware prefix scan.
+- ✅ **Persistent residency index in the online gateway** (`index: holt` / `rocksdb`): the control plane can be backed by Holt (persistent ART), so fleet residency **survives a gateway restart** — verified live (2 blocks placed → SIGTERM flush → reopen → 2 blocks recovered, no replay of events).
 - ✅ Pluggable `RoutingPolicy`: load-only baseline, cache-aware greedy, prefix-affinity, round-robin, SLO-aware (SLO as a near-hard constraint), and session-affine (pin a multi-turn/agent session to the engine accumulating its KV).
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.

--- a/crates/quillcache-control/src/lib.rs
+++ b/crates/quillcache-control/src/lib.rs
@@ -304,6 +304,13 @@ impl ControlPlane {
     pub fn residency(&self) -> &dyn IndexBackend {
         self.residency.as_ref()
     }
+
+    /// Persist the residency index (checkpoint a persistent backend; no-op for
+    /// in-memory). Call periodically and on shutdown so a persistent index
+    /// survives a restart.
+    pub fn flush(&self) {
+        self.residency.flush();
+    }
 }
 
 #[cfg(test)]

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -564,6 +564,12 @@ pub trait IndexBackend: std::fmt::Debug + Send + Sync {
     /// Drop the entire index.
     fn clear(&mut self);
 
+    /// Persist buffered state to disk (checkpoint the WAL / flush memtables). The
+    /// in-memory reference backend is a no-op; persistent backends override this.
+    /// The control plane calls it periodically and on graceful shutdown so a
+    /// persistent residency index survives a restart.
+    fn flush(&self) {}
+
     /// Full residency snapshot, for debugging and for routers that consume a
     /// slice of residency.
     fn snapshot(&self) -> Vec<CacheResidency>;

--- a/crates/quillcache-gateway/Cargo.toml
+++ b/crates/quillcache-gateway/Cargo.toml
@@ -11,6 +11,8 @@ axum = { workspace = true }
 quillcache-control = { path = "../quillcache-control", version = "1.0.0-alpha.1" }
 quillcache-core = { path = "../quillcache-core", version = "1.0.0-alpha.1" }
 quillcache-router = { path = "../quillcache-router", version = "1.0.0-alpha.1" }
+quillcache-index-holt = { path = "../quillcache-index-holt", version = "1.0.0-alpha.1", optional = true }
+quillcache-index-rocksdb = { path = "../quillcache-index-rocksdb", version = "1.0.0-alpha.1", optional = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -18,3 +20,9 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[features]
+# Back the online control plane with a persistent ART (Holt) residency index.
+holt = ["dep:quillcache-index-holt"]
+# Back it with a RocksDB (LSM) residency index (needs a C++ toolchain).
+rocksdb = ["dep:quillcache-index-rocksdb"]

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -6,8 +6,8 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use quillcache_control::{ControlPlane, IngestSummary};
 use quillcache_core::{
-    EngineEndpoint, ExternalKvBlockKey, KvBlockKey, KvEventBatch, MemoryIndex, RequestKvHints,
-    RequestShape, SloTarget,
+    EngineEndpoint, ExternalKvBlockKey, IndexBackend, KvBlockKey, KvEventBatch, MemoryIndex,
+    RequestKvHints, RequestShape, SloTarget,
 };
 use quillcache_router::{
     GreedyStatePlaneRouter, LeastLoadedRouter, PrefixAffinityRouter, RoundRobinRouter,
@@ -56,9 +56,19 @@ pub struct GatewayConfig {
     pub engines: Vec<EngineEndpoint>,
     /// Routing policy: "prefix-affinity" (cache-affine across the fleet),
     /// "round-robin" (spread baseline), "least-loaded", "slo-aware" (SLO as a
-    /// near-hard constraint, cache-affine within it), or "greedy" (default).
+    /// near-hard constraint), "session-affinity", or "greedy" (default).
     #[serde(default)]
     pub policy: Option<String>,
+    /// Residency index backend: "memory" (default, ephemeral), "holt"
+    /// (persistent ART), or "rocksdb" (persistent LSM). The persistent backends
+    /// need the matching build feature; otherwise the gateway warns and uses
+    /// memory. A persistent index keeps fleet residency across restarts.
+    #[serde(default)]
+    pub index: Option<String>,
+    /// On-disk path for a persistent index backend (default
+    /// `quillcache-residency`).
+    #[serde(default)]
+    pub index_path: Option<String>,
 }
 
 impl GatewayConfig {
@@ -109,13 +119,15 @@ pub async fn run_from_config_path(path: impl AsRef<Path>) -> Result<(), GatewayE
 pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
     let policy = build_policy(config.policy.as_deref());
     let policy_name = policy.name().to_string();
-    let control =
-        ControlPlane::with_index_and_policy(config.engines, Box::new(MemoryIndex::new()), policy);
-    tracing::info!(policy = %policy_name, "routing policy selected");
+    let index = build_index(&config);
+    let index_name = index.name().to_string();
+    let control = ControlPlane::with_index_and_policy(config.engines, index, policy);
+    tracing::info!(policy = %policy_name, index = %index_name, "control plane configured");
     let state = GatewayState {
         control: Arc::new(RwLock::new(control)),
         client: Client::new(),
     };
+    let control = state.control.clone();
     let app = router(state);
     let listener = TcpListener::bind(config.bind)
         .await
@@ -125,9 +137,89 @@ pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
         })?;
 
     tracing::info!(addr = %config.bind, "starting QuillCache gateway");
+    // Persist the residency index on shutdown so a persistent backend survives a
+    // restart (in-memory no-ops).
     axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            control.read().await.flush();
+            tracing::info!("flushed residency index on shutdown");
+        })
         .await
         .map_err(GatewayError::Serve)
+}
+
+/// Resolve when the process receives Ctrl-C or (on Unix) SIGTERM.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut stream) => {
+                stream.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+}
+
+/// Build the residency index backend from config. Persistent backends are
+/// feature-gated; if the requested one is not compiled in (or fails to open),
+/// the gateway warns and falls back to the in-memory reference index, so a
+/// misconfigured backend degrades instead of failing to start.
+fn build_index(config: &GatewayConfig) -> Box<dyn IndexBackend> {
+    match config.index.as_deref().unwrap_or("memory") {
+        "memory" => Box::new(MemoryIndex::new()),
+        #[cfg(feature = "holt")]
+        "holt" => {
+            let path = config
+                .index_path
+                .clone()
+                .unwrap_or_else(|| "quillcache-residency".to_string());
+            match quillcache_index_holt::HoltIndex::open(&path) {
+                Ok(index) => {
+                    tracing::info!(path = %path, "persistent ART (Holt) residency index");
+                    Box::new(index)
+                }
+                Err(error) => {
+                    tracing::error!(?error, "failed to open Holt index; using in-memory");
+                    Box::new(MemoryIndex::new())
+                }
+            }
+        }
+        #[cfg(feature = "rocksdb")]
+        "rocksdb" => {
+            let path = config
+                .index_path
+                .clone()
+                .unwrap_or_else(|| "quillcache-residency".to_string());
+            match quillcache_index_rocksdb::RocksIndex::open(&path) {
+                Ok(index) => {
+                    tracing::info!(path = %path, "persistent LSM (RocksDB) residency index");
+                    Box::new(index)
+                }
+                Err(error) => {
+                    tracing::error!(?error, "failed to open RocksDB index; using in-memory");
+                    Box::new(MemoryIndex::new())
+                }
+            }
+        }
+        other => {
+            tracing::warn!(
+                backend = other,
+                "index backend unavailable (needs a build feature); using in-memory"
+            );
+            Box::new(MemoryIndex::new())
+        }
+    }
 }
 
 /// Build a routing policy from its config name (default: cache-aware greedy).
@@ -534,6 +626,25 @@ mod tests {
         assert!(value.get("quillcache").is_none());
         assert_eq!(shape.id, "req-a");
         assert_eq!(shape.blocks[0].block_hash, "h0");
+    }
+
+    #[test]
+    fn build_index_defaults_to_memory_and_degrades_gracefully() {
+        let base = GatewayConfig {
+            bind: "127.0.0.1:0".parse().unwrap(),
+            engines: vec![],
+            policy: None,
+            index: None,
+            index_path: None,
+        };
+        // No backend configured -> in-memory reference.
+        assert_eq!(build_index(&base).name(), "memory");
+        // An unavailable / uncompiled backend falls back to memory, not a panic.
+        let unknown = GatewayConfig {
+            index: Some("not-a-backend".to_string()),
+            ..base.clone()
+        };
+        assert_eq!(build_index(&unknown).name(), "memory");
     }
 
     #[test]

--- a/crates/quillcache-index-holt/src/lib.rs
+++ b/crates/quillcache-index-holt/src/lib.rs
@@ -313,6 +313,10 @@ impl IndexBackend for HoltIndex {
             .count()
     }
 
+    fn flush(&self) {
+        let _ = self.tree.checkpoint();
+    }
+
     fn persistent(&self) -> bool {
         true
     }

--- a/crates/quillcache-index-rocksdb/src/lib.rs
+++ b/crates/quillcache-index-rocksdb/src/lib.rs
@@ -337,6 +337,10 @@ impl IndexBackend for RocksIndex {
         n
     }
 
+    fn flush(&self) {
+        let _ = self.db.flush_wal(true);
+    }
+
     fn persistent(&self) -> bool {
         true
     }

--- a/examples/quillcache-gateway.yaml
+++ b/examples/quillcache-gateway.yaml
@@ -1,5 +1,10 @@
 # QuillCache gateway in front of a 2-vLLM fleet on Modal.
-# policy: prefix-affinity (cache-affine) | round-robin (spread) | least-loaded | greedy
+# policy: prefix-affinity | round-robin | least-loaded | slo-aware | session-affinity | greedy
+# index:  memory (default) | holt (persistent ART) | rocksdb (persistent LSM)
+#   A persistent index keeps fleet residency across gateway restarts. Build with
+#   the matching feature (`cargo run --features holt -- gateway ...`) and set:
+#   index: holt
+#   index_path: quillcache-residency
 bind: 127.0.0.1:8080
 policy: prefix-affinity
 engines:


### PR DESCRIPTION
Makes the persistent residency index (**Holt/ART**, RocksDB/LSM) first-class in **Online** mode — the concrete answer to "how does the persistent storage engine connect into the control plane?" The gateway hardcoded `MemoryIndex`; now the config selects the backend.

## What
- `index: holt | rocksdb | memory` (+ `index_path`) in the gateway config, feature-gated, with graceful fallback to memory when a backend isn't compiled in or fails to open.
- **Durability fix**: nothing checkpointed the WAL, so a persistent index lost un-flushed residency on shutdown. Adds `IndexBackend::flush` (no-op for memory; checkpoint for Holt; `flush_wal` for RocksDB), `ControlPlane::flush`, and a graceful-shutdown handler (SIGTERM/Ctrl-C) that flushes before exit.
- Gateway `holt`/`rocksdb` features, forwarded from the root crate.

## Verified live (Holt-backed gateway)
```
RUN 1: POST request -> HTTP 200; /v1/state resident = 2
SIGTERM -> "flushed residency index on shutdown"
RUN 2: reopen same index_path, NO new requests -> /v1/state resident = 2
```
Fleet residency **survives a gateway restart** — recovered from the ART index on disk, no event replay.

Test: `build_index_defaults_to_memory_and_degrades_gracefully`. fmt · clippy -D warnings (core + gateway×{holt,rocksdb} + rocksdb) · test — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for persistent residency indexes using Holt or RocksDB backends, with automatic recovery on restart.
  * Implemented graceful shutdown that persists index state before application exit.
  * Added configuration options to select and manage the index backend.

* **Documentation**
  * Updated quick start guide with persistent index examples.
  * Enhanced configuration documentation with index setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->