### PR TITLE
feat: distributed KV pool wired end-to-end (master + engine connector)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillcache-master"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "bytes",
+ "quillcache-core",
+ "quillcache-store",
+ "quillcache-transfer",
+ "tokio",
+]
+
+[[package]]
 name = "quillcache-router"
 version = "1.0.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/quillcache-gateway",
     "crates/quillcache-router",
     "crates/quillcache-store",
+    "crates/quillcache-master",
     "crates/quillcache-transfer",
     "crates/quillcache-index-rocksdb",
     "crates/quillcache-index-holt",
@@ -17,6 +18,7 @@ default-members = [
     "crates/quillcache-gateway",
     "crates/quillcache-router",
     "crates/quillcache-store",
+    "crates/quillcache-master",
     "crates/quillcache-transfer",
     "crates/quillcache-index-holt",
 ]

--- a/crates/quillcache-master/Cargo.toml
+++ b/crates/quillcache-master/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "quillcache-master"
+version = "1.0.0-alpha.1"
+edition = "2021"
+description = "QuillCache master metadata service: shared residency index + node registry for the distributed KV pool"
+license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
+
+[dependencies]
+quillcache-core = { version = "1.0.0-alpha.1", path = "../quillcache-core" }
+
+[dev-dependencies]
+quillcache-store = { version = "1.0.0-alpha.1", path = "../quillcache-store" }
+quillcache-transfer = { version = "1.0.0-alpha.1", path = "../quillcache-transfer" }
+bytes = "1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "net"] }

