### PR TITLE
feat(core): DataPlane seam (LMCache/KVBM/FlexKV) + mixed engine fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ Vendor-neutral `/v1/kv-events` ingest (vLLM BlockStored / BlockRemoved / AllBlocksCleared shape).
 - ✅ Single `IndexBackend` seam with an in-memory reference backend + identity-aware prefix scan.
 - ✅ **Persistent residency index in the online gateway** (`index: holt` / `rocksdb`): the control plane can be backed by Holt (persistent ART), so fleet residency **survives a gateway restart** — verified live (2 blocks placed → SIGTERM flush → reopen → 2 blocks recovered, no replay of events).
+- ✅ Mixed **engine fleet** behind one control plane (vLLM + SGLang, both OpenAI-compatible — see `examples/quillcache-mixed-fleet.yaml`) and a **`DataPlane` seam** where a KV-tensor store (LMCache / Dynamo KVBM / FlexKV) plugs in under the control plane (`NoDataPlane` default, `MockDataPlane` for tests).
 - ✅ Pluggable `RoutingPolicy`: load-only baseline, cache-aware greedy, prefix-affinity, round-robin, SLO-aware (SLO as a near-hard constraint), and session-affine (pin a multi-turn/agent session to the engine accumulating its KV).
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.

--- a/crates/quillcache-control/src/lib.rs
+++ b/crates/quillcache-control/src/lib.rs
@@ -1,7 +1,7 @@
 use quillcache_core::{
-    BlockRemovedEvent, BlockStoredEvent, CacheResidency, CacheTier, EngineEndpoint,
+    BlockRemovedEvent, BlockStoredEvent, CacheResidency, CacheTier, DataPlane, EngineEndpoint,
     ExternalKvBlockKey, IdentityScope, IndexBackend, KvBlockKey, KvEvent, KvEventBatch,
-    MemoryIndex, RequestShape, ReuseViolation, WorkerState,
+    MemoryIndex, NoDataPlane, RequestShape, ReuseViolation, WorkerState,
 };
 use quillcache_router::{GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy};
 use serde::{Deserialize, Serialize};
@@ -178,6 +178,7 @@ pub struct ControlPlane {
     workers: Vec<WorkerState>,
     router: Box<dyn RoutingPolicy>,
     residency: Box<dyn IndexBackend>,
+    data_plane: Box<dyn DataPlane>,
 }
 
 impl ControlPlane {
@@ -213,7 +214,20 @@ impl ControlPlane {
             workers,
             router,
             residency,
+            data_plane: Box::new(NoDataPlane),
         }
+    }
+
+    /// Attach a KV-tensor data plane (LMCache / KVBM / FlexKV adapter). By default
+    /// there is none and QuillCache infers residency from routing + KV events;
+    /// this is the seam where a real tensor store plugs in under the control plane.
+    pub fn with_data_plane(mut self, data_plane: Box<dyn DataPlane>) -> Self {
+        self.data_plane = data_plane;
+        self
+    }
+
+    pub fn data_plane(&self) -> &dyn DataPlane {
+        self.data_plane.as_ref()
     }
 
     pub fn route(&self, request: &RequestShape) -> Result<RouteDecision, ControlError> {
@@ -591,5 +605,16 @@ mod tests {
         let control = ControlPlane::with_index(vec![engine()], Box::new(MemoryIndex::new()));
         assert_eq!(control.residency().name(), "memory");
         assert!(!control.residency().persistent());
+    }
+
+    #[test]
+    fn control_plane_data_plane_defaults_to_none_and_is_pluggable() {
+        use quillcache_core::MockDataPlane;
+        let control = ControlPlane::new(vec![engine()]);
+        // By default there is no tensor data plane (infer from events).
+        assert_eq!(control.data_plane().name(), "none");
+        // A data plane (LMCache/KVBM/FlexKV adapter) plugs in at this seam.
+        let control = control.with_data_plane(Box::new(MockDataPlane::new()));
+        assert_eq!(control.data_plane().name(), "mock");
     }
 }

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -745,6 +745,81 @@ impl IndexBackend for MemoryIndex {
     }
 }
 
