### PR TITLE
feat(sim): prefill/decode disaggregation TTFT model (Dynamo/llm-d topology)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ fix.
 
 | Package | Role |
 | --- | --- |
-| `quillcache` | CLI: `simulate`, `bench-index`, `safe-reuse`, `tiered`, `plan`, `gateway`. |
+| `quillcache` | CLI: `simulate`, `bench-index`, `safe-reuse`, `tiered`, `disagg`, `plan`, `gateway`. |
 | `quillcache-core` | `KvBlockKey` identity, `CacheResidency`, cost model, and the `IndexBackend` trait + `MemoryIndex` reference backend. |
 | `quillcache-router` | `RoutingPolicy` trait; `GreedyStatePlaneRouter` (cache-aware) and `LeastLoadedRouter` (baseline). |
 | `quillcache-control` | `ControlPlane` and the backend-agnostic `ingest_batch` (KV events → residency). |
@@ -242,6 +242,8 @@ cargo run -- safe-reuse --tenants 32 --adapters 0   # privacy-heavy mix
 
 # Tiered KV block management (KVBM-style HBM/DRAM/SSD) vs an HBM-only baseline.
 cargo run -- tiered
+# Prefill/decode disaggregation (Dynamo/llm-d topology): TTFT under load.
+cargo run -- disagg --load-percent 90
 
 # Print the research plan / build order.
 cargo run -- plan
@@ -281,6 +283,7 @@ exact block hashes while keeping the upstream request clean. See
 - ✅ **Persistent residency index in the online gateway** (`index: holt` / `rocksdb`): the control plane can be backed by Holt (persistent ART), so fleet residency **survives a gateway restart** — verified live (2 blocks placed → SIGTERM flush → reopen → 2 blocks recovered, no replay of events).
 - ✅ Mixed **engine fleet** behind one control plane (vLLM + SGLang, both OpenAI-compatible — see `examples/quillcache-mixed-fleet.yaml`) and a **`DataPlane` seam** where a KV-tensor store (LMCache / Dynamo KVBM / FlexKV) plugs in under the control plane (`NoDataPlane` default, `MockDataPlane` for tests).
 - ✅ **Tiered KV block management** (`quillcache tiered`) — a KVBM-style HBM→DRAM→SSD cache with promotion / demotion / eviction vs an HBM-only baseline. On a skewed trace it turns ~13k recomputes into cheap tier-hits and cuts total prefill cost **~76%** (HBM 59% / DRAM 22% / SSD 10% hits, 9% miss).
+- ✅ **Prefill/decode disaggregation** (`quillcache disagg`) — a discrete-event TTFT sim of the Dynamo/llm-d topology (aggregated prefill+decode per engine vs a prefill pool + decode pool, Poisson arrivals). Disaggregation cuts p99 TTFT **24% @ 75% load, 41% @ 90%** (prefill no longer queues behind long decodes); the gain grows with load.
 - ✅ Pluggable `RoutingPolicy`: load-only baseline, cache-aware greedy, prefix-affinity, round-robin, SLO-aware (SLO as a near-hard constraint), and session-affine (pin a multi-turn/agent session to the engine accumulating its KV).
 - ✅ Experiment harness comparing policies × backends on one trace.
 - ✅ Holt (ART) and RocksDB (LSM) index backends + `bench-index` ART-vs-LSM comparison.

