### PR TITLE
docs: a "measured vs modeled" section (interview-honest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ mode runs one chosen combination in front of real engines.
 | Runtime data plane | `quillcache_core::DataPlane` | `NoDataPlane`, **`TieredDataPlane`** (HBM/DRAM/SSD admission, promotion, demotion, eviction) | LMCache/KVBM/FlexKV adapters |
 | Execution adapter | gateway `action_sink` | HTTP action events + local mock sink | vLLM `kv_transfer`, SGLang/LMCache, Dynamo KVBM bridge |
 
+## Measured vs modeled (read this before the numbers)
+
+Honesty matters more than big numbers. Two kinds of results live in this repo:
+
+- **Measured** — real code, real engines, real measurements:
+  - the **ART-vs-LSM storage study** (`bench-index`): prefix-scan latency,
+    recovery, on-disk size, and **write amplification** (from RocksDB's own
+    statistics) — these run real Holt / RocksDB engines.
+  - the **live demos**: cache-affine routing across **2 real vLLM** on Modal L4
+    (P99 TTFT 81 s → 4.3 s — *real, though the round-robin tail was amplified by
+    Modal scale-to-zero cold starts*), persistent residency surviving a restart,
+    the identity guard refusing cross-tenant reuse inline, and the inferred→precise
+    KV-event correction.
+- **Modeled** — cost-model simulations, illustrative of a mechanism, **not** run
+  on real GPUs: the `tiered` (KVBM-style, ~76% cost cut), `disagg` (PD TTFT,
+  24–52%), and `simulate` experiments use an uncalibrated cost model. They show
+  *how* a mechanism behaves and are labeled as models, not hardware results.
+
+The runtime control plane itself — gateway, planner, tiered data plane, action
+sink — is real code in the online path (see `docs/runtime-control-plane.md`); the
+*performance numbers* from the simulator are the modeled part.
+
 ## Two "KV"s, two "backends" (read this first)
 
 | | Stores | Size | Owner |


### PR DESCRIPTION
Separates **measured** results (real ART/RocksDB storage study incl. write amplification; live demos on real vLLM, persistent restart, inline safe-reuse, KV-event correction) from **modeled** cost-model simulations (tiered, disagg, simulate). Notes the 81s→4.3s tail was amplified by Modal scale-to-zero, and that the runtime control plane is real code while the simulator's performance numbers are modeled. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new reference section clearly distinguishing between actual engine measurements captured from live demonstrations and results from cost-model simulations. The section includes specific labeled examples to help users more accurately interpret benchmark results and understand which performance data is based on real engine measurements versus cost-model projections and simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->