### PR TITLE
feat: local multi-node cluster simulation over loopback TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ name = "quillcache"
 version = "1.0.0-alpha.1"
 dependencies = [
  "axum",
+ "bytes",
  "clap",
  "futures-util",
  "quillcache-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ categories = ["caching", "development-tools"]
 [dependencies]
 clap = { workspace = true }
 axum = { workspace = true }
+bytes = "1"
 futures-util = "0.3"
 reqwest = { workspace = true }
 quillcache-core = { version = "1.0.0-alpha.1", path = "crates/quillcache-core" }

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -572,16 +572,16 @@ impl NodeRegistry for StaticRegistry {
 /// (node → address). [`Self::get_pooled`] is the pooled-cache read: serve
 /// locally, else fetch from a peer the residency index located, admit it
 /// locally, and return it — Conductor → metadata → Transfer Engine.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PooledStore {
-    local: LocalKvStore,
+    local: Arc<Mutex<LocalKvStore>>,
     transfer: Arc<dyn Transfer>,
     registry: Arc<dyn NodeRegistry>,
 }
 
 impl PooledStore {
     pub fn new(
-        local: LocalKvStore,
+        local: Arc<Mutex<LocalKvStore>>,
         transfer: Arc<dyn Transfer>,
         registry: Arc<dyn NodeRegistry>,
     ) -> Self {
@@ -592,8 +592,10 @@ impl PooledStore {
         }
     }
 
-    pub fn local_mut(&mut self) -> &mut LocalKvStore {
-        &mut self.local
+    /// The shared local byte pool — clone the handle to also serve it to peers
+    /// via [`StoreBlockSource`], so one node both serves and uses one store.
+    pub fn local(&self) -> Arc<Mutex<LocalKvStore>> {
+        self.local.clone()
     }
 
     /// Pooled read. `located_nodes` are the node ids the residency index says
@@ -603,11 +605,16 @@ impl PooledStore {
     /// return. A local cross-identity match is refused before any fetch — the
     /// identity guard wins over a network round trip.
     pub async fn get_pooled(
-        &mut self,
+        &self,
         key: &KvBlockKey,
         located_nodes: &[String],
     ) -> Result<Bytes, StoreError> {
-        match self.local.get(key) {
+        // Serve locally first — release the lock before any `.await`.
+        let local = {
+            let mut guard = self.local.lock().unwrap();
+            guard.get(key)
+        };
+        match local {
             Ok(bytes) => return Ok(bytes),
             Err(StoreError::NotFound) => {}
             Err(other) => return Err(other),
@@ -623,7 +630,7 @@ impl PooledStore {
             // just falls through to the next located node.
             if let Ok(bytes) = self.transfer.read(&addr, key).await {
                 // Keyed by the exact identity-bearing key, so safe to admit.
-                let _ = self.local.put(key.clone(), bytes.clone());
+                let _ = self.local.lock().unwrap().put(key.clone(), bytes.clone());
                 return Ok(bytes);
             }
         }
@@ -642,7 +649,7 @@ impl PooledStore {
 /// block in the local pool and returns the residency to report to the master;
 /// `reload` serves a block from the pool — local first, else fetched from the
 /// peer node the residency index located — identity-guarded.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EngineConnector {
     pool: PooledStore,
     node_id: String,
@@ -663,9 +670,9 @@ impl EngineConnector {
     /// The engine computed a block's KV; offload its bytes into the local pool.
     /// Returns the [`CacheResidency`] to report to the master so peers can find
     /// it (the block lives in this node's DRAM tier of the pool).
-    pub fn offload(&mut self, key: KvBlockKey, bytes: Bytes) -> std::io::Result<CacheResidency> {
+    pub fn offload(&self, key: KvBlockKey, bytes: Bytes) -> std::io::Result<CacheResidency> {
         let len = bytes.len() as u64;
-        self.pool.local_mut().put(key.clone(), bytes)?;
+        self.pool.local().lock().unwrap().put(key.clone(), bytes)?;
         Ok(CacheResidency {
             key,
             worker_id: self.node_id.clone(),
@@ -681,15 +688,16 @@ impl EngineConnector {
     /// fetch from one of `located_nodes` (from the master's residency index) over
     /// the transfer engine, and admit it locally. Identity-guarded.
     pub async fn reload(
-        &mut self,
+        &self,
         key: &KvBlockKey,
         located_nodes: &[String],
     ) -> Result<Bytes, StoreError> {
         self.pool.get_pooled(key, located_nodes).await
     }
 
-    pub fn pool_mut(&mut self) -> &mut PooledStore {
-        &mut self.pool
+    /// The node's shared byte pool, to serve to peers via [`StoreBlockSource`].
+    pub fn store(&self) -> Arc<Mutex<LocalKvStore>> {
+        self.pool.local()
     }
 }
 
@@ -1376,7 +1384,11 @@ mod tests {
         let dir_a = tmp("pool-a");
         let local_a = LocalKvStore::new(&dir_a, 1 << 20, 1 << 20).unwrap();
         let registry = Arc::new(StaticRegistry::new("node-a").with_node("node-b", addr_b.clone()));
-        let mut node_a = PooledStore::new(local_a, Arc::new(TcpTransfer), registry);
+        let node_a = PooledStore::new(
+            Arc::new(Mutex::new(local_a)),
+            Arc::new(TcpTransfer),
+            registry,
+        );
 
         // The residency index located the block on node-a (us — skipped) and
         // node-b; node-a resolves node-b's address and fetches it over TCP.

--- a/crates/quillcache-store/tests/distributed_pool.rs
+++ b/crates/quillcache-store/tests/distributed_pool.rs
@@ -73,8 +73,12 @@ async fn distributed_pool_end_to_end_over_tcp() {
     for (node, addr) in master.nodes() {
         registry = registry.with_node(node.clone(), addr.clone());
     }
-    let pool_a = PooledStore::new(local_a, Arc::new(TcpTransfer), Arc::new(registry));
-    let mut engine_a = EngineConnector::new("node-a", pool_a);
+    let pool_a = PooledStore::new(
+        Arc::new(Mutex::new(local_a)),
+        Arc::new(TcpTransfer),
+        Arc::new(registry),
+    );
+    let engine_a = EngineConnector::new("node-a", pool_a);
 
     // 1) A's engine offloads its own block; reloading it is a local hit.
     let local_block = key("ten-a", "A-only");

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,0 +1,167 @@
+//! Local multi-node cluster simulation.
+//!
+//! Brings up a shared master and N nodes as Tokio tasks over loopback TCP — each
+//! node a real byte pool plus a transfer server — then runs a concurrent
+//! shared-prefix workload so you can watch the distributed pool work: one node's
+//! engine offloads a system prompt, the others locate it via the master and
+//! fetch it cross-node, and the identity guard refuses a cross-tenant request.
+//!
+//! This is the same flow a real multi-machine cluster runs; here the "machines"
+//! are tasks on the multi-thread runtime and the wire is loopback TCP. Swapping
+//! `TcpTransfer` for an RDMA backend and the in-process `EngineConnector` for a
+//! real vLLM/SGLang connector is the only difference to a deployed cluster.
+
+use bytes::Bytes;
+use quillcache_core::{CacheResidency, CacheTier, KvBlockKey, Master};
+use quillcache_store::{
+    serve_listener, EngineConnector, LocalKvStore, PooledStore, StaticRegistry, StoreBlockSource,
+    StoreError, TcpTransfer,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+#[derive(Clone)]
+struct Node {
+    id: String,
+    store: Arc<Mutex<LocalKvStore>>,
+    connector: EngineConnector,
+}
+
+fn shared_block(tenant: &str) -> KvBlockKey {
+    KvBlockKey::new(
+        "Qwen2.5",
+        "Qwen2.5",
+        tenant,
+        "sys",
+        "shared-system-prompt",
+        0,
+        64,
+    )
+}
+
+pub async fn run_cluster(
+    nodes_n: usize,
+    requests: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let nodes_n = nodes_n.max(2);
+    println!("QuillCache local cluster — {nodes_n} nodes over loopback TCP, one shared master\n");
+
+    let master = Arc::new(Mutex::new(Master::new()));
+    let base = std::env::temp_dir().join(format!("qc-cluster-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+
+    // Bring up each node: a byte pool + a TCP transfer server + master registration.
+    let mut stores: Vec<Arc<Mutex<LocalKvStore>>> = Vec::new();
+    for i in 0..nodes_n {
+        let id = format!("node-{i}");
+        let store = Arc::new(Mutex::new(LocalKvStore::new(
+            base.join(&id),
+            1 << 30,
+            1 << 30,
+        )?));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?.to_string();
+        tokio::spawn(serve_listener(
+            listener,
+            Arc::new(StoreBlockSource::new(store.clone())),
+        ));
+        master.lock().unwrap().register(&id, &addr);
+        println!("  {id}  byte pool + transfer server @ {addr}");
+        stores.push(store);
+    }
+
+    // Each node's connector gets the cluster's node→addr map from the master.
+    let node_map = master.lock().unwrap().nodes().clone();
+    let nodes: Vec<Node> = (0..nodes_n)
+        .map(|i| {
+            let id = format!("node-{i}");
+            let mut registry = StaticRegistry::new(id.clone());
+            for (n, a) in &node_map {
+                registry = registry.with_node(n.clone(), a.clone());
+            }
+            let pool =
+                PooledStore::new(stores[i].clone(), Arc::new(TcpTransfer), Arc::new(registry));
+            Node {
+                id: id.clone(),
+                store: stores[i].clone(),
+                connector: EngineConnector::new(id, pool),
+            }
+        })
+        .collect();
+
+    // node-0's engine computes + offloads a shared system prompt's KV (4 KiB).
+    let shared = shared_block("tenant-a");
+    let residency = nodes[0]
+        .connector
+        .offload(shared.clone(), Bytes::from(vec![7u8; 4096]))?;
+    master.lock().unwrap().placed(residency);
+    println!("\n  node-0 offloaded the shared system prompt (4 KiB KV) to its pool; reported to master.\n");
+
+    // Concurrent workload: `requests` requests round-robin across nodes, all
+    // needing the shared prefix. A node that doesn't have it locates it via the
+    // master and fetches it from a peer over TCP, then caches it.
+    let local_hits = Arc::new(AtomicUsize::new(0));
+    let cross_fetches = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+    for r in 0..requests {
+        let node = nodes[r % nodes_n].clone();
+        let master = master.clone();
+        let shared = shared.clone();
+        let (lh, cf) = (local_hits.clone(), cross_fetches.clone());
+        handles.push(tokio::spawn(async move {
+            let was_local = node.store.lock().unwrap().tier_of(&shared).is_some();
+            let located = master.lock().unwrap().locate_nodes(&shared);
+            let _ = node.connector.reload(&shared, &located).await;
+            if was_local {
+                lh.fetch_add(1, Ordering::Relaxed);
+            } else {
+                cf.fetch_add(1, Ordering::Relaxed);
+                master.lock().unwrap().placed(CacheResidency {
+                    key: shared.clone(),
+                    worker_id: node.id.clone(),
+                    tier: CacheTier::CpuDram,
+                    bytes: 4096,
+                    last_access_ms: 0,
+                    ref_count: 0,
+                    pinned: false,
+                });
+            }
+        }));
+    }
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    // Cluster-wide identity guard: tenant-b asks node-0 for the same content.
+    let cross = shared_block("tenant-b");
+    let guarded = nodes[0].connector.reload(&cross, &[]).await;
+    let refused = matches!(guarded, Err(StoreError::Unsafe(_)));
+
+    let (lh, cf) = (
+        local_hits.load(Ordering::Relaxed),
+        cross_fetches.load(Ordering::Relaxed),
+    );
+    println!(
+        "  workload: {requests} requests -> {lh} local hits, {cf} cross-node fetches over TCP"
+    );
+    println!(
+        "  identity guard: tenant-b's request for tenant-a's prefix was {}",
+        if refused {
+            "REFUSED (no leak)"
+        } else {
+            "SERVED (bug!)"
+        }
+    );
+    {
+        let master = master.lock().unwrap();
+        println!(
+            "  master: {} residency records across {} registered nodes",
+            master.resident_blocks(),
+            master.node_count()
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&base);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cluster;
 mod gateway;
 
 use crate::gateway::run_from_config_path;
@@ -44,6 +45,15 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Run a local multi-node cluster simulation over loopback TCP: a shared
+    /// master + N nodes (each a byte pool + transfer server), a concurrent
+    /// shared-prefix workload, cross-node fetch, and the identity guard.
+    Cluster {
+        #[arg(long, default_value_t = 3)]
+        nodes: usize,
+        #[arg(long, default_value_t = 12)]
+        requests: usize,
+    },
 }
 
 #[tokio::main]
@@ -59,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Command::Gateway { config } => run_from_config_path(config).await?,
         Command::Plan => print_plan(),
+        Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
         Command::BenchIndex {
             backend,
             requests,


### PR DESCRIPTION
Makes the distributed KV pool **runnable as a multi-node cluster locally** — the "用多个线程模拟集群" step.

## What's here

- **`PooledStore` + `EngineConnector` now share the byte pool** as `Arc<Mutex<LocalKvStore>>` (was owned), so a node's `StoreBlockSource` (serves peers) and its `PooledStore` (fetches from peers) use **one** store. `get_pooled`/`offload`/`reload` are `&self`; the lock is released before any `.await`; both are `Clone`.
- **`src/cluster.rs` + `quillcache cluster --nodes N --requests M`** — a shared `Master` + N nodes as Tokio tasks over loopback TCP (each a byte pool + transfer server). node-0 offloads a shared system prompt; a **concurrent** round-robin workload locates it via the master and fetches it cross-node over TCP, then caches it; a cluster-wide **identity-guard** check refuses a cross-tenant request.

```text
$ cargo run -- cluster --nodes 4 --requests 16
  node-0..3  byte pool + transfer server @ 127.0.0.1:...
  workload: 16 requests -> 4 local hits, 12 cross-node fetches over TCP
  identity guard: tenant-b's request for tenant-a's prefix was REFUSED (no leak)
  master: 4 residency records across 4 registered nodes
```

The "machines" are tasks on the multi-thread runtime and the wire is loopback TCP — the same flow a real cluster runs. Swapping `TcpTransfer` for RDMA and the in-process `EngineConnector` for a real vLLM/SGLang connector is the only difference to a deployed cluster.

(The 12-vs-3 cross-fetches is honest concurrency — a thundering herd of cold requests all fetch the uncached block; a real system adds single-flight dedup.)

47 tests pass; `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cluster simulation command that enables testing multi-node cache scenarios locally with configurable node counts and concurrent request workloads, including tenant isolation validation and residency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->