### PR TITLE
feat(sim): tiered KV block management (KVBM-style HBM/DRAM/SSD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ fix.
 
 | Package | Role |
 | --- | --- |
-| `quillcache` | CLI: `simulate`, `bench-index`, `safe-reuse`, `plan`, `gateway`. |
+| `quillcache` | CLI: `simulate`, `bench-index`, `safe-reuse`, `tiered`, `plan`, `gateway`. |
 | `quillcache-core` | `KvBlockKey` identity, `CacheResidency`, cost model, and the `IndexBackend` trait + `MemoryIndex` reference backend. |
 | `quillcache-router` | `RoutingPolicy` trait; `GreedyStatePlaneRouter` (cache-aware) and `LeastLoadedRouter` (baseline). |
 | `quillcache-control` | `ControlPlane` and the backend-agnostic `ingest_batch` (KV events → residency). |
@@ -239,6 +239,9 @@ cargo run --features "rocksdb holt" -- bench-index --backend holt
 # Identity-governed safe reuse: naive content-hash reuse vs the identity guard.
 cargo run -- safe-reuse
 cargo run -- safe-reuse --tenants 32 --adapters 0   # privacy-heavy mix
+
+# Tiered KV block management (KVBM-style HBM/DRAM/SSD) vs an HBM-only baseline.
+cargo run -- tiered
 
 # Print the research plan / build order.
 cargo run -- plan
@@ -277,6 +280,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ Single `IndexBackend` seam with an in-memory reference backend + identity-aware prefix scan.
 - ✅ **Persistent residency index in the online gateway** (`index: holt` / `rocksdb`): the control plane can be backed by Holt (persistent ART), so fleet residency **survives a gateway restart** — verified live (2 blocks placed → SIGTERM flush → reopen → 2 blocks recovered, no replay of events).
 - ✅ Mixed **engine fleet** behind one control plane (vLLM + SGLang, both OpenAI-compatible — see `examples/quillcache-mixed-fleet.yaml`) and a **`DataPlane` seam** where a KV-tensor store (LMCache / Dynamo KVBM / FlexKV) plugs in under the control plane (`NoDataPlane` default, `MockDataPlane` for tests).
+- ✅ **Tiered KV block management** (`quillcache tiered`) — a KVBM-style HBM→DRAM→SSD cache with promotion / demotion / eviction vs an HBM-only baseline. On a skewed trace it turns ~13k recomputes into cheap tier-hits and cuts total prefill cost **~76%** (HBM 59% / DRAM 22% / SSD 10% hits, 9% miss).
 - ✅ Pluggable `RoutingPolicy`: load-only baseline, cache-aware greedy, prefix-affinity, round-robin, SLO-aware (SLO as a near-hard constraint), and session-affine (pin a multi-turn/agent session to the engine accumulating its KV).
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.
@@ -290,7 +294,7 @@ exact block hashes while keeping the upstream request clean. See
 1. ✅ Holt (ART) + RocksDB (LSM) `IndexBackend`s + ART-vs-LSM benchmark + eviction churn (O(matches) `remove_block`) — done; next: true write-amplification, Holt compaction/on-disk, larger traces.
 2. ✅ SLO-aware routing (`SloAwareRouter`) and session/DAG-affine routing (`SessionAffinityRouter`: pin a session to the engine accumulating its KV) — done; next: network-aware placement.
 3. ✅ Real vLLM KV-event connector end-to-end (inferred placement + Tier-2 `/v1/kv-events` correction) — done; next: SGLang connector, chat / RAG / agent traces.
-4. Tiered placement and eviction across HBM / DRAM / SSD / remote.
+4. ✅ Tiered placement and eviction across HBM / DRAM / SSD (`tiered`, KVBM-style) — done; next: remote tier, tier-aware routing in the online path.
 5. ✅ Identity-governed safe reuse: refuse unsafe reuse and quantify its cost (`safe-reuse`) — done; next: enforce it inline in the gateway and add cross-model/tokenizer/quant axes.
 6. Baselines: engine-local prefix caching, LMCache-style cache, Mooncake-style pool.
 

--- a/crates/quillcache-sim/src/lib.rs
+++ b/crates/quillcache-sim/src/lib.rs
@@ -12,6 +12,9 @@ pub use index_bench::{bench_index, IndexBenchConfig, IndexBenchReport};
 pub mod safe_reuse;
 pub use safe_reuse::{run_safe_reuse, SafeReuseConfig, SafeReuseReport};
 
+pub mod tiered;
+pub use tiered::{run_tiered, TieredConfig, TieredReport};
+
 #[derive(Debug, Error)]
 pub enum SimError {
     #[error(transparent)]

--- a/crates/quillcache-sim/src/tiered.rs
+++ b/crates/quillcache-sim/src/tiered.rs
@@ -1,0 +1,298 @@
+//! Tiered KV block management — a KVBM-style multi-tier cache.
+//!
+//! Mirrors the tiered block managers of production stacks (NVIDIA Dynamo KVBM's
+//! G1–G4, Tencent FlexKV's StorageEngine): KV blocks live in HBM → DRAM → SSD.
+//! Under capacity pressure a tier demotes its coldest block to the next tier
+//! down (and the bottom tier evicts); on reuse a block is promoted back toward
+//! HBM. The persistent ART index is the natural cross-tier catalog.
+//!
+//! The experiment replays a skewed access trace through the tiered cache and an
+//! HBM-only baseline on the *same* trace, to quantify the win: how many
+//! recomputes tiering turns into cheap tier-hits, and the prefill cost saved.
+
+use quillcache_core::{CacheTier, CostModel};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TieredConfig {
+    /// Distinct blocks in the working set.
+    pub blocks: u32,
+    /// Total accesses replayed.
+    pub accesses: u32,
+    /// HBM capacity, in blocks (the hot tier).
+    pub hbm_blocks: u32,
+    /// DRAM capacity, in blocks.
+    pub dram_blocks: u32,
+    /// SSD capacity, in blocks.
+    pub ssd_blocks: u32,
+    /// Percent of blocks that are "hot" (receive ~80% of accesses).
+    pub hot_percent: u32,
+    pub block_tokens: u32,
+    pub block_bytes: u64,
+}
+
+impl Default for TieredConfig {
+    fn default() -> Self {
+        Self {
+            blocks: 4_000,
+            accesses: 40_000,
+            hbm_blocks: 200,
+            dram_blocks: 800,
+            ssd_blocks: 4_000,
+            hot_percent: 10,
+            block_tokens: 256,
+            block_bytes: 2 * 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TieredReport {
+    pub accesses: u64,
+    pub hbm_hits: u64,
+    pub dram_hits: u64,
+    pub ssd_hits: u64,
+    /// Misses = blocks not resident in any tier (a full prefill recompute).
+    pub misses: u64,
+    pub promotions: u64,
+    pub demotions: u64,
+    pub evictions: u64,
+    /// Total cache capacity across tiers — the "effective cache size".
+    pub effective_cache_blocks: u64,
+    /// Total access cost (HBM hit / tier transfer / recompute), in ms.
+    pub total_cost_ms: f64,
+    /// Counterfactual: the same trace through an HBM-only cache of the same HBM
+    /// size — everything beyond HBM is recomputed.
+    pub hbm_only_cost_ms: f64,
+    pub hbm_only_misses: u64,
+    /// Cost reduction tiering buys over HBM-only.
+    pub cost_saved_pct: f64,
+    /// Recomputes tiering avoided vs HBM-only (turned into cheap tier-hits).
+    pub recomputes_avoided: u64,
+}
+
+/// A multi-tier LRU cache: tier 0 is HBM, then DRAM, then SSD. A block lives in
+/// exactly one tier; promotion moves it to HBM, overflow cascades demotions down
+/// and evicts off the bottom.
+struct TieredCache {
+    caps: Vec<usize>,
+    lru: Vec<VecDeque<u32>>,
+    tier_of: HashMap<u32, usize>,
+    promotions: u64,
+    demotions: u64,
+    evictions: u64,
+}
+
+impl TieredCache {
+    fn new(caps: Vec<usize>) -> Self {
+        let lru = caps.iter().map(|_| VecDeque::new()).collect();
+        Self {
+            caps,
+            lru,
+            tier_of: HashMap::new(),
+            promotions: 0,
+            demotions: 0,
+            evictions: 0,
+        }
+    }
+
+    /// Access `block`. Returns the tier it was found in (`None` = miss). Either
+    /// way the block ends up at HBM (tier 0) MRU, with overflow cascaded down.
+    fn access(&mut self, block: u32) -> Option<usize> {
+        let found = self.tier_of.remove(&block);
+        if let Some(tier) = found {
+            if let Some(pos) = self.lru[tier].iter().position(|&b| b == block) {
+                self.lru[tier].remove(pos);
+            }
+            if tier > 0 {
+                self.promotions += 1;
+            }
+        }
+        // (Re)insert at HBM MRU.
+        self.lru[0].push_back(block);
+        self.tier_of.insert(block, 0);
+        self.cascade();
+        found
+    }
+
+    /// Push overflow down the tiers; evict off the bottom.
+    fn cascade(&mut self) {
+        for tier in 0..self.caps.len() {
+            while self.lru[tier].len() > self.caps[tier] {
+                let Some(victim) = self.lru[tier].pop_front() else {
+                    break;
+                };
+                if tier + 1 < self.caps.len() {
+                    self.lru[tier + 1].push_back(victim);
+                    self.tier_of.insert(victim, tier + 1);
+                    self.demotions += 1;
+                } else {
+                    self.tier_of.remove(&victim);
+                    self.evictions += 1;
+                }
+            }
+        }
+    }
+}
+
+/// Deterministic skewed access trace with temporal locality (the realistic case
+/// LRU/tiering exploits): ~80% of accesses fall in the hot region with a
+/// Zipf-like concentration on the hottest blocks, ~20% sweep the larger cold
+/// region. The hot region is bigger than HBM, so the hottest blocks stay in HBM
+/// while the warm-hot ones live in DRAM and the cold tail in SSD. A fixed seed
+/// keeps it reproducible. (`a % hot` would be a sequential scan — LRU's
+/// worst case — so we sample instead.)
+fn trace(config: &TieredConfig) -> Vec<u32> {
+    let blocks = config.blocks.max(1);
+    let hot = (blocks * config.hot_percent / 100).clamp(1, blocks);
+    let cold = (blocks - hot).max(1);
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut rng = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    (0..config.accesses)
+        .map(|_| {
+            if rng() % 100 < 80 {
+                // Hot region, Zipf-like: block = hot^u, u in [0,1) — concentrates
+                // accesses on the lowest (hottest) indices, giving LRU locality.
+                let u = (rng() >> 11) as f64 / (1u64 << 53) as f64;
+                (f64::from(hot).powf(u) as u32)
+                    .saturating_sub(1)
+                    .min(hot - 1)
+            } else {
+                // Cold region: a uniform sweep over the long tail.
+                hot + (rng() % u64::from(cold)) as u32
+            }
+        })
+        .collect()
+}
+
+/// Run the tiered-vs-HBM-only experiment.
+pub fn run_tiered(config: TieredConfig) -> TieredReport {
+    let cost = CostModel::default();
+    let recompute_us = cost.prefill_cost_us(config.block_tokens) as f64;
+    let tier_cost =
+        |tier: CacheTier| cost.transfer_cost_us(tier, config.block_bytes, true, true) as f64;
+    let hbm_us = cost.transfer_cost_us(CacheTier::Hbm, config.block_bytes, true, true) as f64;
+    let dram_us = tier_cost(CacheTier::CpuDram);
+    let ssd_us = tier_cost(CacheTier::LocalSsd);
+
+    let accesses = trace(&config);
+
+    // Tiered cache: HBM -> DRAM -> SSD.
+    let mut tiered = TieredCache::new(vec![
+        config.hbm_blocks as usize,
+        config.dram_blocks as usize,
+        config.ssd_blocks as usize,
+    ]);
+    let (mut hbm_hits, mut dram_hits, mut ssd_hits, mut misses) = (0u64, 0u64, 0u64, 0u64);
+    let mut total_us = 0.0;
+    for &block in &accesses {
+        match tiered.access(block) {
+            Some(0) => {
+                hbm_hits += 1;
+                total_us += hbm_us;
+            }
+            Some(1) => {
+                dram_hits += 1;
+                total_us += dram_us;
+            }
+            Some(_) => {
+                ssd_hits += 1;
+                total_us += ssd_us;
+            }
+            None => {
+                misses += 1;
+                total_us += recompute_us;
+            }
+        }
+    }
+
+    // HBM-only baseline on the same trace.
+    let mut hbm_only = TieredCache::new(vec![config.hbm_blocks as usize]);
+    let (mut hbm_only_misses, mut hbm_only_us) = (0u64, 0.0);
+    for &block in &accesses {
+        match hbm_only.access(block) {
+            Some(_) => hbm_only_us += hbm_us,
+            None => {
+                hbm_only_misses += 1;
+                hbm_only_us += recompute_us;
+            }
+        }
+    }
+
+    let cost_saved_pct = if hbm_only_us > 0.0 {
+        100.0 * (hbm_only_us - total_us) / hbm_only_us
+    } else {
+        0.0
+    };
+
+    TieredReport {
+        accesses: accesses.len() as u64,
+        hbm_hits,
+        dram_hits,
+        ssd_hits,
+        misses,
+        promotions: tiered.promotions,
+        demotions: tiered.demotions,
+        evictions: tiered.evictions,
+        effective_cache_blocks: u64::from(config.hbm_blocks)
+            + u64::from(config.dram_blocks)
+            + u64::from(config.ssd_blocks),
+        total_cost_ms: total_us / 1_000.0,
+        hbm_only_cost_ms: hbm_only_us / 1_000.0,
+        hbm_only_misses,
+        cost_saved_pct,
+        recomputes_avoided: hbm_only_misses.saturating_sub(misses),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiering_turns_recomputes_into_tier_hits() {
+        let report = run_tiered(TieredConfig::default());
+
+        assert_eq!(report.accesses, 40_000);
+        // The lower tiers catch reuse the HBM-only cache would recompute.
+        assert!(report.dram_hits + report.ssd_hits > 0);
+        assert!(
+            report.misses < report.hbm_only_misses,
+            "tiering should recompute less: {} vs {}",
+            report.misses,
+            report.hbm_only_misses
+        );
+        assert!(report.recomputes_avoided > 0);
+        // A recompute is far costlier than a tier transfer, so tiering wins.
+        assert!(
+            report.cost_saved_pct > 0.0,
+            "expected positive saving, got {}%",
+            report.cost_saved_pct
+        );
+        // Effective cache spans all tiers.
+        assert_eq!(report.effective_cache_blocks, 200 + 800 + 4_000);
+    }
+
+    #[test]
+    fn promotions_and_demotions_happen_under_pressure() {
+        let report = run_tiered(TieredConfig {
+            blocks: 1_000,
+            accesses: 5_000,
+            hbm_blocks: 20,
+            dram_blocks: 80,
+            ssd_blocks: 1_000,
+            hot_percent: 10,
+            block_tokens: 64,
+            block_bytes: 1024 * 1024,
+        });
+        // Cold blocks accessed from lower tiers get promoted; HBM overflow demotes.
+        assert!(report.promotions > 0);
+        assert!(report.demotions > 0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use clap::{Parser, Subcommand};
 use quillcache_core::MemoryIndex;
 use quillcache_gateway::run_from_config_path;
 use quillcache_sim::{
-    bench_index, run_safe_reuse, run_synthetic, IndexBenchConfig, SafeReuseConfig,
-    SyntheticWorkloadConfig,
+    bench_index, run_safe_reuse, run_synthetic, run_tiered, IndexBenchConfig, SafeReuseConfig,
+    SyntheticWorkloadConfig, TieredConfig,
 };
 
 #[derive(Debug, Parser)]
@@ -58,6 +58,26 @@ enum Command {
         scan_queries: u32,
         #[arg(long, default_value_t = 0)]
         churn_ops: u32,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Tiered KV block management (KVBM-style): HBM/DRAM/SSD with promotion and
+    /// eviction, vs an HBM-only baseline on the same trace.
+    Tiered {
+        #[arg(long, default_value_t = 4000)]
+        blocks: u32,
+        #[arg(long, default_value_t = 40000)]
+        accesses: u32,
+        #[arg(long, default_value_t = 200)]
+        hbm: u32,
+        #[arg(long, default_value_t = 800)]
+        dram: u32,
+        #[arg(long, default_value_t = 4000)]
+        ssd: u32,
+        #[arg(long, default_value_t = 10)]
+        hot_percent: u32,
+        #[arg(long, default_value_t = 256)]
+        block_tokens: u32,
         #[arg(long)]
         json: bool,
     },
@@ -192,6 +212,62 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ms) = report.recovery_ms {
                     println!("recovery (reopen from disk): {:.2} ms", ms);
                 }
+            }
+        }
+        Command::Tiered {
+            blocks,
+            accesses,
+            hbm,
+            dram,
+            ssd,
+            hot_percent,
+            block_tokens,
+            json,
+        } => {
+            let report = run_tiered(TieredConfig {
+                blocks,
+                accesses,
+                hbm_blocks: hbm,
+                dram_blocks: dram,
+                ssd_blocks: ssd,
+                hot_percent,
+                block_tokens,
+                block_bytes: 2 * 1024 * 1024,
+            });
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                let total = report.accesses.max(1) as f64;
+                let hit = |n: u64| 100.0 * n as f64 / total;
+                println!("QuillCache tiered KV block management (KVBM-style)");
+                println!(
+                    "tiers: HBM {} · DRAM {} · SSD {} blocks (effective cache {})",
+                    hbm, dram, ssd, report.effective_cache_blocks
+                );
+                println!("accesses: {}", report.accesses);
+                println!(
+                    "hits: HBM {} ({:.1}%) · DRAM {} ({:.1}%) · SSD {} ({:.1}%) · miss {} ({:.1}%)",
+                    report.hbm_hits,
+                    hit(report.hbm_hits),
+                    report.dram_hits,
+                    hit(report.dram_hits),
+                    report.ssd_hits,
+                    hit(report.ssd_hits),
+                    report.misses,
+                    hit(report.misses)
+                );
+                println!(
+                    "movement: {} promotions · {} demotions · {} evictions",
+                    report.promotions, report.demotions, report.evictions
+                );
+                println!(
+                    "vs HBM-only: {} misses → {} ({} recomputes avoided)",
+                    report.hbm_only_misses, report.misses, report.recomputes_avoided
+                );
+                println!(
+                    "cost: {:.1} ms vs HBM-only {:.1} ms → {:.1}% saved",
+                    report.total_cost_ms, report.hbm_only_cost_ms, report.cost_saved_pct
+                );
             }
         }
         Command::SafeReuse {


### PR DESCRIPTION
Replicates the **tiered block manager** of NVIDIA Dynamo KVBM (G1–G4) and Tencent FlexKV's StorageEngine — the storage core of the production stacks, leaning on the persistent ART index as the cross-tier catalog.

## Mechanism
Blocks live in **HBM → DRAM → SSD**. Capacity pressure demotes the coldest block down a tier (the bottom tier evicts); reuse promotes a block back toward HBM. A multi-tier LRU.

## Result — `quillcache tiered` (skewed, locality-bearing trace; tiered vs HBM-only on the same trace)
| | hits | |
| --- | --- | --- |
| HBM | 23452 (58.6%) | |
| DRAM | 8754 (21.9%) | promoted on reuse |
| SSD | 4179 (10.4%) | the cold tail |
| miss (recompute) | 3615 (9.0%) | |

vs an **HBM-only** cache of the same HBM size: **16548 → 3615 misses** (12933 recomputes avoided), total prefill cost **190.8s → 45.1s = 76.4% saved**. Tighter HBM (100·400·4000) → 80.5% saved.

Deterministic Zipf-like trace (fixed seed) so it's reproducible; `a % hot` would be a sequential scan (LRU's worst case), so it samples instead. Tests assert tiering recomputes less than HBM-only with a positive saving, and that promotions/demotions happen.

fmt · clippy -D warnings · test (sim 10) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)