--- a/crates/quillcache-sim/src/disagg.rs
+++ b/crates/quillcache-sim/src/disagg.rs
@@ -1,0 +1,210 @@
+//! Prefill/decode (PD) disaggregation — the headline topology of NVIDIA Dynamo
+//! and llm-d.
+//!
+//! In *aggregated* serving each engine does both prefill and decode, so an
+//! engine tied up in a long (autoregressive) decode can't start the prefill of a
+//! newly arrived request — time-to-first-token (TTFT) waits behind decode work.
+//! *Disaggregated* serving splits the fleet into a prefill pool and a decode pool
+//! (KV is transferred between them), so the prefill pool only ever does short
+//! prefills: same utilization, much shorter service time, so far shorter waits.
+//!
+//! Steady-state *throughput* is similar either way (both saturate the GPUs); the
+//! win is **TTFT under load**. This is a discrete-event simulation: requests
+//! arrive over time at a chosen fraction of fleet throughput and are assigned to
+//! the engine that frees soonest; we measure TTFT (arrival → first token) under
+//! both topologies on the same arrival stream.
+
+use quillcache_core::CostModel;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisaggConfig {
+    /// Requests in the arrival stream.
+    pub requests: u32,
+    /// Total engines (GPUs) in the fleet.
+    pub engines: u32,
+    /// Prompt tokens to prefill per request.
+    pub prefill_tokens: u32,
+    /// Tokens to decode per request (chat-style defaults are decode-dominant).
+    pub decode_tokens: u32,
+    /// Prefill engines for the split; `0` auto-balances P:D to the work ratio.
+    pub prefill_engines: u32,
+    /// Offered load as a percent of fleet throughput (queueing pressure).
+    pub load_percent: u32,
+}
+
+impl Default for DisaggConfig {
+    fn default() -> Self {
+        Self {
+            requests: 2_000,
+            engines: 8,
+            prefill_tokens: 512,
+            decode_tokens: 1_024,
+            prefill_engines: 0,
+            load_percent: 75,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DisaggReport {
+    pub requests: u64,
+    pub engines: u64,
+    pub prefill_ms: f64,
+    pub decode_ms: f64,
+    pub load_percent: u64,
+    pub agg_ttft_p50_ms: f64,
+    pub agg_ttft_p99_ms: f64,
+    pub disagg_prefill_engines: u64,
+    pub disagg_decode_engines: u64,
+    pub disagg_ttft_p50_ms: f64,
+    pub disagg_ttft_p99_ms: f64,
+    /// p99 TTFT reduction disaggregation buys.
+    pub ttft_p99_reduction_pct: f64,
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = (((sorted.len() - 1) as f64) * p).round() as usize;
+    sorted[idx]
+}
+
+fn argmin(values: &[f64]) -> usize {
+    let mut best = 0;
+    for (i, &v) in values.iter().enumerate() {
+        if v < values[best] {
+            best = i;
+        }
+    }
+    best
+}
+
+/// Simulate a pool of FIFO servers over an arrival stream, assigning each
+/// arrival to the engine that frees soonest. An engine is *occupied* for
+/// `occupancy_us` per job (prefill+decode when aggregated; prefill only for a
+/// prefill pool), but the first token — what TTFT measures — lands after
+/// `ttft_us`. Returns each job's TTFT (`start + ttft_us - arrival`); the wait
+/// differs because a request can be stuck behind an engine busy with decode.
+fn simulate_ttft(arrivals: &[f64], pool: usize, occupancy_us: f64, ttft_us: f64) -> Vec<f64> {
+    let mut free = vec![0.0f64; pool.max(1)];
+    arrivals
+        .iter()
+        .map(|&arrival| {
+            let e = argmin(&free);
+            let start = arrival.max(free[e]);
+            free[e] = start + occupancy_us;
+            start + ttft_us - arrival
+        })
+        .collect()
+}
+
+/// Run the aggregated-vs-disaggregated TTFT experiment.
+pub fn run_disagg(config: DisaggConfig) -> DisaggReport {
+    let cost = CostModel::default();
+    let prefill_us = cost.prefill_cost_us(config.prefill_tokens) as f64;
+    let decode_us = cost.decode_cost_us(config.decode_tokens, 0) as f64;
+    let engines = config.engines.max(1) as usize;
+    let requests = config.requests.max(1) as usize;
+
+    // Fleet throughput (req/us) and the arrival rate at the offered load.
+    let throughput = engines as f64 / (prefill_us + decode_us);
+    let lambda = (config.load_percent.max(1) as f64 / 100.0) * throughput;
+    // Poisson arrivals (exponential inter-arrival) — real traffic is bursty, and
+    // bursts are what build queues. A fixed seed keeps it reproducible.
+    let mut state = 0x2545_F491_4F6C_DD1D_u64;
+    let mut next_u = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        ((state >> 11) as f64 / (1u64 << 53) as f64).max(1e-12)
+    };
+    let mut t = 0.0;
+    let arrivals: Vec<f64> = (0..requests)
+        .map(|_| {
+            t += -next_u().ln() / lambda;
+            t
+        })
+        .collect();
+
+    // Aggregated: each engine is occupied prefill+decode per request, but the
+    // first token lands after prefill. TTFT waits behind whatever (including long
+    // decodes) is occupying the engine.
+    let agg = simulate_ttft(&arrivals, engines, prefill_us + decode_us, prefill_us);
+
+    // Disaggregated: a prefill pool sized to the work ratio (decode-dominant ->
+    // fewer prefill engines), serving only short prefills.
+    let p = if config.prefill_engines > 0 {
+        (config.prefill_engines as usize).clamp(1, engines.saturating_sub(1).max(1))
+    } else {
+        let ratio = prefill_us / (prefill_us + decode_us);
+        ((engines as f64 * ratio).round() as usize).clamp(1, engines - 1)
+    };
+    let d = (engines - p).max(1);
+    // The prefill pool is occupied only by short prefills, so it frees fast.
+    let dis = simulate_ttft(&arrivals, p, prefill_us, prefill_us);
+
+    let mut agg_s = agg.clone();
+    let mut dis_s = dis.clone();
+    agg_s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    dis_s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let ms = |us: f64| us / 1_000.0;
+    let agg_p99 = percentile(&agg_s, 0.99);
+    let dis_p99 = percentile(&dis_s, 0.99);
+
+    DisaggReport {
+        requests: requests as u64,
+        engines: engines as u64,
+        prefill_ms: ms(prefill_us),
+        decode_ms: ms(decode_us),
+        load_percent: u64::from(config.load_percent),
+        agg_ttft_p50_ms: ms(percentile(&agg_s, 0.50)),
+        agg_ttft_p99_ms: ms(agg_p99),
+        disagg_prefill_engines: p as u64,
+        disagg_decode_engines: d as u64,
+        disagg_ttft_p50_ms: ms(percentile(&dis_s, 0.50)),
+        disagg_ttft_p99_ms: ms(dis_p99),
+        ttft_p99_reduction_pct: if agg_p99 > 0.0 {
+            100.0 * (agg_p99 - dis_p99) / agg_p99
+        } else {
+            0.0
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disaggregation_cuts_ttft_when_decode_dominates() {
+        let report = run_disagg(DisaggConfig::default());
+        assert_eq!(report.requests, 2_000);
+        assert_eq!(
+            report.disagg_prefill_engines + report.disagg_decode_engines,
+            report.engines
+        );
+        // Decode-dominant: the prefill pool is the smaller one.
+        assert!(report.disagg_prefill_engines < report.disagg_decode_engines);
+        // The headline: disaggregation lowers p99 TTFT under load, because the
+        // prefill pool never waits behind a long decode.
+        assert!(
+            report.disagg_ttft_p99_ms < report.agg_ttft_p99_ms,
+            "disagg p99 {} should beat agg p99 {}",
+            report.disagg_ttft_p99_ms,
+            report.agg_ttft_p99_ms
+        );
+        assert!(report.ttft_p99_reduction_pct > 10.0);
+    }
+
+    #[test]
+    fn auto_balance_respects_an_explicit_split() {
+        let report = run_disagg(DisaggConfig {
+            prefill_engines: 3,
+            ..DisaggConfig::default()
+        });
+        assert_eq!(report.disagg_prefill_engines, 3);
+        assert_eq!(report.disagg_decode_engines, report.engines - 3);
+    }
+}

--- a/crates/quillcache-sim/src/lib.rs
+++ b/crates/quillcache-sim/src/lib.rs
@@ -15,6 +15,9 @@ pub use safe_reuse::{run_safe_reuse, SafeReuseConfig, SafeReuseReport};
 pub mod tiered;
 pub use tiered::{run_tiered, TieredConfig, TieredReport};
 
+pub mod disagg;
+pub use disagg::{run_disagg, DisaggConfig, DisaggReport};
+
 #[derive(Debug, Error)]
 pub enum SimError {
     #[error(transparent)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use clap::{Parser, Subcommand};
 use quillcache_core::MemoryIndex;
 use quillcache_gateway::run_from_config_path;
 use quillcache_sim::{
-    bench_index, run_safe_reuse, run_synthetic, run_tiered, IndexBenchConfig, SafeReuseConfig,
-    SyntheticWorkloadConfig, TieredConfig,
+    bench_index, run_disagg, run_safe_reuse, run_synthetic, run_tiered, DisaggConfig,
+    IndexBenchConfig, SafeReuseConfig, SyntheticWorkloadConfig, TieredConfig,
 };
 
 #[derive(Debug, Parser)]
@@ -78,6 +78,24 @@ enum Command {
         hot_percent: u32,
         #[arg(long, default_value_t = 256)]
         block_tokens: u32,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Prefill/decode disaggregation (Dynamo/llm-d topology): TTFT under a burst,
+    /// aggregated (prefill+decode per engine) vs disaggregated (separate pools).
+    Disagg {
+        #[arg(long, default_value_t = 2000)]
+        requests: u32,
+        #[arg(long, default_value_t = 8)]
+        engines: u32,
+        #[arg(long, default_value_t = 512)]
+        prefill_tokens: u32,
+        #[arg(long, default_value_t = 1024)]
+        decode_tokens: u32,
+        #[arg(long, default_value_t = 0)]
+        prefill_engines: u32,
+        #[arg(long, default_value_t = 75)]
+        load_percent: u32,
         #[arg(long)]
         json: bool,
     },
@@ -267,6 +285,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!(
                     "cost: {:.1} ms vs HBM-only {:.1} ms → {:.1}% saved",
                     report.total_cost_ms, report.hbm_only_cost_ms, report.cost_saved_pct
+                );
+            }
+        }
+        Command::Disagg {
+            requests,
+            engines,
+            prefill_tokens,
+            decode_tokens,
+            prefill_engines,
+            load_percent,
+            json,
+        } => {
+            let report = run_disagg(DisaggConfig {
+                requests,
+                engines,
+                prefill_tokens,
+                decode_tokens,
+                prefill_engines,
+                load_percent,
+            });
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                println!("QuillCache prefill/decode disaggregation");
+                println!(
+                    "{} reqs · {} engines · prefill {:.1} ms · decode {:.1} ms/req · {}% load",
+                    report.requests,
+                    report.engines,
+                    report.prefill_ms,
+                    report.decode_ms,
+                    report.load_percent
+                );
+                println!(
+                    "aggregated  (prefill+decode/engine): TTFT p50 {:.0} · p99 {:.0} ms",
+                    report.agg_ttft_p50_ms, report.agg_ttft_p99_ms
+                );
+                println!(
+                    "disaggregated ({}P + {}D pools):       TTFT p50 {:.0} · p99 {:.0} ms",
+                    report.disagg_prefill_engines,
+                    report.disagg_decode_engines,
+                    report.disagg_ttft_p50_ms,
+                    report.disagg_ttft_p99_ms
+                );
+                println!(
+                    "=> disaggregation cuts p99 TTFT by {:.1}% (prefill no longer waits behind decode)",
+                    report.ttft_p99_reduction_pct
                 );
             }
         }


### PR DESCRIPTION
`quillcache disagg` — a discrete-event simulation of **prefill/decode disaggregation**, the headline topology of NVIDIA Dynamo and llm-d.

## Model
Requests arrive **Poisson** (bursty, seeded → reproducible) at a chosen fraction of fleet throughput, assigned to the engine that frees soonest:
- **aggregated**: each engine does prefill+decode, so a request's prefill can queue behind a long autoregressive decode;
- **disaggregated**: a prefill pool + decode pool (sized to the prefill:decode work ratio), so the prefill pool only ever runs short prefills.

TTFT is arrival → first token (after prefill), on the **same arrival stream**.

## Result — decode-dominant (prefill 23 ms, decode 82 ms), p99 TTFT reduction
| load | 50% | 70% | 80% | 90% | 95% |
| --- | --- | --- | --- | --- | --- |
| p99 TTFT cut | 0.8% | 16% | 29% | **41%** | **52%** |

The gain grows with load (negligible when idle) — the canonical PD result: aggregated engines tied up in decode build queues that delay prefill; the disaggregated prefill pool clears fast. Steady-state throughput is unchanged; the win is tail TTFT.

Tests: disagg beats aggregated p99 by >10% on the default; explicit P:D split respected. fmt · clippy · test (sim 12) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `quillcache disagg` CLI subcommand for prefill/decode disaggregation simulation experiments with configurable request counts, engine allocation, and load parameters; outputs time-to-first-token (TTFT) performance metrics comparing aggregated and disaggregated scheduling strategies.

* **Documentation**
  * Updated README with quick-start instructions for the disaggregation simulation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->