### PR TITLE
feat(store): single-flight cross-node fetch (cache-stampede guard)

### DIFF
--- a/crates/quillcache-store/Cargo.toml
+++ b/crates/quillcache-store/Cargo.toml
@@ -14,11 +14,11 @@ crc32fast = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["net", "io-util"] }
+tokio = { workspace = true, features = ["net", "io-util", "sync"] }
 
 [features]
 # RDMA transfer backend (ibverbs). Reserved seam — stubbed until a NIC is available.
 rdma = []
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "net"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "net", "time"] }

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -29,6 +29,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
 
 pub mod transfer;
 pub use transfer::*;
@@ -577,6 +578,10 @@ pub struct PooledStore {
     local: Arc<Mutex<LocalKvStore>>,
     transfer: Arc<dyn Transfer>,
     registry: Arc<dyn NodeRegistry>,
+    /// In-flight cross-node fetches, keyed by block. A concurrent burst of
+    /// requests that all miss locally coalesces onto ONE peer fetch (the others
+    /// wait on the broadcast) — the single-flight / cache-stampede guard.
+    in_flight: Arc<Mutex<HashMap<KvBlockKey, broadcast::Sender<Option<Bytes>>>>>,
 }
 
 impl PooledStore {
@@ -589,6 +594,7 @@ impl PooledStore {
             local,
             transfer,
             registry,
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -604,6 +610,12 @@ impl PooledStore {
     /// via the registry, fetch over the transfer engine, admit locally, and
     /// return. A local cross-identity match is refused before any fetch — the
     /// identity guard wins over a network round trip.
+    ///
+    /// Cross-node fetches are **single-flighted**: when a burst of concurrent
+    /// requests all miss this block locally, one becomes the leader and does the
+    /// peer fetch while the rest wait on its result — so a thundering herd of
+    /// cold requests for the same block triggers one network round trip, not one
+    /// per request (Mooncake/Dynamo pools need this; Go calls it `singleflight`).
     pub async fn get_pooled(
         &self,
         key: &KvBlockKey,
@@ -617,8 +629,53 @@ impl PooledStore {
         match local {
             Ok(bytes) => return Ok(bytes),
             Err(StoreError::NotFound) => {}
+            // A local cross-identity match is refused before any fetch.
             Err(other) => return Err(other),
         }
+
+        // Single-flight admission: join an in-flight fetch for this key, or lead.
+        enum Flight {
+            Leader,
+            Follower(broadcast::Receiver<Option<Bytes>>),
+        }
+        let flight = {
+            let mut inflight = self.in_flight.lock().unwrap();
+            match inflight.get(key) {
+                Some(tx) => Flight::Follower(tx.subscribe()),
+                None => {
+                    let (tx, _rx) = broadcast::channel(1);
+                    inflight.insert(key.clone(), tx);
+                    Flight::Leader
+                }
+            }
+        };
+
+        if let Flight::Follower(mut rx) = flight {
+            // Wait for the leader and share its result; a dropped/missed leader
+            // reads as a genuine pool-wide miss.
+            return match rx.recv().await {
+                Ok(Some(bytes)) => Ok(bytes),
+                _ => Err(StoreError::NotFound),
+            };
+        }
+
+        // Leader: do the actual peer fetch, then publish to followers and clean up.
+        let result = self.fetch_from_peers(key, located_nodes).await;
+        let payload = result.as_ref().ok().cloned();
+        if let Some(tx) = self.in_flight.lock().unwrap().remove(key) {
+            let _ = tx.send(payload);
+        }
+        result
+    }
+
+    /// The peer-fetch loop: try each located node (skipping self), resolve its
+    /// address, fetch over the transfer engine, admit locally. A peer that lacks
+    /// the block (stale index) or is unreachable falls through to the next.
+    async fn fetch_from_peers(
+        &self,
+        key: &KvBlockKey,
+        located_nodes: &[String],
+    ) -> Result<Bytes, StoreError> {
         for node in located_nodes {
             if node == self.registry.this_node() {
                 continue;
@@ -626,8 +683,6 @@ impl PooledStore {
             let Some(addr) = self.registry.addr_of(node) else {
                 continue;
             };
-            // A peer that doesn't have it (stale index entry) or is unreachable
-            // just falls through to the next located node.
             if let Ok(bytes) = self.transfer.read(&addr, key).await {
                 // Keyed by the exact identity-bearing key, so safe to admit.
                 let _ = self.local.lock().unwrap().put(key.clone(), bytes.clone());
@@ -1411,5 +1466,70 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir_a);
         let _ = std::fs::remove_dir_all(&dir_b);
+    }
+
+    /// A peer whose fetch is slow (so concurrent followers overlap the leader's
+    /// fetch window) — wrap it in [`CountingTransfer`] to count actual fetches.
+    #[derive(Debug)]
+    struct SlowPeer {
+        data: Bytes,
+    }
+
+    #[async_trait::async_trait]
+    impl Transfer for SlowPeer {
+        fn name(&self) -> &str {
+            "slow-peer"
+        }
+        fn link_class(&self) -> LinkClass {
+            LinkClass::Tcp
+        }
+        async fn read(&self, _r: &NodeAddr, _k: &KvBlockKey) -> Result<Bytes, TransferError> {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            Ok(self.data.clone())
+        }
+        async fn write(&self, _: &NodeAddr, _: &KvBlockKey, _: Bytes) -> Result<(), TransferError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_misses_single_flight_into_one_peer_fetch() {
+        // node-a: an empty local pool whose peer fetch is slow + counted, so a
+        // burst of concurrent requests for the same block overlaps in the fetch.
+        let dir_a = tmp("sf-a");
+        let store_a = Arc::new(Mutex::new(
+            LocalKvStore::new(&dir_a, 1 << 20, 1 << 20).unwrap(),
+        ));
+        let counter = Arc::new(CountingTransfer::new(Arc::new(SlowPeer {
+            data: Bytes::from_static(b"hot-shared-prefix"),
+        })));
+        let registry = Arc::new(StaticRegistry::new("node-a").with_node("node-b", "peer:0"));
+        let node = PooledStore::new(store_a, counter.clone(), registry);
+
+        // 16 concurrent requests, all missing locally, all needing one block.
+        let located = vec!["node-b".to_string()];
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let (node, located) = (node.clone(), located.clone());
+            handles.push(tokio::spawn(async move {
+                node.get_pooled(&key("ten-a", "hot"), &located).await
+            }));
+        }
+        for h in handles {
+            assert_eq!(&h.await.unwrap().unwrap()[..], b"hot-shared-prefix");
+        }
+
+        // Single-flight collapsed 16 concurrent cold reads into ONE peer fetch.
+        assert_eq!(counter.reads(), 1);
+
+        // The block is now resident locally — a later read needs no fetch at all.
+        let cached = node
+            .get_pooled(&key("ten-a", "hot"), &located)
+            .await
+            .unwrap();
+        assert_eq!(&cached[..], b"hot-shared-prefix");
+        assert_eq!(counter.reads(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir_a);
     }
 }

--- a/crates/quillcache-store/src/transfer.rs
+++ b/crates/quillcache-store/src/transfer.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use quillcache_core::{CacheTier, KvBlockKey};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -87,6 +88,55 @@ pub trait Transfer: Send + Sync + std::fmt::Debug {
         key: &KvBlockKey,
         data: Bytes,
     ) -> Result<(), TransferError>;
+}
+
+/// A [`Transfer`] decorator that counts `read` calls — the actual cross-node
+/// fetches (network round trips). Wrap any backend to measure how many peer
+/// fetches single-flight coalescing avoided: under a concurrent burst for one
+/// block, `reads()` counts one fetch per node, not one per request.
+#[derive(Debug)]
+pub struct CountingTransfer {
+    inner: Arc<dyn Transfer>,
+    reads: AtomicUsize,
+}
+
+impl CountingTransfer {
+    pub fn new(inner: Arc<dyn Transfer>) -> Self {
+        Self {
+            inner,
+            reads: AtomicUsize::new(0),
+        }
+    }
+
+    /// The number of actual `read` (peer fetch) calls made through this decorator.
+    pub fn reads(&self) -> usize {
+        self.reads.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl Transfer for CountingTransfer {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn link_class(&self) -> LinkClass {
+        self.inner.link_class()
+    }
+
+    async fn read(&self, remote: &NodeAddr, key: &KvBlockKey) -> Result<Bytes, TransferError> {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        self.inner.read(remote, key).await
+    }
+
+    async fn write(
+        &self,
+        remote: &NodeAddr,
+        key: &KvBlockKey,
+        data: Bytes,
+    ) -> Result<(), TransferError> {
+        self.inner.write(remote, key, data).await
+    }
 }
 
 /// In-process transfer over a shared map. The fast path for same-machine moves

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -14,8 +14,8 @@
 use bytes::Bytes;
 use quillcache_core::{CacheResidency, CacheTier, KvBlockKey, Master};
 use quillcache_store::{
-    serve_listener, EngineConnector, LocalKvStore, PooledStore, StaticRegistry, StoreBlockSource,
-    StoreError, TcpTransfer,
+    serve_listener, CountingTransfer, EngineConnector, LocalKvStore, PooledStore, StaticRegistry,
+    StoreBlockSource, StoreError, TcpTransfer,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -73,6 +73,9 @@ pub async fn run_cluster(
 
     // Each node's connector gets the cluster's node→addr map from the master.
     let node_map = master.lock().unwrap().nodes().clone();
+    // One shared transfer engine, wrapped to count ACTUAL cross-node fetches, so
+    // we can show single-flight coalescing the concurrent duplicate reads.
+    let transfer = Arc::new(CountingTransfer::new(Arc::new(TcpTransfer)));
     let nodes: Vec<Node> = (0..nodes_n)
         .map(|i| {
             let id = format!("node-{i}");
@@ -80,8 +83,7 @@ pub async fn run_cluster(
             for (n, a) in &node_map {
                 registry = registry.with_node(n.clone(), a.clone());
             }
-            let pool =
-                PooledStore::new(stores[i].clone(), Arc::new(TcpTransfer), Arc::new(registry));
+            let pool = PooledStore::new(stores[i].clone(), transfer.clone(), Arc::new(registry));
             Node {
                 id: id.clone(),
                 store: stores[i].clone(),
@@ -102,13 +104,13 @@ pub async fn run_cluster(
     // needing the shared prefix. A node that doesn't have it locates it via the
     // master and fetches it from a peer over TCP, then caches it.
     let local_hits = Arc::new(AtomicUsize::new(0));
-    let cross_fetches = Arc::new(AtomicUsize::new(0));
+    let cold_arrivals = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::new();
     for r in 0..requests {
         let node = nodes[r % nodes_n].clone();
         let master = master.clone();
         let shared = shared.clone();
-        let (lh, cf) = (local_hits.clone(), cross_fetches.clone());
+        let (lh, cf) = (local_hits.clone(), cold_arrivals.clone());
         handles.push(tokio::spawn(async move {
             let was_local = node.store.lock().unwrap().tier_of(&shared).is_some();
             let located = master.lock().unwrap().locate_nodes(&shared);
@@ -138,12 +140,14 @@ pub async fn run_cluster(
     let guarded = nodes[0].connector.reload(&cross, &[]).await;
     let refused = matches!(guarded, Err(StoreError::Unsafe(_)));
 
-    let (lh, cf) = (
+    let (lh, cold) = (
         local_hits.load(Ordering::Relaxed),
-        cross_fetches.load(Ordering::Relaxed),
+        cold_arrivals.load(Ordering::Relaxed),
     );
+    let actual = transfer.reads();
     println!(
-        "  workload: {requests} requests -> {lh} local hits, {cf} cross-node fetches over TCP"
+        "  workload: {requests} requests -> {lh} local hits, {cold} arrived cold -> \
+         {actual} actual cross-node fetches over TCP (single-flight coalesced {cold}->{actual})"
     );
     println!(
         "  identity guard: tenant-b's request for tenant-a's prefix was {}",


### PR DESCRIPTION
## The problem

A concurrent burst of requests that all miss the same block locally each fired its **own** peer fetch — a thundering herd. The local cluster demo made it visible: **12 cold arrivals → 12 TCP fetches**, when the ideal is **3** (one per cold node).

## The fix

`PooledStore.get_pooled` now **single-flights** the cross-node fetch (Go calls it `singleflight`; Mooncake/Dynamo pools need it). The first miss for a key leads — does the peer fetch + local admit — while concurrent misses for the same key follow on a `tokio::broadcast` and share the leader's result. **One network round trip per (node, block) under a burst, not one per request.** The local-first identity guard still wins before any fetch.

- **`PooledStore`**: an `in_flight: HashMap<KvBlockKey, broadcast::Sender<Option<Bytes>>>`; leader/follower admission; the peer-fetch loop extracted to `fetch_from_peers`.
- **`CountingTransfer`**: a `Transfer` decorator that counts actual `read` calls, so coalescing is *measurable* (reused by the test and the cluster demo).

## Verified

- **Deterministic test** `concurrent_misses_single_flight_into_one_peer_fetch`: 16 concurrent cold reads (slow peer) collapse to **exactly 1** fetch; the block is then resident locally.
- **Cluster demo** now reports actual fetches:
  ```
  16 requests -> 4 local hits, 12 arrived cold -> 3 actual cross-node fetches over TCP (single-flight coalesced 12->3)
  40 requests -> 10 local hits, 30 arrived cold -> 3 actual cross-node fetches over TCP (single-flight coalesced 30->3)
  ```
  Stable at 3 (the ideal) across runs and at higher load.

**51 tests pass; fmt + clippy clean.** This closes the honest "thundering-herd / needs single-flight dedup" caveat the cluster demo previously carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Concurrent cache requests for the same missing key are now coalesced into a single cross-node fetch, reducing unnecessary network traffic.
  * Improved metrics reporting to display actual cross-node fetch counts and the effectiveness of request coalescing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->