+/// A KV **tensor** data plane (LMCache / NVIDIA Dynamo KVBM / Tencent FlexKV)
+/// that QuillCache's control plane sits *above*. QuillCache owns metadata and
+/// decisions; a data plane actually stores and moves the KV tensor bytes across
+/// tiers (HBM / DRAM / SSD / remote). This trait is the seam where such a system
+/// plugs in: the control plane can ask where a block's bytes live and what
+/// fetching them would cost, without ever owning the tensors. The default
+/// [`NoDataPlane`] means "infer placement from routing + KV events alone".
+pub trait DataPlane: std::fmt::Debug + Send + Sync {
+    /// Stable name for reports (for example "none", "mock", "lmcache").
+    fn name(&self) -> &str;
+
+    /// The tier a block's KV bytes currently occupy on `worker_id`, if resident.
+    fn tier_of(&self, worker_id: &str, key: &KvBlockKey) -> Option<CacheTier>;
+
+    /// Estimated microseconds to make the block available on `worker_id` (fetch
+    /// / transfer / load from its tier). `None` if the data plane can't say.
+    fn fetch_cost_us(&self, worker_id: &str, key: &KvBlockKey) -> Option<u64>;
+}
+
+/// No external data plane: QuillCache infers residency from routing decisions
+/// and KV events alone (the default — there is no separate tensor store to ask).
+#[derive(Debug, Default)]
+pub struct NoDataPlane;
+
+impl DataPlane for NoDataPlane {
+    fn name(&self) -> &str {
+        "none"
+    }
+    fn tier_of(&self, _worker_id: &str, _key: &KvBlockKey) -> Option<CacheTier> {
+        None
+    }
+    fn fetch_cost_us(&self, _worker_id: &str, _key: &KvBlockKey) -> Option<u64> {
+        None
+    }
+}
+
+/// In-memory reference data plane for tests and demos: records which tier each
+/// `(worker, block)` lives in and reports a tier-derived fetch cost. A real
+/// LMCache / KVBM / FlexKV adapter implements [`DataPlane`] the same way over a
+/// live tensor store.
+#[derive(Debug, Default)]
+pub struct MockDataPlane {
+    tiers: HashMap<(String, KvBlockKey), CacheTier>,
+    cost: CostModel,
+}
+
+impl MockDataPlane {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that a block's KV bytes occupy `tier` on `worker_id`.
+    pub fn place(&mut self, worker_id: impl Into<String>, key: KvBlockKey, tier: CacheTier) {
+        self.tiers.insert((worker_id.into(), key), tier);
+    }
+}
+
+impl DataPlane for MockDataPlane {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn tier_of(&self, worker_id: &str, key: &KvBlockKey) -> Option<CacheTier> {
+        self.tiers
+            .get(&(worker_id.to_string(), key.clone()))
+            .copied()
+    }
+
+    fn fetch_cost_us(&self, worker_id: &str, key: &KvBlockKey) -> Option<u64> {
+        let tier = self.tier_of(worker_id, key)?;
+        let bytes = u64::from(key.token_count) * 128 * 1024;
+        Some(self.cost.transfer_cost_us(tier, bytes, true, true))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -756,6 +831,25 @@ mod tests {
             cost.transfer_cost_us(CacheTier::Hbm, 4 * 1024 * 1024, true, true)
                 < cost.prefill_cost_us(64)
         );
+    }
+
+    #[test]
+    fn data_plane_reports_tier_and_fetch_cost() {
+        let key = KvBlockKey::new("m", "t", "ten", "p", "b", 0, 64);
+        // No data plane: knows nothing (QuillCache infers from events instead).
+        assert_eq!(NoDataPlane.name(), "none");
+        assert_eq!(NoDataPlane.tier_of("w0", &key), None);
+        assert_eq!(NoDataPlane.fetch_cost_us("w0", &key), None);
+
+        // Mock data plane: records tiers and derives a fetch cost.
+        let mut dp = MockDataPlane::new();
+        assert_eq!(dp.name(), "mock");
+        assert_eq!(dp.tier_of("w0", &key), None);
+        dp.place("w0", key.clone(), CacheTier::LocalSsd);
+        assert_eq!(dp.tier_of("w0", &key), Some(CacheTier::LocalSsd));
+        assert!(dp.fetch_cost_us("w0", &key).unwrap() > 0);
+        // A block placed nowhere is still unknown.
+        assert_eq!(dp.tier_of("w1", &key), None);
     }
 
     fn mem_scope() -> IdentityScope {

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -254,6 +254,8 @@ async fn state_snapshot(State(state): State<GatewayState>) -> impl IntoResponse 
         "engines": control.engines(),
         "workers": control.workers(),
         "index": control.residency().metrics(),
+        "index_backend": control.residency().name(),
+        "data_plane": control.data_plane().name(),
         "resident_blocks": control.residency().len(),
         "residency": control.residency().snapshot(),
     }))

