### PR TITLE
docs: GitHub Pages landing page (overview, results, Dynamo mapping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [![ci](https://github.com/feichai0017/quillcache/actions/workflows/ci.yml/badge.svg)](https://github.com/feichai0017/quillcache/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![page](https://img.shields.io/badge/page-quillcache-5ee0c0.svg)](https://feichai0017.github.io/quillcache/)
+[![crates.io](https://img.shields.io/badge/crates.io-quillcache-orange.svg)](https://crates.io/crates/quillcache)
 
 > **QuillCache is a research platform and control-plane prototype for
 > identity-aware, persistent, and policy-driven KV cache reuse in LLM serving.**
+
+**▶ Overview & results: [feichai0017.github.io/quillcache](https://feichai0017.github.io/quillcache/)**
 
 QuillCache is a **vendor-neutral KV cache control plane and evaluation platform**
 for LLM inference. It does not run models and it does not move KV tensors. It

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>QuillCache — KV-cache control plane for LLM serving</title>
+<meta name="description" content="A vendor-neutral KV cache control plane and evaluation platform for LLM serving (vLLM/SGLang), written in Rust. Cache-aware routing, identity-governed safe reuse, and a persistent ART residency index." />
+<style>
+  :root{
+    --bg:#0b0e14; --panel:#11151f; --panel2:#161b27; --line:#222a39;
+    --ink:#e6edf3; --mut:#9aa7b8; --dim:#6b7787;
+    --accent:#5ee0c0; --accent2:#7aa2ff; --warn:#ffb86b; --bad:#ff7a93;
+    --mono:"SF Mono",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
+    background-image:radial-gradient(1200px 600px at 70% -10%,rgba(122,162,255,.10),transparent),
+      radial-gradient(900px 500px at 10% 0%,rgba(94,224,192,.08),transparent);}
+  a{color:var(--accent2);text-decoration:none}
+  a:hover{text-decoration:underline}
+  .wrap{max-width:1040px;margin:0 auto;padding:0 22px}
+  code,.mono{font-family:var(--mono)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:12px;color:var(--accent);
+    border:1px solid var(--line);border-radius:999px;padding:3px 11px;background:var(--panel)}
+  header{padding:64px 0 26px}
+  h1{font-size:46px;line-height:1.1;margin:18px 0 10px;letter-spacing:-.5px}
+  h1 .q{color:var(--accent)}
+  .lede{font-size:19px;color:var(--mut);max-width:760px}
+  .sub{color:var(--dim);font-size:15px;margin-top:14px;max-width:760px}
+  .cta{margin:26px 0 6px;display:flex;gap:12px;flex-wrap:wrap}
+  .btn{font-family:var(--mono);font-size:14px;border:1px solid var(--line);border-radius:9px;
+    padding:10px 16px;background:var(--panel);color:var(--ink);transition:.15s}
+  .btn:hover{border-color:var(--accent2);text-decoration:none;transform:translateY(-1px)}
+  .btn.pri{background:linear-gradient(180deg,#1b2333,#141a27);border-color:#2c3a55}
+  .pills{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .pill{font-family:var(--mono);font-size:12px;color:var(--mut);border:1px solid var(--line);
+    border-radius:7px;padding:5px 9px;background:rgba(255,255,255,.02)}
+  section{padding:38px 0;border-top:1px solid var(--line)}
+  h2{font-size:13px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);
+    font-family:var(--mono);margin:0 0 20px;font-weight:600}
+  h3{font-size:20px;margin:0 0 8px}
+  .grid{display:grid;gap:14px}
+  .g3{grid-template-columns:repeat(3,1fr)}
+  .g2{grid-template-columns:repeat(2,1fr)}
+  @media(max-width:780px){.g3,.g2{grid-template-columns:1fr}h1{font-size:34px}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:13px;padding:18px 18px 16px}
+  .card .n{font-family:var(--mono);font-size:30px;font-weight:600;color:var(--accent);letter-spacing:-.5px}
+  .card .n.b{color:var(--accent2)}
+  .card .k{font-size:14px;color:var(--ink);margin:6px 0 3px;font-weight:600}
+  .card .d{font-size:13.5px;color:var(--mut)}
+  .lead{font-size:17px;color:var(--mut);max-width:820px;margin:-6px 0 22px}
+  .diagram{background:var(--panel);border:1px solid var(--line);border-radius:13px;padding:10px}
+  .mermaid{display:flex;justify-content:center}
+  table{width:100%;border-collapse:collapse;font-size:14.5px}
+  th,td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line)}
+  th{color:var(--dim);font-family:var(--mono);font-size:12px;text-transform:uppercase;letter-spacing:.08em}
+  td.mono{font-family:var(--mono)}
+  .good{color:var(--accent)} .blue{color:var(--accent2)} .warnc{color:var(--warn)}
+  .map{display:grid;grid-template-columns:1fr auto 1fr;gap:0;border:1px solid var(--line);
+    border-radius:13px;overflow:hidden;background:var(--panel)}
+  .map .h{font-family:var(--mono);font-size:12px;color:var(--dim);padding:11px 16px;background:var(--panel2);
+    text-transform:uppercase;letter-spacing:.08em}
+  .map .c{padding:11px 16px;border-top:1px solid var(--line);font-size:14.5px}
+  .map .arrow{color:var(--dim);text-align:center;border-top:1px solid var(--line);padding:11px 6px}
+  .map .h.arrow{border-top:none}
+  pre{background:#070a10;border:1px solid var(--line);border-radius:11px;padding:16px;overflow:auto;
+    font-family:var(--mono);font-size:13px;color:#cdd6e4;line-height:1.55}
+  pre .c1{color:var(--dim)} pre .g{color:var(--accent)} pre .b{color:var(--accent2)} pre .w{color:var(--warn)}
+  .note{font-size:13.5px;color:var(--dim);margin-top:10px}
+  ul.clean{list-style:none;padding:0;margin:0}
+  ul.clean li{padding:7px 0 7px 24px;position:relative;color:var(--mut);font-size:15px}
+  ul.clean li:before{content:"▸";position:absolute;left:2px;color:var(--accent)}
+  ul.clean li b{color:var(--ink);font-weight:600}
+  footer{padding:40px 0 60px;border-top:1px solid var(--line);color:var(--dim);font-size:14px}
+  .disc{font-size:13px;color:var(--dim);margin-top:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <span class="tag">Rust · control plane · LLM serving</span>
+  <h1><span class="q">Quill</span>Cache</h1>
+  <p class="lede">A <b>vendor-neutral KV-cache control plane and evaluation platform</b> for LLM
+  inference. It does not run models and it does not move KV tensors — it sits in front of real
+  engines (vLLM / SGLang) and owns the <b>metadata and the decisions</b>: block identity,
+  residency, cache-aware routing, and identity-governed safe reuse.</p>
+  <p class="sub">Two modes — an OpenAI-compatible online gateway, and an experiment harness that
+  replays one trace across pluggable engines × routing policies × index backends to measure them
+  apples-to-apples.</p>
+  <div class="cta">
+    <a class="btn pri" href="https://github.com/feichai0017/quillcache">GitHub →</a>
+    <a class="btn" href="https://crates.io/crates/quillcache">crates.io</a>
+    <a class="btn" href="#results">Results</a>
+    <a class="btn" href="#dynamo">vs. Dynamo</a>
+  </div>
+  <div class="pills">
+    <span class="pill">OpenAI-compatible gateway</span>
+    <span class="pill">cache-aware routing</span>
+    <span class="pill">identity-safe reuse</span>
+    <span class="pill">persistent ART index</span>
+    <span class="pill">ART vs LSM study</span>
+    <span class="pill">6 crates · MIT</span>
+  </div>
+</header>
+
+<section id="results">
+  <h2>Headline results</h2>
+  <p class="lead">Every number below is reproducible from the repo (a CLI flag or a one-line demo),
+  measured against in-tree baselines — not a spec sheet.</p>
+  <div class="grid g3">
+    <div class="card">
+      <div class="n">81s → 4.3s</div>
+      <div class="k">Cache-affine fleet routing</div>
+      <div class="d">P99 TTFT across 2 real vLLM (Qwen2.5) on cloud GPUs: routing the shared prefix to one engine vs scattering it.</div>
+    </div>
+    <div class="card">
+      <div class="n">~1.2 µs</div>
+      <div class="k">ART prefix-scan (p50)</div>
+      <div class="d">Holt (persistent ART) residency index vs RocksDB/LSM 2.7µs and an O(N) flat map. Recovery 0.67 ms.</div>
+    </div>
+    <div class="card">
+      <div class="n">96.8%</div>
+      <div class="k">Unsafe reuse caught</div>
+      <div class="d">Of a naive content-hash cache's hits on a collision workload — cross-tenant leaks + cross-adapter/model/tokenizer errors. The guard serves 0.</div>
+    </div>
+    <div class="card">
+      <div class="n b">100–300×</div>
+      <div class="k">Faster eviction</div>
+      <div class="d">A secondary block-hash index turned O(scope) <code>remove_block</code> into O(matches) — churn the benchmark itself surfaced.</div>
+    </div>
+    <div class="card">
+      <div class="n b">survives restart</div>
+      <div class="k">Persistent residency</div>
+      <div class="d">Holt-backed gateway: blocks placed → SIGTERM flush → reopen → recovered, no event replay.</div>
+    </div>
+    <div class="card">
+      <div class="n b">1.7%</div>
+      <div class="k">Cost of safety</div>
+      <div class="d">Identity-guard overhead on a realistic, mostly-same-identity workload (47.8% only on the adversarial all-collision case).</div>
+    </div>
+  </div>
+</section>
+
+<section id="arch">
+  <h2>Where it sits</h2>
+  <p class="lead">QuillCache is the control/decision plane. The engines run the model; the data plane
+  (LMCache / KVBM / FlexKV) moves the KV tensor bytes. The two planes meet at the index and the
+  storage tier, never as the same object.</p>
+  <div class="diagram">
+    <pre class="mermaid">
+flowchart TB
+  C["Client / benchmark"]
+  subgraph QC["QuillCache — control plane + research platform"]
+    G["<b>gateway</b><br/>OpenAI-compatible proxy + KV-event ingest"]
+    P["<b>control</b><br/>ControlPlane · ingest · safe-reuse audit"]
+    R["<b>router</b><br/>RoutingPolicy: greedy · prefix · SLO · session"]
+    I["<b>core</b><br/>IndexBackend: Memory · Holt(ART) · RocksDB(LSM)"]
+  end
+  E["<b>vLLM / SGLang</b><br/>run model · own live KV tensors"]
+  D["<b>LMCache · Dynamo KVBM · FlexKV</b><br/>KV tensor data plane / tiers"]
+  C --> G --> P --> R --> I
+  P -. KV events .-> E
+  G --> E
+  I -. residency metadata .- D
+  classDef qc fill:#11151f,stroke:#2c3a55,color:#e6edf3;
+  classDef ext fill:#0b0e14,stroke:#222a39,color:#9aa7b8;
+  class G,P,R,I qc; class C,E,D ext;
+    </pre>
+  </div>
+  <p class="note">Three pluggable axes — <b>engines</b> × <b>routing policy</b> × <b>index backend</b> —
+  so Experiment mode replays the same trace across the product and Online mode runs one chosen combination.</p>
+</section>
+
+<section id="dynamo">
+  <h2>Mapped to NVIDIA Dynamo</h2>
+  <p class="lead">QuillCache deliberately mirrors the production reference architecture, so the concepts
+  line up one-to-one — built small enough to read end-to-end and measure.</p>
+  <div class="map">
+    <div class="h">NVIDIA Dynamo (production)</div>
+    <div class="h arrow"></div>
+    <div class="h">QuillCache (this repo)</div>
+
+    <div class="c">KV-aware Router / Smart Router</div>
+    <div class="arrow">≈</div>
+    <div class="c"><code>quillcache-router</code> — greedy, prefix-affinity, SLO-aware, session-affine policies</div>
+
+    <div class="c">KV Block Manager (KVBM), tiers G1–G4</div>
+    <div class="arrow">≈</div>
+    <div class="c"><code>IndexBackend</code> residency index (Memory / Holt-ART / RocksDB-LSM) + <code>CacheTier</code> model</div>
+
+    <div class="c">KV events from the engine</div>
+    <div class="arrow">=</div>
+    <div class="c"><code>/v1/kv-events</code> ingest (BlockStored / Removed / Cleared) + inferred-placement fallback</div>
+
+    <div class="c">Disaggregated serving / Planner</div>
+    <div class="arrow">~</div>
+    <div class="c">cost model + <code>RouteDecision</code> (reuse / transfer / recompute / SLO) — single-node prototype</div>
+
+    <div class="c">Data plane (NIXL transfer, offload)</div>
+    <div class="arrow">↔</div>
+    <div class="c">out of scope by design — QuillCache holds metadata, not tensors</div>
+  </div>
+  <p class="disc">Honest scope: QuillCache is a research/portfolio prototype, not a drop-in for Dynamo.
+  It re-implements the control-plane ideas (and adds an identity-safe-reuse primitive and a persistent
+  ART index study) at a size one person fully understands and can measure.</p>
+</section>
+
+<section id="study">
+  <h2>The storage angle — ART vs LSM for the residency index</h2>
+  <p class="lead">The residency index is written on every KV event and read on every request (longest
+  reusable prefix). Most systems keep it in memory; QuillCache makes it a pluggable, persistent,
+  measured component and asks which engine fits. Same workload, same <code>IndexBackend</code> trait,
+  via <code>quillcache bench-index</code>:</p>
+  <table>
+    <thead><tr><th>backend</th><th>prefix-scan p50</th><th>eviction churn</th><th>recovery</th><th>on-disk</th></tr></thead>
+    <tbody>
+      <tr><td class="mono">memory (flat map)</td><td class="mono">O(N)</td><td class="mono good">1.15M/s</td><td class="mono">—</td><td class="mono">0</td></tr>
+      <tr><td class="mono">rocksdb (LSM)</td><td class="mono">2.7 µs</td><td class="mono">154k/s</td><td class="mono">2.0 ms</td><td class="mono good">175 KB</td></tr>
+      <tr><td class="mono"><b>holt (ART)</b></td><td class="mono good">1.2 µs</td><td class="mono">403k/s</td><td class="mono good">0.67 ms</td><td class="mono">8.4 MB</td></tr>
+    </tbody>
+  </table>
+  <p class="note">ART wins prefix-scan latency and recovery; LSM wins disk footprint. The eviction
+  numbers are <i>after</i> a secondary block-hash index fixed an O(scope) <code>remove_block</code> the
+  churn benchmark exposed (100–300× on the persistent backends). <code>holt</code> is the user's own
+  persistent ART/WAL engine, here serving as the prefix-native index.</p>
+</section>
+
+<section id="safe">
+  <h2>Identity-governed safe reuse</h2>
+  <p class="lead">A KV block's content hash is computed from its tokens — so the same tokens collide
+  across identities (tenant, LoRA adapter, model/quant, tokenizer version) while the KV <i>tensors</i>
+  do not. A cache that reuses on content alone serves wrong or leaked state. QuillCache makes the reuse
+  contract explicit and enforces it inline on the live gateway.</p>
+  <pre><span class="c1"># tenant-a caches a prefix; tenant-b asks for the same content</span>
+$ curl ... -H 'tenant: b' /v1/chat/completions -i
+<span class="b">x-quillcache-local-hits:</span> 0          <span class="c1"># refused — not a stale-but-safe hit</span>
+<span class="w">x-quillcache-reuse-refused:</span> 2       <span class="c1"># 2 cross-tenant blocks the guard blocked</span>
+<span class="c1"># gateway log:</span> <span class="w">WARN</span> identity guard refused unsafe cross-identity reuse</pre>
+  <ul class="clean">
+    <li><b>Privacy:</b> cross-tenant reuse is a prefix-cache leak — the guard blocks it.</li>
+    <li><b>Correctness:</b> cross-adapter / model / tokenizer reuse is numerically wrong — blocked.</li>
+    <li><b>Precise, not blunt:</b> same-identity reuse is preserved; overhead is ~1.7% on a realistic workload.</li>
+  </ul>
+</section>
+
+<section id="try">
+  <h2>Try it</h2>
+  <pre><span class="c1"># Experiment mode — replay one trace across policies × index backends</span>
+$ cargo run --features holt -- bench-index --backend holt --churn-ops 500
+$ cargo run -- safe-reuse            <span class="c1"># naive content reuse vs the identity guard</span>
+
+<span class="c1"># Online mode — OpenAI-compatible gateway, persistent ART residency index</span>
+$ cargo run --features holt -- gateway --config gateway.yaml   <span class="c1"># index: holt</span>
+$ curl localhost:8080/v1/chat/completions -d '{...}'  <span class="c1"># x-quillcache-* decision headers</span></pre>
+  <p class="note">Published on crates.io as six crates (<code>quillcache</code>,
+  <code>-core</code>, <code>-router</code>, <code>-control</code>, <code>-gateway</code>,
+  <code>-sim</code>, + the <code>-index-holt</code> / <code>-index-rocksdb</code> backends).</p>
+</section>
+
+<footer>
+  <div class="wrap" style="padding:0">
+    QuillCache · vendor-neutral KV-cache control plane for LLM serving ·
+    <a href="https://github.com/feichai0017/quillcache">github.com/feichai0017/quillcache</a> · MIT
+    <div class="disc">A research and portfolio project. Not affiliated with NVIDIA Dynamo, vLLM, or SGLang;
+    those names refer to the systems QuillCache interoperates with or is positioned against.</div>
+  </div>
+</footer>
+
+</div>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({startOnLoad:true,theme:"base",securityLevel:"loose",
+    flowchart:{htmlLabels:true,curve:"basis"},themeVariables:{
+    background:"#11151f",primaryColor:"#161b27",primaryTextColor:"#e6edf3",
+    primaryBorderColor:"#2c3a55",lineColor:"#3a4660",fontFamily:"SF Mono,ui-monospace,monospace",
+    fontSize:"13px"}});
+</script>
+</body>
+</html>


### PR DESCRIPTION
A self-contained, dark-themed single-page site (`docs/index.html`, served via GitHub Pages) as the portfolio face.

## Contents
- Hero + positioning (vendor-neutral KV-cache control plane).
- **Headline results** cards — cache-affine TTFT 81s→4.3s, ART prefix-scan ~1.2µs, 96.8% unsafe reuse caught, 100–300× faster eviction, persistent residency survives restart, 1.7% safety overhead.
- **Architecture diagram** (mermaid) — engines / QuillCache control plane / data plane.
- **Mapped to NVIDIA Dynamo** — router / KVBM / KV events / Planner / data plane, one-to-one, with an honest "prototype, not a drop-in" scope note.
- ART-vs-LSM study table, the safe-reuse decision-headers demo, a try-it section.

Verified the render locally (hero, cards, and the mermaid diagram with HTML labels). README links to the page; `.nojekyll` so Pages serves the HTML as-is.

Pages will be enabled on `main` / `docs` after merge → https://feichai0017.github.io/quillcache/

🤖 Generated with [Claude Code](https://claude.com/claude-code)