### PR TITLE
feat(router): Dynamo KV-cost router + measured gateway overhead fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ name = "quillcache-gateway"
 version = "1.0.0-alpha.1"
 dependencies = [
  "axum",
+ "futures-util",
  "quillcache-control",
  "quillcache-core",
  "quillcache-index-holt",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ mode runs one chosen combination in front of real engines.
 | Axis | Trait / type | Available | Planned |
 | --- | --- | --- | --- |
 | Inference engine / connector | `EngineEndpoint` + KV events | vLLM (OpenAI-compatible + KV events) | SGLang, LMCache events |
-| Routing policy | `quillcache_core` → `quillcache_router::RoutingPolicy` | `LeastLoadedRouter` (baseline), `GreedyStatePlaneRouter` (cache-aware), `PrefixAffinityRouter`, `RoundRobinRouter`, **`SloAwareRouter`** (SLO as a near-hard constraint), **`SessionAffinityRouter`** (pin a session/DAG to its engine) | network-aware |
+| Routing policy | `quillcache_core` → `quillcache_router::RoutingPolicy` | `LeastLoadedRouter` (baseline), `GreedyStatePlaneRouter` (cache-aware), **`DynamoCostRouter`** (mirrors NVIDIA Dynamo's KV-router cost function), `PrefixAffinityRouter`, `RoundRobinRouter`, **`SloAwareRouter`** (SLO as a near-hard constraint), **`SessionAffinityRouter`** (pin a session/DAG to its engine) | network-aware |
 | Index backend | `quillcache_core::IndexBackend` | `MemoryIndex` (reference), **Holt** (ART), **RocksDB** (LSM) | filesystem |
 | Runtime data plane | `quillcache_core::DataPlane` | `NoDataPlane`, **`TieredDataPlane`** (HBM/DRAM/SSD admission, promotion, demotion, eviction) | LMCache/KVBM/FlexKV adapters |
 | Execution adapter | gateway `action_sink` | HTTP action events + local mock sink | vLLM `kv_transfer`, SGLang/LMCache, Dynamo KVBM bridge |
@@ -94,11 +94,20 @@ Honesty matters more than big numbers. Two kinds of results live in this repo:
   - the **ART-vs-LSM storage study** (`bench-index`): prefix-scan latency,
     recovery, on-disk size, and **write amplification** (from RocksDB's own
     statistics) — these run real Holt / RocksDB engines.
-  - the **live demos**: cache-affine routing across **2 real vLLM** on Modal L4
-    (P99 TTFT 81 s → 4.3 s — *real, though the round-robin tail was amplified by
-    Modal scale-to-zero cold starts*), persistent residency surviving a restart,
-    the identity guard refusing cross-tenant reuse inline, and the inferred→precise
-    KV-event correction.
+  - the **control-plane overhead** (`bench/bench_gateway.py`): QuillCache's own
+    hot-path latency vs hitting the engine directly — **~0.2 ms median added**,
+    higher throughput than direct at concurrency (see below). A real
+    request-path measurement, and it caught a real O(N) bug.
+  - the **live demos**: fronting **2 real vLLM** on Modal L4 — the Dynamo-style
+    router is cache-affine (pins a shared prefix to the engine holding its KV,
+    real local hits in the decision headers), persistent residency survives a
+    restart, the identity guard refuses cross-tenant reuse inline, and the
+    inferred→precise KV-event correction works. *Steady-state (concurrency 1)
+    warm TTFT is the honest number; high-concurrency **tail** latency on Modal is
+    unreliable because scale-to-zero re-cold-starts a container mid-run (100 s+
+    outliers) — a serverless-deployment artifact, not a routing property. The old
+    "81 s → 4.3 s" headline was exactly this cold-start noise; it is not a clean
+    routing result and is no longer claimed as one.*
 - **Modeled** — cost-model simulations, illustrative of a mechanism, **not** run
   on real GPUs: the `tiered` (KVBM-style, ~76% cost cut), `disagg` (PD TTFT,
   24–52%), and `simulate` experiments use an uncalibrated cost model. They show
@@ -257,6 +266,83 @@ unchanged. This is the benchmark working as intended: it is a research
 instrument, not a victory-lap table — it found the bottleneck, then measured the
 fix.
 
+## Routing: the Dynamo KV-router cost function, reproduced
+
+`DynamoCostRouter` implements the same cost function NVIDIA Dynamo's KV router
+runs (`lib/kv-router/src/scheduling/selector.rs`). For each worker:
+
+```text
+overlap_credit   = overlap_score_credit · device_overlap_blocks      (default 1.0)
+                 + host_cache_hit_weight · host_overlap_blocks         (default 0.75)
+                 + disk_cache_hit_weight · disk_overlap_blocks         (default 0.25)
+adjusted_prefill = max(0, raw_prefill_blocks − overlap_credit)
+cost             = prefill_load_scale · adjusted_prefill + decode_blocks
+```
+
+It routes to the lowest-cost worker (`temperature == 0`, Dynamo's default) or
+softmax-samples the costs when `temperature > 0`. `raw_prefill_blocks` is the
+prompt's blocks plus the worker's queued prefill load; `device/host/disk overlap`
+are the request's blocks already resident on that worker in HBM / DRAM / SSD;
+`decode_blocks` is the worker's active decode load. The credit weights make a
+GPU-resident prefix hit worth 4× an SSD one — the cache-locality-vs-load
+trade-off, as a single number. A unit test reproduces Dynamo's own published
+worked example (costs 18 / 10 / 11 → pick worker 2). The other policies
+(`greedy`, `prefix-affinity`, `round-robin`, `slo-aware`, `session-affinity`)
+remain for apples-to-apples comparison on the same trace.
+
+## Control-plane overhead (measured)
+
+A control plane sits in the hot path of every request, so its **own** latency is
+the first thing to measure. `bench/bench_gateway.py` drives the same shared-prefix
+streaming workload two ways — client→engine vs client→QuillCache→engine — against
+the *same* near-instant mock engine (`tools/mock_engine.py`); the difference is
+QuillCache's added cost (parse, prompt→block-hash derivation, the routing
+decision + residency write-back, decision headers, the streaming proxy).
+
+| path | p50 | p99 | throughput |
+| --- | --- | --- | --- |
+| direct → engine | 0.21 ms | 0.31 ms | — |
+| **through QuillCache** | **0.42 ms** | **0.45 ms** | 121% of direct @ C=32 |
+
+**QuillCache adds ~0.2 ms median per request** (C=1, no contention), and at
+concurrency 32 it sustains *higher* throughput than hitting the engine directly
+(it pools upstream connections). That number is the *fixed* version: the
+benchmark first measured a flat **~14 ms** p50 at C=32, and the cause was a
+genuine hot-path bug — `plan()` and the inline reuse guard each took a full O(N)
+snapshot of the **entire** residency index on every request (cloning all ~2000
+resident records, twice). Replacing those with request-scoped lookups (the
+`IndexBackend`'s O(1) `locate()` for routing + an O(matches) content-hash reverse
+index for the guard) cut the median overhead **~35×**, to 0.2 ms. The benchmark
+working as intended — it caught the bottleneck, then measured the fix.
+
+## Real-engine validation on Modal (and an honest serverless caveat)
+
+The gateway runs in front of **2 real vLLM** (Qwen2.5-0.5B) on Modal L4
+(`deploy/modal_vllm.py`, `examples/quillcache-modal.yaml`). What this validates,
+end-to-end, against real engines:
+
+- **The `DynamoCostRouter` is cache-affine on real hardware.** With a shared
+  system prompt, it pinned **every** request to the one engine holding that
+  prefix's KV (engine distribution from the decision headers), with real local
+  hits (`x-quillcache-local-hits` > 0 on 16/24 served) — the Dynamo cost function
+  steering a real fleet via the inferred-residency loop, no KV-events bridge.
+- **Real streamed TTFT** flows through the gateway with full decision headers;
+  warm steady-state TTFT was ~1.2 s p50 for this 0.5B model on L4.
+
+**The honest caveat (this is the interview-useful part):** Modal scales each
+engine to zero on idle, so a request to an idle engine pays a **~120 s cold
+start**. That — not routing — dominates tail latency, and it is non-deterministic
+(an engine can scale down *between* warmup and measurement). So **Modal is a good
+functional harness but a poor steady-state-latency harness.** The earlier
+"P99 81 s → 4.3 s" headline was exactly this cold-start artifact and is no longer
+claimed as a routing result. For clean latency, QuillCache measures its own
+overhead against a local engine (~0.2 ms, above) and treats the cache-vs-load
+routing behaviour as something to prove deterministically (the
+`dynamo_cost_*` unit tests) rather than on noisy serverless GPUs. Reproduce:
+`modal deploy deploy/modal_vllm.py` (×2 with `QC_VLLM_APP`), then
+`bench/run_trace.py --warmup-urls <a>,<b>` to absorb the cold start before
+measuring.
+
 ## Packages
 
 | Package | Role |
@@ -331,6 +417,17 @@ See [`docs/mvp-runbook.md`](docs/mvp-runbook.md) for the vLLM KV-events bridge.
 ## Status (v0.1)
 
 - ✅ OpenAI-compatible gateway with cache-aware routing and decision headers.
+- ✅ **`DynamoCostRouter`** — the NVIDIA Dynamo KV-router cost function
+  (`prefill_load_scale · adjusted_prefill_blocks + decode_blocks`, HBM/DRAM/SSD
+  overlap credits, temperature softmax), with a test reproducing Dynamo's own
+  worked example. Made **load-aware online**: the gateway feeds its in-flight
+  count back into worker load, so the policy spreads under load instead of
+  dog-piling the cache-hot engine (the llm-d "prefix + load" lesson).
+- ✅ **Measured control-plane overhead** (`bench/bench_gateway.py` + committed
+  `tools/mock_engine.py`): **~0.2 ms** median added per request, >100% of direct
+  throughput at concurrency. Surfaced and fixed a real hot-path bug — `plan()`
+  and the reuse guard were snapshotting the whole residency index per request
+  (O(N)); request-scoped lookups cut median overhead ~35×.
 - ✅ **Live SLO goodput** — the gateway times real first-token latency (arrival → first streamed chunk) against each request's TTFT SLO budget and reports `served` / `met_slo` / `goodput_pct` / `mean_ttft_ms` at `/v1/state`. A measured online metric, not a cost-model estimate.
 - ✅ **Closed online residency loop**: the gateway records inferred placement from its own routing decisions and derives prefix blocks from the prompt, so cache-aware routing works end-to-end without a KV-events bridge (verified live: a 2nd request sharing a system prompt routes to the same engine with a real local hit). KV events (Tier 2) upgrade inferred residency to ground truth.
 - ✅ Vendor-neutral `/v1/kv-events` ingest (vLLM BlockStored / BlockRemoved / AllBlocksCleared shape).

--- a/bench/bench_gateway.py
+++ b/bench/bench_gateway.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Measure the QuillCache gateway's own hot-path overhead.
+
+A control plane sits in front of every request, so the question an interviewer
+asks first is: *what does the control plane itself cost?* This driver answers it
+by sending the same shared-prefix streaming workload two ways —
+
+  1. **direct**  : client -> mock engine
+  2. **gateway** : client -> QuillCache gateway -> mock engine
+
+against the *same* near-instant mock engine (tools/mock_engine.py with ttft/itl
+0). The difference in latency is QuillCache's added cost: request parse, prompt
+-> block-hash derivation, the control-plane routing decision + residency
+write-back, decision headers, and the streaming proxy. Throughput (req/s) shows
+whether the gateway is a bottleneck. Standard library only.
+
+    # term 1: instant engine        python tools/mock_engine.py --port 9000
+    # term 2: gateway -> :9000       cargo run -- gateway --config <cfg with base_url :9000>
+    # term 3:
+    python bench/bench_gateway.py \
+        --direct-url http://127.0.0.1:9000 \
+        --gateway-url http://127.0.0.1:8080 \
+        --model mock --requests 2000 --concurrency 32
+"""
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+SHARED_SYSTEM_PROMPT = "You are QuillCache-Bench, a precise assistant. " * 64
+
+
+def one_request(base_url, model, idx, max_tokens):
+    body = {
+        "model": model,
+        "stream": True,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "messages": [
+            {"role": "system", "content": SHARED_SYSTEM_PROMPT},
+            {"role": "user", "content": f"Question {idx}: reply briefly."},
+        ],
+    }
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/v1/chat/completions",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    ttft = None
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", "ignore").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:"):].strip()
+                if payload == "[DONE]":
+                    break
+                if ttft is None:
+                    try:
+                        chunk = json.loads(payload)
+                        delta = chunk.get("choices", [{}])[0].get("delta", {})
+                        if delta.get("content") or chunk["choices"][0].get("text"):
+                            ttft = (time.perf_counter() - start) * 1000.0
+                    except (json.JSONDecodeError, KeyError, IndexError):
+                        pass
+        return {"ok": True, "ttft": ttft, "total": (time.perf_counter() - start) * 1000.0}
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+def pct(values, p):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[min(len(ordered) - 1, int(round(p * (len(ordered) - 1))))]
+
+
+def run_phase(name, base_url, args):
+    # Warmup (not measured): prime connections and the gateway's residency index.
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        list(pool.map(
+            lambda i: one_request(base_url, args.model, i, args.max_tokens),
+            range(args.warmup),
+        ))
+
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        results = list(pool.map(
+            lambda i: one_request(base_url, args.model, i, args.max_tokens),
+            range(args.requests),
+        ))
+    wall = time.perf_counter() - start
+
+    ok = [r for r in results if r.get("ok")]
+    totals = [r["total"] for r in ok]
+    ttfts = [r["ttft"] for r in ok if r.get("ttft") is not None]
+    summary = {
+        "name": name,
+        "ok": len(ok),
+        "failed": len(results) - len(ok),
+        "throughput_rps": len(ok) / wall if wall > 0 else 0.0,
+        "total": {q: pct(totals, p) for q, p in (("p50", 0.5), ("p99", 0.99), ("p999", 0.999))},
+        "ttft": {q: pct(ttfts, p) for q, p in (("p50", 0.5), ("p99", 0.99), ("p999", 0.999))},
+        "total_mean": sum(totals) / len(totals) if totals else 0.0,
+        "ttft_mean": sum(ttfts) / len(ttfts) if ttfts else 0.0,
+    }
+    if ok and ok[0].get("error"):
+        summary["first_error"] = ok[0]["error"]
+    if summary["failed"]:
+        summary["first_error"] = next((r.get("error") for r in results if not r.get("ok")), None)
+    return summary
+
+
+def fmt(s):
+    return (
+        f"  {s['name']:8s}  ok {s['ok']:5d}  fail {s['failed']:4d}  "
+        f"{s['throughput_rps']:8.1f} req/s | "
+        f"total ms p50 {s['total']['p50']:7.2f}  p99 {s['total']['p99']:8.2f}  "
+        f"p999 {s['total']['p999']:8.2f}  mean {s['total_mean']:7.2f} | "
+        f"TTFT ms p50 {s['ttft']['p50']:7.2f}  p99 {s['ttft']['p99']:8.2f}"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--direct-url", default="http://127.0.0.1:9000")
+    ap.add_argument("--gateway-url", default="http://127.0.0.1:8080")
+    ap.add_argument("--model", default="mock")
+    ap.add_argument("--requests", type=int, default=2000)
+    ap.add_argument("--concurrency", type=int, default=32)
+    ap.add_argument("--max-tokens", type=int, default=8)
+    ap.add_argument("--warmup", type=int, default=50)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    direct = run_phase("direct", args.direct_url, args)
+    gateway = run_phase("gateway", args.gateway_url, args)
+
+    overhead = {
+        q: gateway["total"][q] - direct["total"][q] for q in ("p50", "p99", "p999")
+    }
+    overhead_mean = gateway["total_mean"] - direct["total_mean"]
+
+    if args.json:
+        print(json.dumps(
+            {"direct": direct, "gateway": gateway,
+             "added_overhead_ms": {**overhead, "mean": overhead_mean}},
+            indent=2,
+        ))
+        return
+
+    print(f"\nQuillCache gateway overhead  (reqs={args.requests} concurrency={args.concurrency} "
+          f"max_tokens={args.max_tokens}, same mock engine both paths)")
+    print(fmt(direct))
+    print(fmt(gateway))
+    print(f"\n  => QuillCache added latency:  p50 {overhead['p50']:+.2f} ms   "
+          f"p99 {overhead['p99']:+.2f} ms   p999 {overhead['p999']:+.2f} ms   mean {overhead_mean:+.2f} ms")
+    if direct["throughput_rps"] > 0:
+        ratio = 100.0 * gateway["throughput_rps"] / direct["throughput_rps"]
+        print(f"     gateway sustains {ratio:.1f}% of direct throughput "
+              f"({gateway['throughput_rps']:.0f} vs {direct['throughput_rps']:.0f} req/s)")
+    for s in (direct, gateway):
+        if s.get("first_error"):
+            print(f"     {s['name']} first error: {s['first_error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/run_trace.py
+++ b/bench/run_trace.py
@@ -78,6 +78,26 @@ def pct(values, p):
     return ordered[min(len(ordered) - 1, int(len(ordered) * p))]
 
 
+def warm(urls, model, per_engine, max_tokens):
+    """Pre-warm each engine *directly* (bypassing the gateway) so the measured
+    run sees steady-state TTFT, not container boot / first-request CUDA-graph
+    capture. On Modal (scale-to-zero) the first request to a cold engine can take
+    30-120s — that is a deployment artifact, not a routing property, so we absorb
+    it here. Warming the shared prefix on every engine also makes the affinity-vs-
+    round-robin comparison purely about routing, both with warm prefix caches."""
+    for url in urls:
+        ok = False
+        for attempt in range(3):
+            r = one_request(url, model, attempt, max_tokens)
+            if r.get("ok"):
+                ok = True
+                break
+            time.sleep(2)
+        print(f"  warm {url}: {'ready' if ok else 'FAILED (cold?)'}")
+        for i in range(max(0, per_engine - 1)):
+            one_request(url, model, i, max_tokens)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base-url", default="http://127.0.0.1:8080")
@@ -85,7 +105,20 @@ def main():
     ap.add_argument("--requests", type=int, default=64)
     ap.add_argument("--concurrency", type=int, default=8)
     ap.add_argument("--max-tokens", type=int, default=32)
+    ap.add_argument(
+        "--warmup-urls",
+        default="",
+        help="comma-separated engine base URLs to warm DIRECTLY before measuring "
+        "(kills the cold-start confound); e.g. https://a.modal.run,https://b.modal.run",
+    )
+    ap.add_argument("--warmup", type=int, default=4, help="warmup requests per engine")
     args = ap.parse_args()
+
+    warm_urls = [u.strip() for u in args.warmup_urls.split(",") if u.strip()]
+    if warm_urls:
+        print(f"warming {len(warm_urls)} engine(s) directly ({args.warmup} reqs each)...")
+        warm(warm_urls, args.model, args.warmup, args.max_tokens)
+        print("warm complete — measuring steady-state through the gateway\n")
 
     results = []
     with ThreadPoolExecutor(max_workers=args.concurrency) as pool:

--- a/crates/quillcache-control/src/lib.rs
+++ b/crates/quillcache-control/src/lib.rs
@@ -6,7 +6,6 @@ use quillcache_core::{
 };
 use quillcache_router::{GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -274,7 +273,16 @@ impl ControlPlane {
     }
 
     pub fn plan(&self, request: &RequestShape) -> Result<RequestPlan, ControlError> {
-        let residency = self.residency.snapshot();
+        // The router only ever inspects residency for *this request's* blocks
+        // (local hit / transfer / recompute per block), so look those up
+        // directly instead of dumping the whole index. O(request blocks) point
+        // lookups — O(1) on the flat map, O(log n)/O(matches) on ART/LSM — keep
+        // the online routing decision off the index's O(N) snapshot path.
+        let residency: Vec<CacheResidency> = request
+            .blocks
+            .iter()
+            .flat_map(|block| self.residency.locate(block))
+            .collect();
         let decode_workers = self
             .workers
             .iter()
@@ -419,30 +427,22 @@ impl ControlPlane {
     /// the online path can report the unsafe reuse it prevented (the same
     /// property the `safe-reuse` experiment measures offline).
     pub fn audit_reuse(&self, request: &RequestShape) -> ReuseAudit {
-        let snapshot = self.residency.snapshot();
-        let mut by_content: HashMap<&str, Vec<&KvBlockKey>> = HashMap::new();
-        for residency in &snapshot {
-            by_content
-                .entry(residency.key.block_hash.as_str())
-                .or_default()
-                .push(&residency.key);
-        }
-
         let mut audit = ReuseAudit::default();
         for block in &request.blocks {
-            let Some(resident_keys) = by_content.get(block.block_hash.as_str()) else {
+            // Only the blocks sharing *this* block's content hash can be a
+            // (possibly cross-identity) reuse candidate — seek them directly
+            // rather than scanning a full snapshot per request.
+            let resident = self.residency.residency_by_content_hash(&block.block_hash);
+            if resident.is_empty() {
                 continue;
-            };
+            }
             let scope = IdentityScope::from_key(block);
-            if resident_keys.iter().any(|key| scope.matches(key)) {
+            if resident.iter().any(|r| scope.matches(&r.key)) {
                 audit.safe_reusable += 1;
                 continue;
             }
             // Content is resident, but only under other identities: refused.
-            if let Some(violation) = resident_keys
-                .iter()
-                .find_map(|key| scope.reuse_violation(key))
-            {
+            if let Some(violation) = resident.iter().find_map(|r| scope.reuse_violation(&r.key)) {
                 audit.refused_unsafe += 1;
                 match violation {
                     ReuseViolation::Tenant => audit.refused_cross_tenant += 1,
@@ -453,6 +453,26 @@ impl ControlPlane {
             }
         }
         audit
+    }
+
+    /// Mark a request as in flight on an engine, bumping that worker's live
+    /// decode load. The online router reads static `WorkerState` load, so without
+    /// this the cost function's load term is inert and a cache-aware policy
+    /// over-pins every request to the one cache-hot engine. Feeding the gateway's
+    /// own in-flight count back into the worker state makes load-aware routing
+    /// real on the live path — the gateway-side analogue of the engine metrics
+    /// Dynamo/llm-d route on. Call [`Self::end_request`] when the request drains.
+    pub fn begin_request(&mut self, engine_id: &str) {
+        if let Some(worker) = self.workers.iter_mut().find(|w| w.id == engine_id) {
+            worker.running_decodes = worker.running_decodes.saturating_add(1);
+        }
+    }
+
+    /// Release a request's in-flight load on an engine (see [`Self::begin_request`]).
+    pub fn end_request(&mut self, engine_id: &str) {
+        if let Some(worker) = self.workers.iter_mut().find(|w| w.id == engine_id) {
+            worker.running_decodes = worker.running_decodes.saturating_sub(1);
+        }
     }
 
     pub fn engine(&self, id: &str) -> Option<&EngineEndpoint> {
@@ -604,6 +624,7 @@ impl ControlPlane {
 mod tests {
     use super::*;
     use quillcache_core::{EngineKind, SloTarget};
+    use std::collections::HashMap;
 
     fn engine() -> EngineEndpoint {
         EngineEndpoint {

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -602,6 +602,21 @@ pub trait IndexBackend: std::fmt::Debug + Send + Sync {
     /// slice of residency.
     fn snapshot(&self) -> Vec<CacheResidency>;
 
+    /// Every residency whose block carries this content `block_hash`, across
+    /// *all* identity scopes. The inline reuse guard uses it to find
+    /// content-matching blocks that may belong to a **different** identity
+    /// (the safety check). The default scans a snapshot — correct but O(N); the
+    /// in-memory backend overrides it with a content-hash reverse index so the
+    /// online guard is an O(matches) seek rather than a full index dump per
+    /// request. Persistent backends can override similarly via their secondary
+    /// namespace.
+    fn residency_by_content_hash(&self, block_hash: &str) -> Vec<CacheResidency> {
+        self.snapshot()
+            .into_iter()
+            .filter(|residency| residency.key.block_hash == block_hash)
+            .collect()
+    }
+
     /// Number of residency records currently held.
     fn len(&self) -> usize;
 
@@ -643,6 +658,11 @@ pub struct MemoryIndex {
     /// index turns eviction into an O(matches) lookup. This mirrors the
     /// secondary-namespace reverse index the persistent backends keep on disk.
     by_hash: HashMap<(IdentityScope, String), HashSet<KvBlockKey>>,
+    /// Content-hash reverse index: `block_hash -> the set of full keys carrying
+    /// that content hash, across *all* identities`. The inline reuse guard
+    /// (`residency_by_content_hash`) needs cross-identity content matches; this
+    /// makes that an O(matches) seek instead of a full snapshot scan per request.
+    by_content_hash: HashMap<String, HashSet<KvBlockKey>>,
     puts: u64,
     removes: u64,
 }
@@ -650,6 +670,16 @@ pub struct MemoryIndex {
 impl MemoryIndex {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Drop a fully-evicted key from the content-hash reverse index.
+    fn forget_content_hash(&mut self, key: &KvBlockKey) {
+        if let Some(set) = self.by_content_hash.get_mut(&key.block_hash) {
+            set.remove(key);
+            if set.is_empty() {
+                self.by_content_hash.remove(&key.block_hash);
+            }
+        }
     }
 }
 
@@ -667,6 +697,10 @@ impl IndexBackend for MemoryIndex {
         entries.push(residency);
         self.by_hash
             .entry((IdentityScope::from_key(&key), key.block_hash.clone()))
+            .or_default()
+            .insert(key.clone());
+        self.by_content_hash
+            .entry(key.block_hash.clone())
             .or_default()
             .insert(key);
         self.puts += 1;
@@ -713,6 +747,9 @@ impl IndexBackend for MemoryIndex {
                     self.by_hash.remove(&map_key);
                 }
             }
+            for key in &emptied {
+                self.forget_content_hash(key);
+            }
         }
         self.removes += removed as u64;
         removed
@@ -737,17 +774,31 @@ impl IndexBackend for MemoryIndex {
                     self.by_hash.remove(&map_key);
                 }
             }
+            self.forget_content_hash(&key);
         }
     }
 
     fn clear(&mut self) {
         self.entries.clear();
         self.by_hash.clear();
+        self.by_content_hash.clear();
     }
 
     fn snapshot(&self) -> Vec<CacheResidency> {
         self.entries
             .values()
+            .flat_map(|entries| entries.iter().cloned())
+            .collect()
+    }
+
+    fn residency_by_content_hash(&self, block_hash: &str) -> Vec<CacheResidency> {
+        // O(matches): seek the keys carrying this content hash, then their
+        // residency — no full-index scan on the online reuse-guard path.
+        let Some(keys) = self.by_content_hash.get(block_hash) else {
+            return Vec::new();
+        };
+        keys.iter()
+            .filter_map(|key| self.entries.get(key))
             .flat_map(|entries| entries.iter().cloned())
             .collect()
     }
@@ -1638,5 +1689,35 @@ mod tests {
         idx.clear_worker("w0");
         assert!(idx.prefix_scan(&mem_scope(), "root").is_empty());
         assert_eq!(idx.remove_block(&mem_scope(), "w0", "b0"), 0);
+    }
+
+    #[test]
+    fn residency_by_content_hash_finds_cross_identity_and_stays_consistent() {
+        let mut idx = MemoryIndex::new();
+        // Same content hash "b0" under two different keys (different prefix
+        // position) plus a copy on a second worker -> three residency records,
+        // all of which the content-hash seek must surface (this is what the
+        // online reuse guard relies on to spot cross-identity matches).
+        idx.put(CacheResidency::hbm("w0", mem_block("root", "b0", 0), 1024));
+        idx.put(CacheResidency::hbm("w1", mem_block("root", "b0", 0), 1024));
+        idx.put(CacheResidency::hbm("w0", mem_block("other", "b0", 5), 1024));
+        idx.put(CacheResidency::hbm("w0", mem_block("root", "b1", 1), 1024));
+
+        assert_eq!(idx.residency_by_content_hash("b0").len(), 3);
+        assert_eq!(idx.residency_by_content_hash("b1").len(), 1);
+        assert!(idx.residency_by_content_hash("absent").is_empty());
+
+        // Removing one worker's copy of one key leaves the others findable.
+        assert_eq!(idx.remove_block(&mem_scope(), "w0", "b0"), 2); // both "b0" keys on w0
+        assert_eq!(idx.residency_by_content_hash("b0").len(), 1); // w1's copy remains
+        idx.clear_worker("w1");
+        assert!(idx.residency_by_content_hash("b0").is_empty()); // bucket pruned
+                                                                 // The override agrees with the default snapshot-scan implementation.
+        let by_scan: Vec<_> = idx
+            .snapshot()
+            .into_iter()
+            .filter(|r| r.key.block_hash == "b1")
+            .collect();
+        assert_eq!(idx.residency_by_content_hash("b1").len(), by_scan.len());
     }
 }

--- a/crates/quillcache-gateway/src/lib.rs
+++ b/crates/quillcache-gateway/src/lib.rs
@@ -12,8 +12,8 @@ use quillcache_core::{
     TieredDataPlane, TieredDataPlaneConfig,
 };
 use quillcache_router::{
-    GreedyStatePlaneRouter, LeastLoadedRouter, PrefixAffinityRouter, RoundRobinRouter,
-    RoutingPolicy, SessionAffinityRouter, SloAwareRouter,
+    DynamoCostRouter, GreedyStatePlaneRouter, LeastLoadedRouter, PrefixAffinityRouter,
+    RoundRobinRouter, RoutingPolicy, SessionAffinityRouter, SloAwareRouter,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,8 @@ pub struct GatewayConfig {
     pub engines: Vec<EngineEndpoint>,
     /// Routing policy: "prefix-affinity" (cache-affine across the fleet),
     /// "round-robin" (spread baseline), "least-loaded", "slo-aware" (SLO as a
-    /// near-hard constraint), "session-affinity", or "greedy" (default).
+    /// near-hard constraint), "session-affinity", "dynamo-cost" (mirrors NVIDIA
+    /// Dynamo's KV-router cost function), or "greedy" (default).
     #[serde(default)]
     pub policy: Option<String>,
     /// Residency index backend: "memory" (default, ephemeral), "holt"
@@ -529,6 +530,7 @@ fn build_policy(name: Option<&str>) -> Box<dyn RoutingPolicy> {
         "least-loaded" | "load" => Box::new(LeastLoadedRouter::default()),
         "slo-aware" | "slo" => Box::new(SloAwareRouter::default()),
         "session-affinity" | "session" => Box::new(SessionAffinityRouter::default()),
+        "dynamo-cost" | "dynamo" | "kv-router" => Box::new(DynamoCostRouter::default()),
         _ => Box::new(GreedyStatePlaneRouter::default()),
     }
 }
@@ -684,7 +686,14 @@ async fn proxy_openai_path(
         trace.reusable_blocks.to_string(),
     );
 
-    let upstream = request.send().await?;
+    // Count this request as in flight on the chosen engine for the prefill
+    // window (dispatch → response headers), so concurrent requests see the load
+    // and a cache-aware policy spreads instead of dog-piling the one cache-hot
+    // engine. This is the gateway's own load signal feeding back into routing.
+    state.control.write().await.begin_request(&trace.engine_id);
+    let send_result = request.send().await;
+    state.control.write().await.end_request(&trace.engine_id);
+    let upstream = send_result?;
     let status = StatusCode::from_u16(upstream.status().as_u16())
         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 

--- a/crates/quillcache-router/src/lib.rs
+++ b/crates/quillcache-router/src/lib.rs
@@ -517,6 +517,215 @@ impl RoutingPolicy for SessionAffinityRouter {
     }
 }
 
+/// Knobs for [`DynamoCostRouter`], named and defaulted to match NVIDIA Dynamo's
+/// `KvRouterConfig` (`lib/kv-router/src/scheduling/config.rs`) so the cost
+/// function is the same one Dynamo's KV router runs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DynamoCostConfig {
+    /// Credit multiplier for prefix blocks already on the worker's **GPU/HBM**.
+    /// Dynamo `overlap_score_credit`, default 1.0. 0.0 ignores caches entirely.
+    pub overlap_score_credit: f64,
+    /// Weight on the overlap-adjusted prefill load relative to decode blocks.
+    /// Dynamo `prefill_load_scale`, default 1.0.
+    pub prefill_load_scale: f64,
+    /// Credit multiplier for prefix blocks in the worker's **CPU/host** tier.
+    /// Dynamo `host_cache_hit_weight`, default 0.75.
+    pub host_cache_hit_weight: f64,
+    /// Credit multiplier for prefix blocks in the worker's **disk/SSD** tier.
+    /// Dynamo `disk_cache_hit_weight`, default 0.25.
+    pub disk_cache_hit_weight: f64,
+    /// 0.0 = deterministic argmin over cost. >0 = softmax-sample the cost logits
+    /// to spread load (Dynamo `router_temperature`, default 0.0).
+    pub temperature: f64,
+    /// Tokens per KV block, to convert a worker's queued prefill tokens into
+    /// block units for `raw_prefill_blocks`.
+    pub block_tokens: u32,
+}
+
+impl Default for DynamoCostConfig {
+    fn default() -> Self {
+        Self {
+            overlap_score_credit: 1.0,
+            prefill_load_scale: 1.0,
+            host_cache_hit_weight: 0.75,
+            disk_cache_hit_weight: 0.25,
+            temperature: 0.0,
+            block_tokens: 64,
+        }
+    }
+}
+
+/// KV-aware router that mirrors **NVIDIA Dynamo's** KV-router cost function. For
+/// each worker it computes
+///
+/// ```text
+/// overlap_credit       = overlap_score_credit · device_overlap_blocks
+///                      + host_cache_hit_weight · host_overlap_blocks
+///                      + disk_cache_hit_weight · disk_overlap_blocks
+/// adjusted_prefill     = max(0, raw_prefill_blocks − overlap_credit)
+/// cost                 = prefill_load_scale · adjusted_prefill + decode_blocks
+/// ```
+///
+/// and routes to the worker with the **lowest cost** (`temperature == 0`), or
+/// softmax-samples the costs when `temperature > 0` — exactly Dynamo's
+/// `worker_logit` / `select_worker` (`lib/kv-router/src/scheduling/selector.rs`).
+/// `raw_prefill_blocks` is the request's prompt blocks plus the worker's queued
+/// prefill load (so a busy worker looks more expensive); `device/host/disk
+/// overlap` are the request's blocks already resident on that worker in HBM /
+/// CPU-DRAM / SSD; `decode_blocks` is the worker's active decode load.
+///
+/// Where QuillCache's [`GreedyStatePlaneRouter`] blends latency estimates into an
+/// additive score, this reproduces Dynamo's block-count cost so the fleet can be
+/// compared against the production reference design apples-to-apples. After
+/// selecting the worker it reuses [`plan_for_worker`] for the per-block
+/// hit/transfer/recompute accounting, so its `RouteDecision` is directly
+/// comparable to every other policy.
+#[derive(Debug, Clone, Default)]
+pub struct DynamoCostRouter {
+    cost_model: CostModel,
+    config: DynamoCostConfig,
+}
+
+impl DynamoCostRouter {
+    pub fn new(cost_model: CostModel) -> Self {
+        Self {
+            cost_model,
+            config: DynamoCostConfig::default(),
+        }
+    }
+
+    pub fn with_config(cost_model: CostModel, config: DynamoCostConfig) -> Self {
+        Self { cost_model, config }
+    }
+
+    /// Dynamo's per-worker cost ("logit"). Lower is better.
+    fn worker_cost(
+        &self,
+        request: &RequestShape,
+        worker: &WorkerState,
+        residency: &[CacheResidency],
+    ) -> f64 {
+        let block_tokens = self.config.block_tokens.max(1);
+        // raw_prefill_blocks = this request's prompt blocks + the worker's
+        // already-queued prefill load (in block units).
+        let queued_blocks = f64::from(worker.queued_prefill_tokens) / f64::from(block_tokens);
+        let raw_prefill_blocks = request.blocks.len() as f64 + queued_blocks;
+
+        // Per-tier overlap: the request's blocks already resident on THIS worker.
+        let (mut device, mut host, mut disk) = (0.0_f64, 0.0_f64, 0.0_f64);
+        for block in &request.blocks {
+            let on_worker = residency
+                .iter()
+                .find(|r| r.worker_id == worker.id && r.key == *block);
+            match on_worker.map(|r| r.tier) {
+                Some(CacheTier::Hbm) => device += 1.0,
+                Some(CacheTier::RemoteHbm) | Some(CacheTier::CpuDram) => host += 1.0,
+                Some(CacheTier::LocalSsd) | Some(CacheTier::ObjectStore) => disk += 1.0,
+                None => {}
+            }
+        }
+
+        let overlap_credit = self.config.overlap_score_credit * device
+            + self.config.host_cache_hit_weight * host
+            + self.config.disk_cache_hit_weight * disk;
+        let adjusted_prefill = (raw_prefill_blocks - overlap_credit).max(0.0);
+        let decode_blocks = f64::from(worker.running_decodes);
+        self.config.prefill_load_scale * adjusted_prefill + decode_blocks
+    }
+
+    pub fn route(
+        &self,
+        request: &RequestShape,
+        workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, RouterError> {
+        if workers.is_empty() {
+            return Err(RouterError::NoWorkers);
+        }
+        let costs: Vec<f64> = workers
+            .iter()
+            .map(|w| self.worker_cost(request, w, residency))
+            .collect();
+
+        let idx = if self.config.temperature > 0.0 {
+            softmax_sample(&costs, self.config.temperature, &request.id)
+        } else {
+            // Deterministic argmin; ties broken by lowest worker index.
+            costs
+                .iter()
+                .enumerate()
+                .min_by(|(_, a), (_, b)| a.total_cmp(b))
+                .map(|(i, _)| i)
+                .unwrap_or(0)
+        };
+
+        let worker_by_id: HashMap<&str, &WorkerState> = workers
+            .iter()
+            .map(|worker| (worker.id.as_str(), worker))
+            .collect();
+        Ok(plan_for_worker(
+            &self.cost_model,
+            request,
+            &workers[idx],
+            &worker_by_id,
+            residency,
+        ))
+    }
+}
+
+impl RoutingPolicy for DynamoCostRouter {
+    fn name(&self) -> &str {
+        "dynamo-cost"
+    }
+
+    fn route(
+        &self,
+        request: &RequestShape,
+        workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, RouterError> {
+        DynamoCostRouter::route(self, request, workers, residency)
+    }
+}
+
+/// Softmax-sample an index over cost logits, mirroring Dynamo's `softmax_sample`:
+/// negate+rescale the costs to `[-1/temperature, 0]` (lower cost → higher
+/// probability) using the candidate set's own min/max range, then inverse-CDF
+/// sample. Seeded deterministically from the request id so a given request always
+/// routes the same way and tests are reproducible (Dynamo uses a thread RNG).
+fn softmax_sample(costs: &[f64], temperature: f64, seed_key: &str) -> usize {
+    let n = costs.len();
+    if n <= 1 {
+        return 0;
+    }
+    let min = costs.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = costs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    if (max - min).abs() < f64::EPSILON {
+        return 0; // all equal — first wins
+    }
+    let scale = -1.0 / ((max - min) * temperature);
+    let max_scaled = min * scale;
+    let weights: Vec<f64> = costs
+        .iter()
+        .map(|c| (c * scale - max_scaled).exp())
+        .collect();
+    let total: f64 = weights.iter().sum();
+
+    // Deterministic uniform in [0,1) from a hash of the request id.
+    let mut hasher = DefaultHasher::new();
+    seed_key.hash(&mut hasher);
+    let u = (hasher.finish() >> 11) as f64 / (1u64 << 53) as f64;
+
+    let mut acc = 0.0;
+    for (i, w) in weights.iter().enumerate() {
+        acc += w / total;
+        if u < acc {
+            return i;
+        }
+    }
+    n - 1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -702,5 +911,178 @@ mod tests {
         let decision = router.route(&turn1, &workers, &residency).unwrap();
         assert_eq!(decision.worker_id, other);
         assert_eq!(decision.local_hits.len(), 1);
+    }
+
+    /// A request whose prompt is `n` distinct blocks under the default identity.
+    fn request_with_n_blocks(n: u32) -> RequestShape {
+        let blocks = (0..n)
+            .map(|i| {
+                KvBlockKey::new(
+                    "llama",
+                    "tok",
+                    "tenant-a",
+                    format!("p{i}"),
+                    format!("b{i}"),
+                    i,
+                    64,
+                )
+            })
+            .collect();
+        RequestShape {
+            id: "req-dyn".to_string(),
+            model_id: "llama".to_string(),
+            tokenizer_id: "tok".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            session_id: None,
+            blocks,
+            estimated_decode_tokens: 32,
+            slo: SloTarget::default(),
+        }
+    }
+
+    #[test]
+    fn dynamo_cost_reproduces_official_worked_example() {
+        // From Dynamo's router-concepts doc (overlap_score_credit = 1.0):
+        //   w1: raw 10, device overlap 2, decode 10 -> cost 8 + 10 = 18
+        //   w2: raw 10, device overlap 5, decode  5 -> cost 5 +  5 = 10  (chosen)
+        //   w3: raw 10, device overlap 8, decode  9 -> cost 2 +  9 = 11
+        let request = request_with_n_blocks(10);
+        let workers = vec![
+            WorkerState::new("w1", "rack-a").with_load(0, 10),
+            WorkerState::new("w2", "rack-a").with_load(0, 5),
+            WorkerState::new("w3", "rack-a").with_load(0, 9),
+        ];
+        let mut residency = Vec::new();
+        let put =
+            |res: &mut Vec<CacheResidency>, worker: &str, count: usize, req: &RequestShape| {
+                for block in req.blocks.iter().take(count) {
+                    res.push(CacheResidency::hbm(worker, block.clone(), 4 * 1024 * 1024));
+                }
+            };
+        put(&mut residency, "w1", 2, &request);
+        put(&mut residency, "w2", 5, &request);
+        put(&mut residency, "w3", 8, &request);
+
+        let router = DynamoCostRouter::default();
+        assert_eq!(router.worker_cost(&request, &workers[0], &residency), 18.0);
+        assert_eq!(router.worker_cost(&request, &workers[1], &residency), 10.0);
+        assert_eq!(router.worker_cost(&request, &workers[2], &residency), 11.0);
+
+        let decision = router.route(&request, &workers, &residency).unwrap();
+        assert_eq!(decision.worker_id, "w2");
+        // The chosen worker's accounting reflects its 5 local HBM hits.
+        assert_eq!(decision.local_hits.len(), 5);
+    }
+
+    #[test]
+    fn dynamo_cost_credits_lower_tiers_less_than_hbm() {
+        // Same overlap count, but on HBM vs SSD: HBM (credit 1.0) must beat SSD
+        // (credit 0.25), so the device-resident worker wins.
+        let request = request_with_n_blocks(4);
+        let workers = vec![
+            WorkerState::new("hbm-worker", "rack-a"),
+            WorkerState::new("ssd-worker", "rack-a"),
+        ];
+        let mut residency = Vec::new();
+        for block in &request.blocks {
+            residency.push(CacheResidency::hbm(
+                "hbm-worker",
+                block.clone(),
+                4 * 1024 * 1024,
+            ));
+            residency.push(CacheResidency {
+                key: block.clone(),
+                worker_id: "ssd-worker".to_string(),
+                tier: CacheTier::LocalSsd,
+                bytes: 4 * 1024 * 1024,
+                last_access_ms: 0,
+                ref_count: 0,
+                pinned: false,
+            });
+        }
+        let router = DynamoCostRouter::default();
+        // HBM: 4 - 1.0*4 = 0 ; SSD: 4 - 0.25*4 = 3.
+        assert_eq!(router.worker_cost(&request, &workers[0], &residency), 0.0);
+        assert_eq!(router.worker_cost(&request, &workers[1], &residency), 3.0);
+        assert_eq!(
+            router
+                .route(&request, &workers, &residency)
+                .unwrap()
+                .worker_id,
+            "hbm-worker"
+        );
+    }
+
+    #[test]
+    fn dynamo_cost_spills_off_cache_hot_engine_under_load() {
+        // Engine "a" holds the request's whole 4-block prefix (overlap credit 4);
+        // engine "b" is cold. Cost(a) = (4 − 4) + load_a, Cost(b) = 4 + 0, so a
+        // wins while load_a < 4 and loses once load_a > 4 — the cache-vs-load
+        // crossover the live in-flight feedback drives on the gateway.
+        let request = request_with_n_blocks(4);
+        let residency: Vec<CacheResidency> = request
+            .blocks
+            .iter()
+            .map(|b| CacheResidency::hbm("a", b.clone(), 4 * 1024 * 1024))
+            .collect();
+        let router = DynamoCostRouter::default();
+
+        // Light load on the cache-hot engine: reuse wins, stay on "a".
+        let light = vec![
+            WorkerState::new("a", "r").with_load(0, 2),
+            WorkerState::new("b", "r").with_load(0, 0),
+        ];
+        assert_eq!(
+            router
+                .route(&request, &light, &residency)
+                .unwrap()
+                .worker_id,
+            "a"
+        );
+
+        // Heavy load on the cache-hot engine: load outweighs the cache credit,
+        // so the router spills to the cold-but-idle engine "b".
+        let heavy = vec![
+            WorkerState::new("a", "r").with_load(0, 6),
+            WorkerState::new("b", "r").with_load(0, 0),
+        ];
+        assert_eq!(
+            router
+                .route(&request, &heavy, &residency)
+                .unwrap()
+                .worker_id,
+            "b"
+        );
+    }
+
+    #[test]
+    fn dynamo_cost_zero_credit_ignores_cache() {
+        // overlap_score_credit = 0 -> pure load balancing (cost = decode_blocks),
+        // so the cache-rich-but-busy worker loses to the idle one.
+        let request = request_with_n_blocks(4);
+        let workers = vec![
+            WorkerState::new("warm-busy", "rack-a").with_load(0, 8),
+            WorkerState::new("cold-idle", "rack-a").with_load(0, 0),
+        ];
+        let residency: Vec<CacheResidency> = request
+            .blocks
+            .iter()
+            .map(|b| CacheResidency::hbm("warm-busy", b.clone(), 4 * 1024 * 1024))
+            .collect();
+        let router = DynamoCostRouter::with_config(
+            CostModel::default(),
+            DynamoCostConfig {
+                overlap_score_credit: 0.0,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            router
+                .route(&request, &workers, &residency)
+                .unwrap()
+                .worker_id,
+            "cold-idle"
+        );
     }
 }

--- a/examples/quillcache-local-mock.yaml
+++ b/examples/quillcache-local-mock.yaml
@@ -1,0 +1,14 @@
+# Local gateway for the self-overhead benchmark (bench/bench_gateway.py).
+# Points at tools/mock_engine.py (a near-instant OpenAI-compatible engine) so the
+# only latency the client sees through this gateway is QuillCache's own hot-path
+# cost. Uses the Dynamo-style KV-router cost function.
+bind: 127.0.0.1:8080
+policy: dynamo-cost
+engines:
+  - id: mock-a
+    kind: Mock
+    base_url: http://127.0.0.1:9000
+    model_id: mock
+    tokenizer_id: mock
+    tenant_id: default
+    locality_domain: local

--- a/examples/quillcache-modal.yaml
+++ b/examples/quillcache-modal.yaml
@@ -1,0 +1,21 @@
+# QuillCache gateway in front of a 2-vLLM fleet on Modal L4, using the
+# Dynamo-style KV-router cost function. Swap `policy:` to round-robin for the
+# cache-blind baseline. Warm both engines first (bench/run_trace.py --warmup-urls)
+# so the measured TTFT is steady-state, not Modal scale-to-zero cold start.
+bind: 127.0.0.1:8080
+policy: dynamo-cost
+engines:
+  - id: modal-vllm-a
+    kind: Vllm
+    base_url: https://feichai0017--quillcache-vllm-serve.modal.run
+    model_id: Qwen/Qwen2.5-0.5B-Instruct
+    tokenizer_id: Qwen/Qwen2.5-0.5B-Instruct
+    tenant_id: default
+    locality_domain: modal
+  - id: modal-vllm-b
+    kind: Vllm
+    base_url: https://feichai0017--quillcache-vllm-b-serve.modal.run
+    model_id: Qwen/Qwen2.5-0.5B-Instruct
+    tokenizer_id: Qwen/Qwen2.5-0.5B-Instruct
+    tenant_id: default
+    locality_domain: modal

--- a/tools/mock_engine.py
+++ b/tools/mock_engine.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""A minimal OpenAI-compatible mock inference engine — stdlib only, no GPU.
+
+It speaks just enough of the vLLM/OpenAI surface for QuillCache to proxy it:
+streaming `/v1/chat/completions` and `/v1/completions`, plus `/healthz`. Token
+output is synthetic; timing is configurable so you can isolate one variable:
+
+  --ttft-ms N   delay before the first streamed token (default 0 = instant)
+  --itl-ms  N   inter-token latency between subsequent tokens (default 0)
+  --tokens  N   tokens to emit when the request doesn't cap max_tokens
+
+With the defaults (0/0) the engine is effectively instant, so any latency a
+client observes *through the QuillCache gateway* is the control plane's own
+overhead — which is exactly what bench/bench_gateway.py measures. Threaded so it
+serves concurrent load.
+
+    python tools/mock_engine.py --port 9000                 # instant engine
+    python tools/mock_engine.py --port 9000 --ttft-ms 200   # mimic a real TTFT
+"""
+import argparse
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ARGS = None
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_):  # silence per-request logging
+        pass
+
+    def do_GET(self):
+        if self.path.rstrip("/") in ("/healthz", "/health", "/v1/models"):
+            self._json(200, {"status": "ok"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            self._json(400, {"error": "bad json"})
+            return
+
+        is_chat = self.path.rstrip("/").endswith("/chat/completions")
+        if not (is_chat or self.path.rstrip("/").endswith("/completions")):
+            self._json(404, {"error": "not found"})
+            return
+
+        max_tokens = body.get("max_tokens") or ARGS.tokens
+        n_tokens = max(1, min(int(max_tokens), 256))
+        model = body.get("model", "mock-engine")
+        if body.get("stream"):
+            self._stream(is_chat, model, n_tokens)
+        else:
+            self._whole(is_chat, model, n_tokens)
+
+    def _stream(self, is_chat, model, n_tokens):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        if ARGS.ttft_ms:
+            time.sleep(ARGS.ttft_ms / 1000.0)
+        for i in range(n_tokens):
+            if i and ARGS.itl_ms:
+                time.sleep(ARGS.itl_ms / 1000.0)
+            delta = {"content": f"tok{i} "}
+            choice = (
+                {"index": 0, "delta": delta, "finish_reason": None}
+                if is_chat
+                else {"index": 0, "text": f"tok{i} ", "finish_reason": None}
+            )
+            chunk = {
+                "id": "mock-1",
+                "object": "chat.completion.chunk" if is_chat else "text_completion",
+                "model": model,
+                "choices": [choice],
+            }
+            self._sse(chunk)
+        self._sse_raw("[DONE]")
+
+    def _whole(self, is_chat, model, n_tokens):
+        if ARGS.ttft_ms or ARGS.itl_ms:
+            time.sleep((ARGS.ttft_ms + ARGS.itl_ms * (n_tokens - 1)) / 1000.0)
+        text = " ".join(f"tok{i}" for i in range(n_tokens))
+        choice = (
+            {"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}
+            if is_chat
+            else {"index": 0, "text": text, "finish_reason": "stop"}
+        )
+        self._json(
+            200,
+            {
+                "id": "mock-1",
+                "object": "chat.completion" if is_chat else "text_completion",
+                "model": model,
+                "choices": [choice],
+                "usage": {"prompt_tokens": 0, "completion_tokens": n_tokens, "total_tokens": n_tokens},
+            },
+        )
+
+    def _sse(self, obj):
+        self._sse_raw(json.dumps(obj))
+
+    def _sse_raw(self, payload):
+        try:
+            self.wfile.write(f"data: {payload}\n\n".encode())
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def _json(self, code, obj):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        try:
+            self.wfile.write(data)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+
+def main():
+    global ARGS
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=9000)
+    ap.add_argument("--ttft-ms", type=float, default=0.0)
+    ap.add_argument("--itl-ms", type=float, default=0.0)
+    ap.add_argument("--tokens", type=int, default=16)
+    ARGS = ap.parse_args()
+    server = ThreadingHTTPServer((ARGS.host, ARGS.port), Handler)
+    print(f"mock engine on http://{ARGS.host}:{ARGS.port}  ttft={ARGS.ttft_ms}ms itl={ARGS.itl_ms}ms")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hardens the control plane against the gaps a reviewer hits first, mirroring the production reference designs (NVIDIA Dynamo, llm-d).

## What's in here

**1. `DynamoCostRouter` — Dynamo's real cost function**
Implements NVIDIA Dynamo's KV-router cost function (`prefill_load_scale · max(0, raw_prefill_blocks − overlap_credit) + decode_blocks`, with HBM/DRAM/SSD overlap credits 1.0/0.75/0.25 and a `temperature` softmax). A unit test reproduces Dynamo's published worked example (costs 18/10/11 → pick worker 2). Selectable as `policy: dynamo-cost`.

**2. Measured control-plane overhead — and a real bug it caught**
New `tools/mock_engine.py` + `bench/bench_gateway.py` measure QuillCache's own added latency (direct vs through-gateway). First run showed a flat **~14 ms p50 @ C=32**; root cause was a genuine O(N) hot-path bug — `plan()` and `audit_reuse()` each snapshotted the **entire** residency index per request (~2000 records, twice). Fixed with request-scoped lookups (`IndexBackend::locate()` + a new `residency_by_content_hash` reverse index):

| path | p50 added | throughput @ C=32 |
| --- | --- | --- |
| before | ~14 ms | — |
| after | **+0.2 ms** | **121% of direct** |

**3. Load-aware online routing**
The gateway feeds its in-flight count back into worker load (`begin_request`/`end_request`) so the cost function's `decode_blocks` term is no longer inert online — it spreads under load instead of dog-piling the cache-hot engine (the llm-d "prefix + load" lesson). Deterministic crossover test included.

**4. Modal real-engine validation + honesty**
`examples/quillcache-modal.yaml` + `run_trace.py --warmup-urls`. Verified the Dynamo router is cache-affine on 2 real vLLM. README now states honestly that serverless scale-to-zero makes Modal a **functional**, not a steady-state-latency, harness — the old "81 s → 4.3 s" was cold-start noise, no longer claimed as a routing result.

## Verification
- `cargo fmt --check` ✅
- `cargo test --workspace --exclude quillcache-index-rocksdb` → **47 passed, 0 failed** ✅
- `cargo clippy --workspace --exclude quillcache-index-rocksdb --all-targets` → **0 warnings** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DynamoCostRouter` routing policy with Dynamo-inspired cost-based worker selection and overlap credit support.
  * Control-plane now tracks per-request load via begin/end request lifecycle methods.
  * New gateway overhead benchmarking tool with configurable concurrency and quantile reporting.
  * Benchmarking warmup phase support for cleaner steady-state measurements.

* **Documentation**
  * Updated README with DynamoCostRouter details, control-plane overhead measurements, and improved guidance on reproducing latency benchmarks.
  * Added example configurations for local and Modal-based deployments.

* **Tests**
  * Extended test coverage for DynamoCostRouter and residency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->