--- a/examples/quillcache-mixed-fleet.yaml
+++ b/examples/quillcache-mixed-fleet.yaml
@@ -1,0 +1,25 @@
+# QuillCache over a MIXED engine fleet — vLLM and SGLang behind one control
+# plane. Both speak the OpenAI-compatible API, so the gateway proxies either; the
+# `kind` is metadata used for engine-specific KV-event adapters (the bridge).
+#
+# Backed by a persistent ART (Holt) residency index, with SLO-aware routing.
+# Run: cargo run --features holt -- gateway --config examples/quillcache-mixed-fleet.yaml
+bind: 127.0.0.1:8080
+policy: slo-aware          # greedy | prefix-affinity | session-affinity | slo-aware | round-robin | least-loaded
+index: holt                # memory | holt (persistent ART) | rocksdb (persistent LSM)
+index_path: quillcache-residency
+engines:
+  - id: vllm-a
+    kind: Vllm
+    base_url: http://127.0.0.1:8001
+    model_id: Qwen/Qwen2.5-7B-Instruct
+    tokenizer_id: Qwen/Qwen2.5-7B-Instruct
+    tenant_id: default
+    locality_domain: rack-a
+  - id: sglang-a
+    kind: Sglang
+    base_url: http://127.0.0.1:30000
+    model_id: Qwen/Qwen2.5-7B-Instruct
+    tokenizer_id: Qwen/Qwen2.5-7B-Instruct
+    tenant_id: default
+    locality_domain: rack-a


### PR DESCRIPTION
Adds the architectural seam where a KV-**tensor** data plane plugs in *under* the control plane — the boundary QuillCache deliberately does not cross (it owns metadata + decisions; the data plane owns the bytes). Aligns with Dynamo's KVBM split.

## What
- **core**: `DataPlane` trait (`tier_of`, `fetch_cost_us`) + `NoDataPlane` (default — infer placement from routing + KV events) + `MockDataPlane` (in-memory reference). A real LMCache / Dynamo KVBM / FlexKV adapter implements it the same way over a live tensor store.
- **control**: `ControlPlane` holds a `Box<dyn DataPlane>` (default `NoDataPlane`) with `with_data_plane` + `data_plane()`.
- **gateway**: `/v1/state` now reports `index_backend` and `data_plane` names.
- **mixed fleet**: `examples/quillcache-mixed-fleet.yaml` — vLLM + SGLang behind one control plane (both OpenAI-compatible), SLO-aware routing, persistent Holt index.

So all four axes are now pluggable: **engines** (vLLM/SGLang) × **routing policy** × **index backend** × **data plane**. Tests: `data_plane_reports_tier_and_fetch_cost`, `control_plane_data_plane_defaults_to_none_and_is_pluggable`.

fmt · clippy -D warnings (core + rocksdb) · test — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for mixed engine fleets behind a single control plane.
  * Pluggable interface for KV-tensor storage backend integration.
  * Gateway state endpoint now reports data plane information.

* **Documentation**
  * Added example configuration for mixed engine fleet deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->