--- a/crates/quillcache-master/src/lib.rs
+++ b/crates/quillcache-master/src/lib.rs
@@ -1,0 +1,166 @@
+//! The master metadata service for the distributed KV pool.
+//!
+//! Promotes the residency index out of any single gateway process into a shared
+//! service, so node A can discover that node B holds a block. Two pieces of
+//! state, matching the master/etcd split discussed in the docs:
+//!
+//! - a **shared residency index** — which node (and tier) holds each block. A
+//!   pluggable [`IndexBackend`] (Memory now; Holt-ART for a persistent,
+//!   fast-recovering master; this is the large, high-churn, rebuildable state).
+//! - a **node registry** — node id → transfer-engine address. Small, low-churn
+//!   coordination state (the etcd analogue; an etcd-backed registry plugs in
+//!   later without touching the read path).
+//!
+//! Gateways `register` themselves, report `placed` blocks, and `locate` blocks
+//! here; the cross-node read path is then Conductor → `locate` → registry addr →
+//! transfer engine (see `quillcache_store::PooledStore` / `EngineConnector`).
+
+use quillcache_core::{CacheResidency, IndexBackend, KvBlockKey, MemoryIndex};
+use std::collections::HashMap;
+
+/// The master: a shared residency index plus a node registry.
+#[derive(Debug)]
+pub struct Master {
+    index: Box<dyn IndexBackend>,
+    nodes: HashMap<String, String>,
+}
+
+impl Master {
+    /// A master backed by the in-memory reference index.
+    pub fn new() -> Self {
+        Self {
+            index: Box::new(MemoryIndex::new()),
+            nodes: HashMap::new(),
+        }
+    }
+
+    /// A master backed by a chosen index (e.g. Holt-ART for persistence + fast
+    /// recovery). The index is soft state — rebuildable from node block reports —
+    /// so persistence buys fast restart, not correctness.
+    pub fn with_index(index: Box<dyn IndexBackend>) -> Self {
+        Self {
+            index,
+            nodes: HashMap::new(),
+        }
+    }
+
+    /// A node joins the pool, announcing its transfer-engine address.
+    pub fn register(&mut self, node_id: impl Into<String>, transfer_addr: impl Into<String>) {
+        self.nodes.insert(node_id.into(), transfer_addr.into());
+    }
+
+    /// A node leaves the pool; its residency is dropped (peers stop targeting it).
+    pub fn deregister(&mut self, node_id: &str) {
+        self.nodes.remove(node_id);
+        self.index.clear_worker(node_id);
+    }
+
+    /// The transfer-engine address for a node, if registered.
+    pub fn node_addr(&self, node_id: &str) -> Option<&str> {
+        self.nodes.get(node_id).map(String::as_str)
+    }
+
+    /// The full node id → address map (what a gateway loads into its registry).
+    pub fn nodes(&self) -> &HashMap<String, String> {
+        &self.nodes
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// A node reports it placed (offloaded) a block into its pool.
+    pub fn placed(&mut self, residency: CacheResidency) {
+        self.index.put(residency);
+    }
+
+    /// A node reports a batch of placements (a block report).
+    pub fn placed_batch(&mut self, residencies: impl IntoIterator<Item = CacheResidency>) {
+        for residency in residencies {
+            self.index.put(residency);
+        }
+    }
+
+    /// A node reports a block was evicted from its pool.
+    pub fn evicted(&mut self, node_id: &str, key: &KvBlockKey) {
+        let scope = quillcache_core::IdentityScope::from_key(key);
+        self.index.remove_block(&scope, node_id, &key.block_hash);
+    }
+
+    /// Every residency for a block — which nodes / tiers hold it.
+    pub fn locate(&self, key: &KvBlockKey) -> Vec<CacheResidency> {
+        self.index.locate(key)
+    }
+
+    /// The node ids that hold a block, for the cross-node fetch path.
+    pub fn locate_nodes(&self, key: &KvBlockKey) -> Vec<String> {
+        let mut nodes: Vec<String> = self
+            .index
+            .locate(key)
+            .into_iter()
+            .map(|residency| residency.worker_id)
+            .collect();
+        nodes.dedup();
+        nodes
+    }
+
+    /// Number of residency records held (for reports / metrics).
+    pub fn resident_blocks(&self) -> usize {
+        self.index.len()
+    }
+}
+
+impl Default for Master {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quillcache_core::{CacheResidency, KvBlockKey};
+
+    fn key(tenant: &str, hash: &str) -> KvBlockKey {
+        KvBlockKey::new("m", "t", tenant, "p", hash, 0, 64)
+    }
+
+    #[test]
+    fn register_locate_and_evict() {
+        let mut master = Master::new();
+        master.register("node-a", "127.0.0.1:7001");
+        master.register("node-b", "127.0.0.1:7002");
+        assert_eq!(master.node_count(), 2);
+        assert_eq!(master.node_addr("node-b"), Some("127.0.0.1:7002"));
+
+        let k = key("ten-a", "blk-1");
+        master.placed(CacheResidency {
+            key: k.clone(),
+            worker_id: "node-b".into(),
+            tier: quillcache_core::CacheTier::CpuDram,
+            bytes: 16,
+            last_access_ms: 0,
+            ref_count: 0,
+            pinned: false,
+        });
+        assert_eq!(master.locate_nodes(&k), vec!["node-b".to_string()]);
+        assert_eq!(master.resident_blocks(), 1);
+
+        master.evicted("node-b", &k);
+        assert!(master.locate_nodes(&k).is_empty());
+
+        // Deregistering a node drops its residency so peers stop targeting it.
+        master.placed(CacheResidency {
+            key: k.clone(),
+            worker_id: "node-b".into(),
+            tier: quillcache_core::CacheTier::CpuDram,
+            bytes: 16,
+            last_access_ms: 0,
+            ref_count: 0,
+            pinned: false,
+        });
+        master.deregister("node-b");
+        assert_eq!(master.node_count(), 1);
+        assert!(master.locate_nodes(&k).is_empty());
+    }
+}

--- a/crates/quillcache-master/tests/distributed_pool.rs
+++ b/crates/quillcache-master/tests/distributed_pool.rs
@@ -1,0 +1,111 @@
+//! End-to-end test of the distributed KV pool, exercising every component
+//! together over real TCP (in-process, two "nodes"):
+//!
+//!   master (shared index + registry)
+//!     ├─ node B: engine offloads a prefix's KV -> reports placement -> serves it
+//!     └─ node A: engine needs the prefix -> locate via master -> fetch from B
+//!
+//! This is the flow a real multi-machine cluster runs; here both nodes are in one
+//! process and the transfer is loopback TCP. The remaining gap to a deployed
+//! cluster is the live gateway HTTP wiring + a real vLLM/SGLang connector (the
+//! `EngineConnector` here is the in-process stand-in).
+
+use bytes::Bytes;
+use quillcache_core::{CacheResidency, CacheTier, KvBlockKey};
+use quillcache_master::Master;
+use quillcache_store::{
+    EngineConnector, LocalKvStore, PooledStore, StaticRegistry, StoreBlockSource, StoreError,
+};
+use quillcache_transfer::{serve_listener, TcpTransfer};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("qc-dist-{}-{}", name, std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+fn key(tenant: &str, hash: &str) -> KvBlockKey {
+    KvBlockKey::new("m", "t", tenant, "p", hash, 0, 64)
+}
+
+#[tokio::test]
+async fn distributed_pool_end_to_end_over_tcp() {
+    // The master holds the shared residency index + node registry.
+    let mut master = Master::new();
+
+    // ---- Node B: a peer whose engine offloaded a block; it serves the pool. ----
+    let dir_b = tmp("b");
+    let store_b = Arc::new(Mutex::new(
+        LocalKvStore::new(&dir_b, 1 << 20, 1 << 20).unwrap(),
+    ));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr_b = listener.local_addr().unwrap().to_string();
+    tokio::spawn(serve_listener(
+        listener,
+        Arc::new(StoreBlockSource::new(store_b.clone())),
+    ));
+    master.register("node-b", &addr_b);
+    // B's engine offloads a shared system prompt's KV into B's pool and reports it.
+    let shared = key("ten-a", "sysprompt");
+    store_b
+        .lock()
+        .unwrap()
+        .put(shared.clone(), Bytes::from_static(b"sysprompt-KV-on-B"))
+        .unwrap();
+    master.placed(CacheResidency {
+        key: shared.clone(),
+        worker_id: "node-b".into(),
+        tier: CacheTier::CpuDram,
+        bytes: 17,
+        last_access_ms: 0,
+        ref_count: 0,
+        pinned: false,
+    });
+
+    // ---- Node A: an empty pool + an engine connector. ----
+    let dir_a = tmp("a");
+    let local_a = LocalKvStore::new(&dir_a, 1 << 20, 1 << 20).unwrap();
+    // A loads the cluster's node -> addr map from the master into its registry.
+    let mut registry = StaticRegistry::new("node-a");
+    for (node, addr) in master.nodes() {
+        registry = registry.with_node(node.clone(), addr.clone());
+    }
+    let pool_a = PooledStore::new(local_a, Arc::new(TcpTransfer), Arc::new(registry));
+    let mut engine_a = EngineConnector::new("node-a", pool_a);
+
+    // 1) A's engine offloads its own block; reloading it is a local hit.
+    let local_block = key("ten-a", "A-only");
+    let residency = engine_a
+        .offload(local_block.clone(), Bytes::from_static(b"local-KV-on-A"))
+        .unwrap();
+    master.placed(residency);
+    assert_eq!(
+        &engine_a.reload(&local_block, &[]).await.unwrap()[..],
+        b"local-KV-on-A"
+    );
+
+    // 2) A's engine needs the shared prefix: locate via master -> fetch from B over TCP.
+    let located = master.locate_nodes(&shared);
+    assert_eq!(located, vec!["node-b".to_string()]);
+    let bytes = engine_a.reload(&shared, &located).await.unwrap();
+    assert_eq!(&bytes[..], b"sysprompt-KV-on-B");
+    // It is now resident locally on A too (cached after the cross-node fetch).
+    assert_eq!(
+        &engine_a.reload(&shared, &[]).await.unwrap()[..],
+        b"sysprompt-KV-on-B"
+    );
+
+    // 3) Cluster-wide identity guard: tenant-b cannot reload tenant-a's block from
+    //    A's pool (same content hash, different identity) — refused, not leaked.
+    let cross = key("ten-b", "sysprompt");
+    assert!(matches!(
+        engine_a.reload(&cross, &[]).await,
+        Err(StoreError::Unsafe(_))
+    ));
+
+    let _ = std::fs::remove_dir_all(&dir_a);
+    let _ = std::fs::remove_dir_all(&dir_b);
+}

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -629,6 +629,68 @@ impl PooledStore {
 }
 
 // =====================================================================
+// EngineConnector — the engine <-> pool byte handoff (the KV connector seam).
+// =====================================================================
+
+/// The seam where an inference engine offloads its KV to the pool and reloads
+/// it. A real vLLM / SGLang connector hooks the engine's KV-transfer API; this
+/// in-process connector drives a [`PooledStore`] directly so the offload/reload
+/// path is end-to-end testable without a GPU. `offload` lands a freshly-computed
+/// block in the local pool and returns the residency to report to the master;
+/// `reload` serves a block from the pool — local first, else fetched from the
+/// peer node the residency index located — identity-guarded.
+#[derive(Debug)]
+pub struct EngineConnector {
+    pool: PooledStore,
+    node_id: String,
+}
+
+impl EngineConnector {
+    pub fn new(node_id: impl Into<String>, pool: PooledStore) -> Self {
+        Self {
+            pool,
+            node_id: node_id.into(),
+        }
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    /// The engine computed a block's KV; offload its bytes into the local pool.
+    /// Returns the [`CacheResidency`] to report to the master so peers can find
+    /// it (the block lives in this node's DRAM tier of the pool).
+    pub fn offload(&mut self, key: KvBlockKey, bytes: Bytes) -> std::io::Result<CacheResidency> {
+        let len = bytes.len() as u64;
+        self.pool.local_mut().put(key.clone(), bytes)?;
+        Ok(CacheResidency {
+            key,
+            worker_id: self.node_id.clone(),
+            tier: CacheTier::CpuDram,
+            bytes: len,
+            last_access_ms: 0,
+            ref_count: 0,
+            pinned: false,
+        })
+    }
+
+    /// The engine needs a block's KV. Serve it from the pool: local first, else
+    /// fetch from one of `located_nodes` (from the master's residency index) over
+    /// the transfer engine, and admit it locally. Identity-guarded.
+    pub async fn reload(
+        &mut self,
+        key: &KvBlockKey,
+        located_nodes: &[String],
+    ) -> Result<Bytes, StoreError> {
+        self.pool.get_pooled(key, located_nodes).await
+    }
+
+    pub fn pool_mut(&mut self) -> &mut PooledStore {
+        &mut self.pool
+    }
+}
+
+// =====================================================================
 // StoreDataPlane — tiered block manager (DataPlane seam), fused with bytes.
 // =====================================================================
 


### PR DESCRIPTION
Wires the distributed-pool components together and **proves the full flow over real TCP** — closing the biggest gaps from the "is the distributed pool complete?" discussion (cross-node fetch online + the engine⟷pool connector + a master service), with an end-to-end test.

## What's here

- **`quillcache-master`** (new) — `Master` = a **shared residency index** (`Box<dyn IndexBackend>`) + a **node registry** (node id → transfer address). `register` / `placed` / `locate` / `locate_nodes` / `evicted` / `deregister`. Promotes the residency index out of any single gateway process (the master + etcd split from the docs).
- **`quillcache-store::EngineConnector`** — the **engine⟷pool byte-handoff seam**. `offload(key, bytes)` lands a block in the local pool and returns the residency to report; `reload(key, located_nodes)` serves it from the pool (local-first, else cross-node fetch over the transfer engine), identity-guarded. The in-process stand-in for a real vLLM/SGLang KV connector.
- **End-to-end test** (`quillcache-master/tests/distributed_pool.rs`) — two in-process nodes over loopback TCP: node B's engine offloads a shared prefix and reports it; node A locates it via the master, fetches it from B, caches it locally; the cluster-wide identity guard refuses a cross-tenant reload.

## Honest status

✅ verified now (no hardware): the connector seam, the master service, and cross-node fetch driven by master `locate`.

Still **buildable next** (no hardware): live gateway HTTP wiring (gateway registers with the master, runs a `StoreBlockSource` server, calls `PooledStore` on `route.transfers`), a master HTTP server, and a multi-**process** demo (currently in-process).

Still **needs hardware** (real code can be written feature-gated, not verifiable here): `RdmaTransfer`, the CUDA device tier build, an etcd-backed registry, a real vLLM/SGLang connector, and a real multi-machine cloud deploy.

47 tests pass; `cargo fmt --check` + `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added master metadata service for coordinating distributed KV pool operations across nodes
  * Enabled secure cross-node KV block retrieval with identity-based access control
  * Introduced engine connector for seamless KV offload and reload in distributed environments

* **Tests**
  * Added end-to-end test validating distributed KV pool operations and security controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->