### PR TITLE
feat(transfer-engine): faithful Rust port of Mooncake's Transfer Engine (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillcache-transfer-engine"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     ".",
     "crates/quillcache-core",
     "crates/quillcache-store",
+    "crates/quillcache-transfer-engine",
     "crates/quillcache-index-rocksdb",
     "crates/quillcache-index-holt",
 ]
@@ -10,6 +11,7 @@ default-members = [
     ".",
     "crates/quillcache-core",
     "crates/quillcache-store",
+    "crates/quillcache-transfer-engine",
     "crates/quillcache-index-holt",
 ]
 # The CUDA device tier is excluded so the default build never resolves/compiles

--- a/crates/quillcache-transfer-engine/Cargo.toml
+++ b/crates/quillcache-transfer-engine/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quillcache-transfer-engine"
+version = "1.0.0-alpha.1"
+edition = "2021"
+description = "Faithful Rust port of Mooncake's Transfer Engine: TransferEngine facade + MultiTransport + Transport backends (TCP real, RDMA/NVMe-oF/GPU reserved) + TransferMetadata + Topology; one-sided (segment, offset) transfers between registered memory"
+license = "MIT"
+repository = "https://github.com/feichai0017/quillcache"
+
+[dependencies]
+async-trait = "0.1"
+bytes = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["net", "io-util", "rt"] }
+
+[features]
+# RDMA transport backend (ibverbs / GPUDirect-RDMA). Reserved seam — the trait
+# is implemented as an Unsupported stub until an RDMA NIC is wired.
+rdma = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/crates/quillcache-transfer-engine/src/engine.rs
+++ b/crates/quillcache-transfer-engine/src/engine.rs
@@ -1,0 +1,276 @@
+//! TransferEngine (Mooncake's `transfer_engine.h`) — the top-level facade. Owns
+//! this node's RAM segment (a registered byte arena), the metadata backend, the
+//! [`MultiTransport`], and the batch table; for TCP it binds a listener and
+//! serves its segment to peers.
+//!
+//! The faithful flow:
+//! 1. [`TransferEngine::init`] — bind, publish our [`SegmentDesc`], serve.
+//! 2. [`TransferEngine::register_local_memory`] — register a buffer → offset.
+//! 3. [`TransferEngine::open_segment`] — resolve a peer's segment → [`SegmentId`].
+//! 4. [`TransferEngine::allocate_batch_id`] → [`TransferEngine::submit_transfer`]
+//!    (READ / WRITE against `(target_id, target_offset)`) →
+//!    [`TransferEngine::get_transfer_status`] → [`TransferEngine::free_batch_id`].
+
+use crate::metadata::{MetadataBackend, SegmentDesc};
+use crate::multi_transport::MultiTransport;
+use crate::transport::tcp::{self, TcpTransport};
+use crate::transport::{
+    BatchId, OpCode, SegmentId, TransferError, TransferRequest, TransferStatus, TransferStatusEnum,
+};
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+#[derive(Debug)]
+pub struct TransferEngine {
+    local_name: String,
+    /// This node's RAM segment: a registered byte arena peers READ / WRITE by offset.
+    segment: Arc<Mutex<Vec<u8>>>,
+    metadata: Arc<dyn MetadataBackend>,
+    multi: MultiTransport,
+    next_batch: AtomicU64,
+    batches: Mutex<HashMap<BatchId, TransferStatus>>,
+    /// Opened remote segments: handle → (protocol, endpoint).
+    segment_cache: Mutex<HashMap<SegmentId, (String, String)>>,
+    next_seg: AtomicI64,
+}
+
+impl TransferEngine {
+    /// Bind a TCP listener, publish this node's segment to the metadata backend,
+    /// install the TCP transport, and start serving the segment to peers.
+    pub async fn init(
+        local_name: impl Into<String>,
+        metadata: Arc<dyn MetadataBackend>,
+        bind_addr: &str,
+    ) -> std::io::Result<Arc<Self>> {
+        let local_name = local_name.into();
+        let segment = Arc::new(Mutex::new(Vec::new()));
+        let listener = TcpListener::bind(bind_addr).await?;
+        let endpoint = listener.local_addr()?.to_string();
+
+        let mut multi = MultiTransport::new();
+        multi.install("tcp", Arc::new(TcpTransport));
+
+        metadata.put_segment(SegmentDesc {
+            name: local_name.clone(),
+            protocol: "tcp".into(),
+            endpoint,
+            buffers: Vec::new(),
+        });
+
+        let engine = Arc::new(Self {
+            local_name,
+            segment: segment.clone(),
+            metadata,
+            multi,
+            next_batch: AtomicU64::new(1),
+            batches: Mutex::new(HashMap::new()),
+            segment_cache: Mutex::new(HashMap::new()),
+            next_seg: AtomicI64::new(1),
+        });
+        tokio::spawn(tcp::serve_segment(listener, segment));
+        Ok(engine)
+    }
+
+    pub fn local_name(&self) -> &str {
+        &self.local_name
+    }
+
+    /// Register a local buffer (copy it into the RAM segment); returns its offset
+    /// — the handle a peer targets, and the source for our own writes.
+    pub fn register_local_memory(&self, data: &[u8]) -> u64 {
+        let mut seg = self.segment.lock().unwrap();
+        let offset = seg.len() as u64;
+        seg.extend_from_slice(data);
+        offset
+    }
+
+    /// Reserve `len` zeroed bytes in the RAM segment — a READ destination.
+    pub fn register_zeroed(&self, len: usize) -> u64 {
+        let mut seg = self.segment.lock().unwrap();
+        let offset = seg.len() as u64;
+        seg.resize(offset as usize + len, 0);
+        offset
+    }
+
+    /// Read bytes back from our own RAM segment.
+    pub fn read_local(&self, offset: u64, len: u64) -> Bytes {
+        let seg = self.segment.lock().unwrap();
+        Bytes::copy_from_slice(&seg[offset as usize..(offset + len) as usize])
+    }
+
+    /// Resolve a remote segment by name → an opaque [`SegmentId`] handle.
+    pub fn open_segment(&self, name: &str) -> Result<SegmentId, TransferError> {
+        let desc = self
+            .metadata
+            .get_segment(name)
+            .ok_or(TransferError::NotFound)?;
+        let id = self.next_seg.fetch_add(1, Ordering::Relaxed);
+        self.segment_cache
+            .lock()
+            .unwrap()
+            .insert(id, (desc.protocol, desc.endpoint));
+        Ok(id)
+    }
+
+    /// Open a batch for `submit_transfer` (Mooncake's `allocateBatchID`).
+    pub fn allocate_batch_id(&self, _batch_size: usize) -> BatchId {
+        let id = self.next_batch.fetch_add(1, Ordering::Relaxed);
+        self.batches.lock().unwrap().insert(
+            id,
+            TransferStatus {
+                state: TransferStatusEnum::Waiting,
+                transferred_bytes: 0,
+            },
+        );
+        id
+    }
+
+    /// Execute a batch of one-sided transfers against opened remote segments.
+    /// READ copies `target[target_offset..]` into `local[source_offset..]`;
+    /// WRITE copies `local[source_offset..]` into `target[target_offset..]`.
+    pub async fn submit_transfer(
+        &self,
+        batch: BatchId,
+        requests: Vec<TransferRequest>,
+    ) -> Result<(), TransferError> {
+        let mut transferred = 0u64;
+        for req in &requests {
+            let (protocol, endpoint) = self
+                .segment_cache
+                .lock()
+                .unwrap()
+                .get(&req.target_id)
+                .cloned()
+                .ok_or(TransferError::BadSegment)?;
+            let transport = self
+                .multi
+                .select(&protocol)
+                .ok_or(TransferError::Unsupported("no transport for protocol"))?;
+            match req.opcode {
+                OpCode::Read => {
+                    let bytes = transport
+                        .read_remote(&endpoint, req.target_offset, req.length)
+                        .await?;
+                    let mut seg = self.segment.lock().unwrap();
+                    let (start, end) = (
+                        req.source_offset as usize,
+                        (req.source_offset + req.length) as usize,
+                    );
+                    if end > seg.len() {
+                        return Err(TransferError::Protocol(
+                            "local source buffer too small for READ".into(),
+                        ));
+                    }
+                    seg[start..end].copy_from_slice(&bytes);
+                }
+                OpCode::Write => {
+                    let data = {
+                        let seg = self.segment.lock().unwrap();
+                        let (start, end) = (
+                            req.source_offset as usize,
+                            (req.source_offset + req.length) as usize,
+                        );
+                        if end > seg.len() {
+                            return Err(TransferError::Protocol(
+                                "local source buffer too small for WRITE".into(),
+                            ));
+                        }
+                        Bytes::copy_from_slice(&seg[start..end])
+                    };
+                    transport
+                        .write_remote(&endpoint, req.target_offset, data)
+                        .await?;
+                }
+            }
+            transferred += req.length;
+        }
+        self.batches.lock().unwrap().insert(
+            batch,
+            TransferStatus {
+                state: TransferStatusEnum::Completed,
+                transferred_bytes: transferred,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn get_transfer_status(&self, batch: BatchId) -> Option<TransferStatus> {
+        self.batches.lock().unwrap().get(&batch).cloned()
+    }
+
+    pub fn free_batch_id(&self, batch: BatchId) {
+        self.batches.lock().unwrap().remove(&batch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::InMemoryMetadata;
+
+    #[tokio::test]
+    async fn tcp_segment_read_and_write_over_registered_memory() {
+        // Shared (in-memory / P2PHANDSHAKE) metadata so the two engines discover
+        // each other with no external store.
+        let md: Arc<dyn MetadataBackend> = Arc::new(InMemoryMetadata::new());
+
+        // Engine A registers a buffer in its RAM segment.
+        let a = TransferEngine::init("A", md.clone(), "127.0.0.1:0")
+            .await
+            .unwrap();
+        let a_off = a.register_local_memory(b"hello-mooncake-kv"); // 17 bytes
+
+        // Engine B opens A's segment and READs the bytes over TCP into local memory.
+        let b = TransferEngine::init("B", md.clone(), "127.0.0.1:0")
+            .await
+            .unwrap();
+        let seg_a = b.open_segment("A").unwrap();
+        let dst = b.register_zeroed(17);
+        let batch = b.allocate_batch_id(1);
+        b.submit_transfer(
+            batch,
+            vec![TransferRequest {
+                opcode: OpCode::Read,
+                source_offset: dst,
+                target_id: seg_a,
+                target_offset: a_off,
+                length: 17,
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            b.get_transfer_status(batch).unwrap().state,
+            TransferStatusEnum::Completed
+        );
+        assert_eq!(&b.read_local(dst, 17)[..], b"hello-mooncake-kv");
+        b.free_batch_id(batch);
+
+        // WRITE path: B pushes a local buffer into A's segment at a fresh offset;
+        // A reads it back locally.
+        let src = b.register_local_memory(b"written-by-B"); // 12 bytes
+        let batch2 = b.allocate_batch_id(1);
+        b.submit_transfer(
+            batch2,
+            vec![TransferRequest {
+                opcode: OpCode::Write,
+                source_offset: src,
+                target_id: seg_a,
+                target_offset: 1000,
+                length: 12,
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(&a.read_local(1000, 12)[..], b"written-by-B");
+
+        // Opening a segment that was never published is a clean miss.
+        assert!(matches!(
+            b.open_segment("does-not-exist"),
+            Err(TransferError::NotFound)
+        ));
+    }
+}

--- a/crates/quillcache-transfer-engine/src/lib.rs
+++ b/crates/quillcache-transfer-engine/src/lib.rs
@@ -1,0 +1,41 @@
+//! QuillCache Transfer Engine — a faithful Rust port of Mooncake's
+//! `mooncake-transfer-engine` (the KVCache-centric data plane, FAST'25).
+//!
+//! **Component map** (Mooncake C++ → this crate):
+//!
+//! | Mooncake (`mooncake-transfer-engine/`) | here |
+//! | --- | --- |
+//! | `TransferEngine` (`transfer_engine.h`) | [`engine::TransferEngine`] facade |
+//! | `MultiTransport` (`multi_transport.h`) | [`multi_transport::MultiTransport`] |
+//! | `Transport` + subclasses (`transport/*`) | [`transport::Transport`] + backends |
+//! | &nbsp;&nbsp;`TcpTransport` | [`transport::tcp::TcpTransport`] — **real** |
+//! | &nbsp;&nbsp;`RdmaTransport` (ibverbs) | [`transport::rdma::RdmaTransport`] — reserved |
+//! | `TransferMetadata` (`transfer_metadata.h`) | [`metadata`] (`SegmentDesc`, backend) |
+//! | `Topology` (`topology.h`) | [`topology::Topology`] |
+//!
+//! **Design we mirror:** Mooncake's engine moves bytes *one-sidedly* between
+//! *registered memory* regions addressed by `(segment, offset)` — NOT by key
+//! (keys live in the store layer). Each engine owns one RAM segment (a
+//! registered byte arena); a peer [`engine::TransferEngine::open_segment`]s it
+//! and [`engine::TransferEngine::submit_transfer`]s READ/WRITE requests against
+//! `(target_id, target_offset)`. TCP is the real, portable backend; RDMA /
+//! GPUDirect / NVMe-oF are the reserved seams (need a NIC / GPU) — nothing above
+//! the [`transport::Transport`] trait changes when they land.
+//!
+//! This is Phase 1 of the Mooncake-faithful restructure: the store
+//! (`quillcache-store`) is rebuilt on this engine in a later phase.
+
+pub mod engine;
+pub mod metadata;
+pub mod multi_transport;
+pub mod topology;
+pub mod transport;
+
+pub use engine::TransferEngine;
+pub use metadata::{BufferDesc, InMemoryMetadata, MetadataBackend, SegmentDesc};
+pub use multi_transport::MultiTransport;
+pub use topology::Topology;
+pub use transport::{
+    BatchId, LinkClass, OpCode, SegmentId, TransferError, TransferRequest, TransferStatus,
+    TransferStatusEnum, Transport,
+};

--- a/crates/quillcache-transfer-engine/src/metadata.rs
+++ b/crates/quillcache-transfer-engine/src/metadata.rs
@@ -1,0 +1,72 @@
+//! TransferMetadata (Mooncake's `transfer_metadata.h`) — segment discovery and
+//! handshake. A node publishes its [`SegmentDesc`] (name, protocol, endpoint,
+//! buffers); peers look it up to `open_segment`. The backend is pluggable
+//! (Mooncake: `etcd://` / `redis://` / `http://` / `P2PHANDSHAKE`). Here an
+//! in-memory backend is the P2PHANDSHAKE / single-process analogue; etcd / redis
+//! / http are the reserved seams (need a metadata server or cluster) and plug in
+//! behind [`MetadataBackend`].
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A registered buffer within a segment (Mooncake's `BufferDesc`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BufferDesc {
+    pub offset: u64,
+    pub length: u64,
+}
+
+/// A node's RAM segment descriptor (Mooncake's `SegmentDesc`): how to reach it
+/// and what it exposes. The minimal fields needed to discover + open a segment;
+/// the topology / device list is added when an RDMA backend needs path selection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SegmentDesc {
+    pub name: String,
+    pub protocol: String,
+    pub endpoint: String,
+    pub buffers: Vec<BufferDesc>,
+}
+
+/// The metadata storage seam (Mooncake's `MetadataStoragePlugin`): resolve a
+/// segment name → its descriptor. etcd / redis / http backends implement this.
+pub trait MetadataBackend: Send + Sync + std::fmt::Debug {
+    fn put_segment(&self, desc: SegmentDesc);
+    fn get_segment(&self, name: &str) -> Option<SegmentDesc>;
+    fn remove_segment(&self, name: &str);
+    fn segment_names(&self) -> Vec<String>;
+}
+
+/// In-memory metadata — the P2PHANDSHAKE / single-process backend. Two engines
+/// sharing one `Arc<InMemoryMetadata>` discover each other with no external store.
+#[derive(Debug, Default)]
+pub struct InMemoryMetadata {
+    segments: Mutex<HashMap<String, SegmentDesc>>,
+}
+
+impl InMemoryMetadata {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MetadataBackend for InMemoryMetadata {
+    fn put_segment(&self, desc: SegmentDesc) {
+        self.segments
+            .lock()
+            .unwrap()
+            .insert(desc.name.clone(), desc);
+    }
+
+    fn get_segment(&self, name: &str) -> Option<SegmentDesc> {
+        self.segments.lock().unwrap().get(name).cloned()
+    }
+
+    fn remove_segment(&self, name: &str) {
+        self.segments.lock().unwrap().remove(name);
+    }
+
+    fn segment_names(&self) -> Vec<String> {
+        self.segments.lock().unwrap().keys().cloned().collect()
+    }
+}

--- a/crates/quillcache-transfer-engine/src/multi_transport.rs
+++ b/crates/quillcache-transfer-engine/src/multi_transport.rs
@@ -1,0 +1,33 @@
+//! MultiTransport (Mooncake's `multi_transport.h`) — the registry of installed
+//! transports plus per-request backend selection. The engine installs one
+//! backend per protocol (`"tcp"`, `"rdma"`, …) and selects by the target
+//! segment's protocol. Mooncake's `MultiTransport::selectTransport` also weighs
+//! topology; that hook lands with the RDMA backend.
+
+use crate::transport::Transport;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct MultiTransport {
+    transports: HashMap<String, Arc<dyn Transport>>,
+}
+
+impl MultiTransport {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn install(&mut self, protocol: impl Into<String>, transport: Arc<dyn Transport>) {
+        self.transports.insert(protocol.into(), transport);
+    }
+
+    /// Pick the backend for a target segment's protocol.
+    pub fn select(&self, protocol: &str) -> Option<Arc<dyn Transport>> {
+        self.transports.get(protocol).cloned()
+    }
+
+    pub fn installed(&self) -> Vec<String> {
+        self.transports.keys().cloned().collect()
+    }
+}

--- a/crates/quillcache-transfer-engine/src/topology.rs
+++ b/crates/quillcache-transfer-engine/src/topology.rs
@@ -1,0 +1,35 @@
+//! Topology (Mooncake's `topology.h`) — the NIC / GPU affinity matrix that drives
+//! topology-aware path selection and multi-NIC striping. On a laptop there is one
+//! TCP "device"; this keeps the seam so an RDMA backend can stripe across NICs by
+//! a buffer's `location` (which GPU / NUMA node it is near) without changing any
+//! caller. Mooncake calls this the `priority_matrix`.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct Topology {
+    /// location (e.g. `"cpu:0"`, `"cuda:0"`) → preferred device names, best first.
+    matrix: HashMap<String, Vec<String>>,
+}
+
+impl Topology {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_preference(&mut self, location: impl Into<String>, devices: Vec<String>) {
+        self.matrix.insert(location.into(), devices);
+    }
+
+    /// The preferred device for a buffer's location (first in its priority list).
+    pub fn select_device(&self, location: &str) -> Option<&str> {
+        self.matrix
+            .get(location)
+            .and_then(|devices| devices.first())
+            .map(|s| s.as_str())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.matrix.is_empty()
+    }
+}

--- a/crates/quillcache-transfer-engine/src/transport.rs
+++ b/crates/quillcache-transfer-engine/src/transport.rs
@@ -1,0 +1,112 @@
+//! The `Transport` seam (Mooncake's `transport/transport.h`) plus its request /
+//! status types. A backend moves bytes one-sidedly against a remote node's RAM
+//! segment by `(offset, length)`; the engine selects a backend per request via
+//! [`crate::multi_transport::MultiTransport`].
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+pub mod rdma;
+pub mod tcp;
+
+/// An opaque handle to an opened remote segment (Mooncake's `SegmentID`).
+pub type SegmentId = i64;
+/// A submitted transfer batch (Mooncake's `BatchID`).
+pub type BatchId = u64;
+
+/// Transfer direction — read from / write to the remote segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpCode {
+    Read,
+    Write,
+}
+
+/// Lifecycle of a submitted batch (Mooncake's `TransferStatusEnum`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferStatusEnum {
+    Waiting,
+    Pending,
+    Completed,
+    Failed,
+    Timeout,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransferStatus {
+    pub state: TransferStatusEnum,
+    pub transferred_bytes: u64,
+}
+
+/// The physical link a transfer rides — feeds topology-aware path selection and
+/// the store's cost model (HBM < NVLink < RDMA < TCP).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkClass {
+    LocalShm,
+    Nvlink,
+    RdmaIb,
+    RdmaRoce,
+    Tcp,
+}
+
+impl LinkClass {
+    pub fn name(self) -> &'static str {
+        match self {
+            LinkClass::LocalShm => "local-shm",
+            LinkClass::Nvlink => "nvlink",
+            LinkClass::RdmaIb => "rdma-ib",
+            LinkClass::RdmaRoce => "rdma-roce",
+            LinkClass::Tcp => "tcp",
+        }
+    }
+}
+
+/// A one-sided transfer between local registered memory (`source_offset` in this
+/// node's RAM segment) and a remote segment at `(target_id, target_offset)` —
+/// mirrors Mooncake's
+/// `TransferRequest{ opcode, source, target_id, target_offset, length }`.
+#[derive(Debug, Clone)]
+pub struct TransferRequest {
+    pub opcode: OpCode,
+    pub source_offset: u64,
+    pub target_id: SegmentId,
+    pub target_offset: u64,
+    pub length: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransferError {
+    #[error("segment or object not found")]
+    NotFound,
+    #[error("unknown target segment handle")]
+    BadSegment,
+    #[error("io: {0}")]
+    Io(String),
+    #[error("protocol error: {0}")]
+    Protocol(String),
+    #[error("unsupported: {0}")]
+    Unsupported(&'static str),
+}
+
+/// Move bytes to / from a remote node's RAM segment. Backends differ only in the
+/// wire (TCP now; RDMA / NVMe-oF / GPU reserved). The store layer maps object
+/// keys to `(segment, offset)`; this trait is key-agnostic, exactly like
+/// Mooncake's transport.
+#[async_trait]
+pub trait Transport: Send + Sync + std::fmt::Debug {
+    fn name(&self) -> &str;
+    fn link_class(&self) -> LinkClass;
+    /// Read `length` bytes from `endpoint`'s segment starting at `offset`.
+    async fn read_remote(
+        &self,
+        endpoint: &str,
+        offset: u64,
+        length: u64,
+    ) -> Result<Bytes, TransferError>;
+    /// Write `data` into `endpoint`'s segment starting at `offset`.
+    async fn write_remote(
+        &self,
+        endpoint: &str,
+        offset: u64,
+        data: Bytes,
+    ) -> Result<(), TransferError>;
+}

--- a/crates/quillcache-transfer-engine/src/transport/rdma.rs
+++ b/crates/quillcache-transfer-engine/src/transport/rdma.rs
@@ -1,0 +1,45 @@
+//! RDMA backend (Mooncake's `RdmaTransport`, ibverbs / GPUDirect-RDMA) — the
+//! reserved seam. RDMA is Mooncake's *primary* path (and its core IP: one-sided
+//! RDMA READ/WRITE, multi-NIC striping, GPUDirect HBM↔NIC zero-copy). It needs
+//! an RDMA NIC, so it is stubbed until hardware is wired — the real impl
+//! registers memory regions (`lkey`/`rkey`), opens queue pairs, and posts
+//! one-sided verbs. Nothing above the [`Transport`] trait changes when it lands;
+//! build the real version behind `--features rdma`.
+
+use super::{LinkClass, TransferError, Transport};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+#[derive(Debug, Default)]
+pub struct RdmaTransport;
+
+const NEEDS_NIC: &str = "RDMA transport requires an ibverbs NIC (reserved; build with --features rdma once a NIC is wired)";
+
+#[async_trait]
+impl Transport for RdmaTransport {
+    fn name(&self) -> &str {
+        "rdma"
+    }
+
+    fn link_class(&self) -> LinkClass {
+        LinkClass::RdmaIb
+    }
+
+    async fn read_remote(
+        &self,
+        _endpoint: &str,
+        _offset: u64,
+        _length: u64,
+    ) -> Result<Bytes, TransferError> {
+        Err(TransferError::Unsupported(NEEDS_NIC))
+    }
+
+    async fn write_remote(
+        &self,
+        _endpoint: &str,
+        _offset: u64,
+        _data: Bytes,
+    ) -> Result<(), TransferError> {
+        Err(TransferError::Unsupported(NEEDS_NIC))
+    }
+}

--- a/crates/quillcache-transfer-engine/src/transport/tcp.rs
+++ b/crates/quillcache-transfer-engine/src/transport/tcp.rs
@@ -1,0 +1,136 @@
+//! TCP backend (Mooncake's `TcpTransport`) — the portable, always-available
+//! transport. Moves bytes one-sidedly against a peer's RAM segment by
+//! `(offset, length)`: READ pulls a range, WRITE pushes a range. This is the
+//! real path on any machine; the RDMA backend supersedes it where a NIC exists.
+
+use super::{LinkClass, TransferError, Transport};
+use async_trait::async_trait;
+use bytes::Bytes;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const OP_READ: u8 = 0;
+const OP_WRITE: u8 = 1;
+const ST_OK: u8 = 0;
+const ST_ERR: u8 = 2;
+
+#[derive(Debug, Default)]
+pub struct TcpTransport;
+
+#[async_trait]
+impl Transport for TcpTransport {
+    fn name(&self) -> &str {
+        "tcp"
+    }
+
+    fn link_class(&self) -> LinkClass {
+        LinkClass::Tcp
+    }
+
+    async fn read_remote(
+        &self,
+        endpoint: &str,
+        offset: u64,
+        length: u64,
+    ) -> Result<Bytes, TransferError> {
+        let mut sock = TcpStream::connect(endpoint).await.map_err(io_err)?;
+        sock.write_u8(OP_READ).await.map_err(io_err)?;
+        sock.write_u64(offset).await.map_err(io_err)?;
+        sock.write_u64(length).await.map_err(io_err)?;
+        let status = sock.read_u8().await.map_err(io_err)?;
+        if status != ST_OK {
+            return Err(TransferError::Protocol(
+                "remote read out of segment bounds".into(),
+            ));
+        }
+        let len = sock.read_u64().await.map_err(io_err)?;
+        let mut buf = vec![0u8; len as usize];
+        sock.read_exact(&mut buf).await.map_err(io_err)?;
+        Ok(Bytes::from(buf))
+    }
+
+    async fn write_remote(
+        &self,
+        endpoint: &str,
+        offset: u64,
+        data: Bytes,
+    ) -> Result<(), TransferError> {
+        let mut sock = TcpStream::connect(endpoint).await.map_err(io_err)?;
+        sock.write_u8(OP_WRITE).await.map_err(io_err)?;
+        sock.write_u64(offset).await.map_err(io_err)?;
+        sock.write_u64(data.len() as u64).await.map_err(io_err)?;
+        sock.write_all(&data).await.map_err(io_err)?;
+        let status = sock.read_u8().await.map_err(io_err)?;
+        if status != ST_OK {
+            return Err(TransferError::Protocol("remote write failed".into()));
+        }
+        Ok(())
+    }
+}
+
+fn io_err(e: std::io::Error) -> TransferError {
+    TransferError::Io(e.to_string())
+}
+
+/// Serve a node's RAM segment to peers: handle READ / WRITE frames against the
+/// shared byte arena. Each connection may issue many ops. A WRITE past the
+/// current end grows the arena (zero-filled) — the segment owns its registered
+/// space. Spawned by [`crate::engine::TransferEngine::init`].
+pub async fn serve_segment(listener: TcpListener, segment: Arc<Mutex<Vec<u8>>>) {
+    loop {
+        let Ok((sock, _)) = listener.accept().await else {
+            return;
+        };
+        let segment = segment.clone();
+        tokio::spawn(async move {
+            let _ = handle_conn(sock, segment).await;
+        });
+    }
+}
+
+async fn handle_conn(mut sock: TcpStream, segment: Arc<Mutex<Vec<u8>>>) -> std::io::Result<()> {
+    loop {
+        let op = match sock.read_u8().await {
+            Ok(op) => op,
+            Err(_) => return Ok(()), // peer closed
+        };
+        let offset = sock.read_u64().await? as usize;
+        let len = sock.read_u64().await? as usize;
+        match op {
+            OP_READ => {
+                let data = {
+                    let seg = segment.lock().unwrap();
+                    match offset.checked_add(len) {
+                        Some(end) if end <= seg.len() => {
+                            Some(Bytes::copy_from_slice(&seg[offset..end]))
+                        }
+                        _ => None,
+                    }
+                };
+                match data {
+                    Some(bytes) => {
+                        sock.write_u8(ST_OK).await?;
+                        sock.write_u64(bytes.len() as u64).await?;
+                        sock.write_all(&bytes).await?;
+                    }
+                    None => sock.write_u8(ST_ERR).await?,
+                }
+            }
+            OP_WRITE => {
+                let mut buf = vec![0u8; len];
+                sock.read_exact(&mut buf).await?;
+                {
+                    let mut seg = segment.lock().unwrap();
+                    let end = offset + len;
+                    if seg.len() < end {
+                        seg.resize(end, 0);
+                    }
+                    seg[offset..end].copy_from_slice(&buf);
+                }
+                sock.write_u8(ST_OK).await?;
+            }
+            _ => return Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
**Phase 1 of N** restructuring QuillCache to mirror [Mooncake](https://github.com/kvcache-ai/Mooncake)'s component decomposition (FAST'25). This crate is the faithful Rust port of `mooncake-transfer-engine`.

## Component map (Mooncake C++ → this crate)

| Mooncake | here |
| --- | --- |
| `TransferEngine` (`transfer_engine.h`) | `engine::TransferEngine` facade |
| `MultiTransport` (`multi_transport.h`) | `multi_transport::MultiTransport` |
| `Transport` + subclasses (`transport/*`) | `transport::Transport` + backends |
| &nbsp;&nbsp;`TcpTransport` | `transport::tcp::TcpTransport` — **real** |
| &nbsp;&nbsp;`RdmaTransport` (ibverbs) | `transport::rdma::RdmaTransport` — reserved |
| `TransferMetadata` (`transfer_metadata.h`) | `metadata` (`SegmentDesc`, `MetadataBackend`) |
| `Topology` (`topology.h`) | `topology::Topology` |

## Design faithfully mirrored

Mooncake's engine moves bytes **one-sidedly between registered memory by `(segment, offset)`** — *not* by key (keys live in the store layer). Each engine owns one RAM segment (a registered byte arena); a peer `open_segment`s it and `submit_transfer`s READ/WRITE requests against `(target_id, target_offset)`. The faithful flow: `init` → `register_local_memory` → `open_segment` → `allocate_batch_id` → `submit_transfer` → `get_transfer_status` → `free_batch_id`.

## Verified

Two `TransferEngine`s over **real TCP**, sharing an in-memory (P2PHANDSHAKE-style) metadata backend: B opens A's segment and **READs** bytes into local registered memory, then **WRITEs** a buffer into A's segment; A reads it back. Opening an unpublished segment is a clean `NotFound`.

- `transport::rdma::RdmaTransport` returns `Unsupported` until a NIC is wired (`--features rdma`) — the reserved seam, nothing above the `Transport` trait changes when it lands.
- ~53 tests pass; `cargo fmt` + `clippy` clean.

The store still uses its own transfer module; **Phase 2** rebuilds the store (`Client` / `MasterService` / `BufferAllocator` / `Replica`, two-phase `Put`) on this engine, folding in the identity guard + crash-consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Transfer Engine crate enabling one-sided remote memory operations
  * Added TCP transport for reading and writing data across network segments
  * Implemented metadata management for segment discovery and registration
  * Added device topology support for location-based device preferences
  * Enabled batch transfer operations with status tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->