### PR TITLE
feat(store): Mooncake-store data model + buffer allocator (Phase 2a)

### DIFF
--- a/crates/quillcache-store/src/allocation_strategy.rs
+++ b/crates/quillcache-store/src/allocation_strategy.rs
@@ -1,0 +1,195 @@
+//! Allocation strategy (Mooncake's `mooncake-store/include/allocation_strategy.h`):
+//! given the per-segment [`BufferAllocator`]s, choose which segment(s) to place
+//! an object's replicas on. Each replica lands on a **distinct** segment.
+//!
+//! - [`RandomAllocationStrategy`] (Mooncake's default) — spread across segments.
+//! - [`FreeRatioFirstAllocationStrategy`] — prefer the emptiest segments.
+//!
+//! (Mooncake's `Random` shuffles for load spread; this port picks distinct
+//! candidates in a deterministic order so the placement is testable — the
+//! invariant that matters, one segment per replica, is identical.)
+
+use crate::allocator::{AllocatedBuffer, BufferAllocator};
+use crate::types::ErrorCode;
+
+/// Choose segments and allocate one buffer of `size` per replica.
+pub trait AllocationStrategy: std::fmt::Debug + Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Allocate `replica_num` buffers of `size`, each on a distinct segment,
+    /// honouring `preferred` (placed first) and `excluded` (skipped). Fails with
+    /// [`ErrorCode::NoAvailableSegment`] if fewer than `replica_num` segments can
+    /// fit it.
+    fn allocate(
+        &self,
+        allocators: &mut [Box<dyn BufferAllocator>],
+        size: u64,
+        replica_num: usize,
+        preferred: Option<&str>,
+        excluded: &[String],
+    ) -> Result<Vec<AllocatedBuffer>, ErrorCode>;
+}
+
+/// Segment indices that aren't excluded and can fit `size`.
+fn candidates(
+    allocators: &[Box<dyn BufferAllocator>],
+    size: u64,
+    excluded: &[String],
+) -> Vec<usize> {
+    (0..allocators.len())
+        .filter(|&i| {
+            let a = &allocators[i];
+            a.largest_free_region() >= size && !excluded.iter().any(|e| e == a.segment_name())
+        })
+        .collect()
+}
+
+fn free_ratio(a: &dyn BufferAllocator) -> f64 {
+    if a.capacity() == 0 {
+        0.0
+    } else {
+        (a.capacity() - a.allocated()) as f64 / a.capacity() as f64
+    }
+}
+
+/// Allocate one buffer of `size` on the first `replica_num` of `ordered`.
+fn place(
+    allocators: &mut [Box<dyn BufferAllocator>],
+    ordered: &[usize],
+    size: u64,
+    replica_num: usize,
+) -> Result<Vec<AllocatedBuffer>, ErrorCode> {
+    if ordered.len() < replica_num {
+        return Err(ErrorCode::NoAvailableSegment);
+    }
+    let mut out = Vec::with_capacity(replica_num);
+    for &i in ordered.iter().take(replica_num) {
+        out.push(
+            allocators[i]
+                .allocate(size)
+                .ok_or(ErrorCode::NoAvailableSegment)?,
+        );
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Default)]
+pub struct RandomAllocationStrategy;
+
+impl AllocationStrategy for RandomAllocationStrategy {
+    fn name(&self) -> &str {
+        "random"
+    }
+
+    fn allocate(
+        &self,
+        allocators: &mut [Box<dyn BufferAllocator>],
+        size: u64,
+        replica_num: usize,
+        preferred: Option<&str>,
+        excluded: &[String],
+    ) -> Result<Vec<AllocatedBuffer>, ErrorCode> {
+        let mut order = candidates(allocators, size, excluded);
+        if let Some(pref) = preferred {
+            // Stable sort: the preferred segment floats to the front, rest hold order.
+            order.sort_by_key(|&i| allocators[i].segment_name() != pref);
+        }
+        place(allocators, &order, size, replica_num)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FreeRatioFirstAllocationStrategy;
+
+impl AllocationStrategy for FreeRatioFirstAllocationStrategy {
+    fn name(&self) -> &str {
+        "free_ratio_first"
+    }
+
+    fn allocate(
+        &self,
+        allocators: &mut [Box<dyn BufferAllocator>],
+        size: u64,
+        replica_num: usize,
+        preferred: Option<&str>,
+        excluded: &[String],
+    ) -> Result<Vec<AllocatedBuffer>, ErrorCode> {
+        let mut order = candidates(allocators, size, excluded);
+        // Emptiest segment first (descending free ratio).
+        order.sort_by(|&a, &b| {
+            free_ratio(allocators[b].as_ref())
+                .partial_cmp(&free_ratio(allocators[a].as_ref()))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        if let Some(pref) = preferred {
+            order.sort_by_key(|&i| allocators[i].segment_name() != pref);
+        }
+        place(allocators, &order, size, replica_num)
+    }
+}
+
+/// Build a strategy from its config name (Mooncake's `CreateAllocationStrategy`).
+pub fn create_allocation_strategy(name: &str) -> Box<dyn AllocationStrategy> {
+    match name {
+        "free_ratio_first" => Box::new(FreeRatioFirstAllocationStrategy),
+        _ => Box::new(RandomAllocationStrategy),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allocator::OffsetBufferAllocator;
+
+    fn fleet() -> Vec<Box<dyn BufferAllocator>> {
+        vec![
+            Box::new(OffsetBufferAllocator::new("seg-0", 100)),
+            Box::new(OffsetBufferAllocator::new("seg-1", 100)),
+            Box::new(OffsetBufferAllocator::new("seg-2", 100)),
+        ]
+    }
+
+    #[test]
+    fn each_replica_lands_on_a_distinct_segment() {
+        let mut a = fleet();
+        let bufs = RandomAllocationStrategy
+            .allocate(&mut a, 10, 2, None, &[])
+            .unwrap();
+        assert_eq!(bufs.len(), 2);
+        assert_ne!(bufs[0].segment_name, bufs[1].segment_name);
+    }
+
+    #[test]
+    fn not_enough_segments_is_an_error() {
+        let mut a = fleet();
+        // 4 replicas, only 3 segments → cannot place.
+        assert_eq!(
+            RandomAllocationStrategy.allocate(&mut a, 10, 4, None, &[]),
+            Err(ErrorCode::NoAvailableSegment)
+        );
+    }
+
+    #[test]
+    fn excluded_segment_is_skipped() {
+        let mut a = fleet();
+        let bufs = RandomAllocationStrategy
+            .allocate(&mut a, 10, 2, None, &["seg-1".to_string()])
+            .unwrap();
+        assert!(bufs.iter().all(|b| b.segment_name != "seg-1"));
+    }
+
+    #[test]
+    fn free_ratio_first_prefers_the_emptiest_segments() {
+        let mut a = fleet();
+        // Fill seg-0 most, seg-1 a little; seg-2 stays empty.
+        a[0].allocate(90);
+        a[1].allocate(30);
+        let bufs = FreeRatioFirstAllocationStrategy
+            .allocate(&mut a, 10, 2, None, &[])
+            .unwrap();
+        let picked: Vec<&str> = bufs.iter().map(|b| b.segment_name.as_str()).collect();
+        // The two emptiest (seg-2, seg-1) are chosen; the near-full seg-0 is not.
+        assert!(picked.contains(&"seg-2") && picked.contains(&"seg-1"));
+        assert!(!picked.contains(&"seg-0"));
+    }
+}

--- a/crates/quillcache-store/src/allocator.rs
+++ b/crates/quillcache-store/src/allocator.rs
@@ -1,0 +1,164 @@
+//! Buffer allocator (Mooncake's `mooncake-store/include/allocator.h` +
+//! `offset_allocator/`). A mounted RAM segment is a fixed-size byte arena; the
+//! allocator hands out offset ranges within it. [`OffsetBufferAllocator`] is the
+//! default backend — Mooncake's is an O(1) size-binned offset allocator; this is
+//! a first-fit free-list with coalescing-on-free, the same `allocate` /
+//! `deallocate` / `largest_free_region` contract with simpler internals.
+
+use crate::types::SegmentName;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A buffer allocated from a segment (Mooncake's `AllocatedBuffer`): a
+/// `(segment, offset, size)` triple naming where an object's bytes live so the
+/// transfer engine can address them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AllocatedBuffer {
+    pub segment_name: SegmentName,
+    pub offset: u64,
+    pub size: u64,
+}
+
+impl AllocatedBuffer {
+    pub fn segment_name(&self) -> &str {
+        &self.segment_name
+    }
+}
+
+/// A per-segment buffer allocator (Mooncake's `BufferAllocatorBase`).
+pub trait BufferAllocator: std::fmt::Debug + Send + Sync {
+    fn segment_name(&self) -> &str;
+    fn capacity(&self) -> u64;
+    /// Bytes currently handed out.
+    fn allocated(&self) -> u64;
+    /// Allocate `size` bytes; `None` if no free region is large enough.
+    fn allocate(&mut self, size: u64) -> Option<AllocatedBuffer>;
+    /// Return a buffer's range to the free list (coalescing with neighbours).
+    fn deallocate(&mut self, buffer: &AllocatedBuffer);
+    /// The largest single contiguous free region (the biggest allocatable size).
+    fn largest_free_region(&self) -> u64;
+}
+
+/// First-fit offset allocator over a sorted free-list of `offset -> length`
+/// regions, coalescing adjacent free ranges on `deallocate`.
+#[derive(Debug)]
+pub struct OffsetBufferAllocator {
+    segment_name: SegmentName,
+    capacity: u64,
+    /// Non-overlapping free regions, keyed by offset (so neighbours are adjacent).
+    free: BTreeMap<u64, u64>,
+    allocated: u64,
+}
+
+impl OffsetBufferAllocator {
+    pub fn new(segment_name: impl Into<SegmentName>, capacity: u64) -> Self {
+        let mut free = BTreeMap::new();
+        if capacity > 0 {
+            free.insert(0, capacity);
+        }
+        Self {
+            segment_name: segment_name.into(),
+            capacity,
+            free,
+            allocated: 0,
+        }
+    }
+}
+
+impl BufferAllocator for OffsetBufferAllocator {
+    fn segment_name(&self) -> &str {
+        &self.segment_name
+    }
+
+    fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    fn allocated(&self) -> u64 {
+        self.allocated
+    }
+
+    fn allocate(&mut self, size: u64) -> Option<AllocatedBuffer> {
+        if size == 0 {
+            return None;
+        }
+        // First-fit: the first free region large enough.
+        let (offset, region_len) = self
+            .free
+            .iter()
+            .find(|(_, &len)| len >= size)
+            .map(|(&off, &len)| (off, len))?;
+        self.free.remove(&offset);
+        if region_len > size {
+            // The remainder stays free, starting just past the allocation.
+            self.free.insert(offset + size, region_len - size);
+        }
+        self.allocated += size;
+        Some(AllocatedBuffer {
+            segment_name: self.segment_name.clone(),
+            offset,
+            size,
+        })
+    }
+
+    fn deallocate(&mut self, buffer: &AllocatedBuffer) {
+        let mut start = buffer.offset;
+        let mut end = buffer.offset + buffer.size;
+        // Coalesce with the region immediately before, if it abuts us.
+        let prev = self.free.range(..start).next_back().map(|(&o, &l)| (o, l));
+        if let Some((p_off, p_len)) = prev {
+            if p_off + p_len == start {
+                start = p_off;
+                self.free.remove(&p_off);
+            }
+        }
+        // Coalesce with the region immediately after, if it abuts us.
+        let next = self.free.range(end..).next().map(|(&o, &l)| (o, l));
+        if let Some((n_off, n_len)) = next {
+            if n_off == end {
+                end = n_off + n_len;
+                self.free.remove(&n_off);
+            }
+        }
+        self.free.insert(start, end - start);
+        self.allocated = self.allocated.saturating_sub(buffer.size);
+    }
+
+    fn largest_free_region(&self) -> u64 {
+        self.free.values().copied().max().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_split_and_fail_when_too_fragmented() {
+        let mut a = OffsetBufferAllocator::new("seg-0", 100);
+        let b1 = a.allocate(40).unwrap();
+        assert_eq!(b1.offset, 0);
+        let b2 = a.allocate(40).unwrap();
+        assert_eq!(b2.offset, 40);
+        assert_eq!(a.allocated(), 80);
+        assert_eq!(a.largest_free_region(), 20);
+        // Only 20 contiguous bytes left — a 30-byte request can't be served.
+        assert!(a.allocate(30).is_none());
+    }
+
+    #[test]
+    fn deallocate_coalesces_adjacent_free_regions() {
+        let mut a = OffsetBufferAllocator::new("seg-0", 100);
+        let b1 = a.allocate(50).unwrap(); // [0,50)
+        let b2 = a.allocate(50).unwrap(); // [50,100) — segment full
+        assert_eq!(a.largest_free_region(), 0);
+        // Free both out of order; the two halves must coalesce back to one 100B
+        // region, not stay as two 50B fragments.
+        a.deallocate(&b2);
+        a.deallocate(&b1);
+        assert_eq!(a.allocated(), 0);
+        assert_eq!(a.largest_free_region(), 100);
+        // And a full-size allocation succeeds again.
+        assert_eq!(a.allocate(100).unwrap().offset, 0);
+    }
+}

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -34,6 +34,22 @@ use tokio::sync::broadcast;
 pub mod transfer;
 pub use transfer::*;
 
+// The Mooncake-`store`-aligned data plane (Phase 2): object/replica model, the
+// per-segment buffer allocator, and the replica placement strategy. The
+// MasterService (two-phase Put) and Client are built on these next.
+pub mod allocation_strategy;
+pub mod allocator;
+pub mod replica;
+pub mod types;
+
+pub use allocation_strategy::{
+    create_allocation_strategy, AllocationStrategy, FreeRatioFirstAllocationStrategy,
+    RandomAllocationStrategy,
+};
+pub use allocator::{AllocatedBuffer, BufferAllocator, OffsetBufferAllocator};
+pub use replica::{Replica, ReplicaData, ReplicaList, ReplicaStatus};
+pub use types::{ErrorCode, ObjectKey, ReplicaId, ReplicateConfig, SegmentName, Slice};
+
 // =====================================================================
 // LocalKvStore — the real KV byte pool (DRAM + SSD), identity-guarded.
 // =====================================================================

--- a/crates/quillcache-store/src/replica.rs
+++ b/crates/quillcache-store/src/replica.rs
@@ -1,0 +1,137 @@
+//! Replica model (Mooncake's `mooncake-store/include/replica.h`). An object's
+//! bytes can live in several places at once; each is a [`Replica`]. A replica is
+//! either in a mounted RAM segment ([`ReplicaData::Memory`]) or on a node's
+//! durable disk tier ([`ReplicaData::Disk`]) — the latter is QuillCache's
+//! crash-consistent persistent tier (Mooncake's pool is volatile DRAM).
+
+use crate::allocator::AllocatedBuffer;
+use crate::types::ReplicaId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A replica's lifecycle (Mooncake's `ReplicaStatus`). The two-phase `Put`
+/// drives `Initialized` → (client writes) → `Complete`; `Processing` is the
+/// in-flight window, `Failed`/`Removed` the terminal aborts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplicaStatus {
+    Undefined,
+    Initialized,
+    Processing,
+    Complete,
+    Removed,
+    Failed,
+}
+
+/// Where a replica's bytes live (Mooncake's `MemoryReplicaData` /
+/// `DiskReplicaData` variant).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReplicaData {
+    /// In a mounted RAM segment, at an allocated buffer.
+    Memory(AllocatedBuffer),
+    /// On a node's durable SSD tier — file-backed, crash-consistent (the
+    /// QuillCache persistent tier, addressed by the owning node + path).
+    Disk { file_path: String, object_size: u64 },
+}
+
+impl ReplicaData {
+    pub fn segment_name(&self) -> Option<&str> {
+        match self {
+            ReplicaData::Memory(buffer) => Some(buffer.segment_name()),
+            ReplicaData::Disk { .. } => None,
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        match self {
+            ReplicaData::Memory(buffer) => buffer.size,
+            ReplicaData::Disk { object_size, .. } => *object_size,
+        }
+    }
+
+    pub fn is_disk(&self) -> bool {
+        matches!(self, ReplicaData::Disk { .. })
+    }
+}
+
+/// One copy of an object (Mooncake's `Replica`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Replica {
+    pub id: ReplicaId,
+    pub status: ReplicaStatus,
+    pub ref_count: u32,
+    pub data: ReplicaData,
+}
+
+impl Replica {
+    /// A freshly-allocated replica, before the client has written its bytes.
+    pub fn new(id: ReplicaId, data: ReplicaData) -> Self {
+        Self {
+            id,
+            status: ReplicaStatus::Initialized,
+            ref_count: 0,
+            data,
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.status == ReplicaStatus::Complete
+    }
+
+    pub fn segment_name(&self) -> Option<&str> {
+        self.data.segment_name()
+    }
+
+    pub fn size(&self) -> u64 {
+        self.data.size()
+    }
+}
+
+/// All replicas of one object (Mooncake's `ReplicaList`).
+pub type ReplicaList = HashMap<ReplicaId, Replica>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem(id: ReplicaId, off: u64) -> Replica {
+        Replica::new(
+            id,
+            ReplicaData::Memory(AllocatedBuffer {
+                segment_name: "seg-0".into(),
+                offset: off,
+                size: 64,
+            }),
+        )
+    }
+
+    #[test]
+    fn replica_starts_initialized_and_completes() {
+        let mut r = mem(0, 0);
+        assert_eq!(r.status, ReplicaStatus::Initialized);
+        assert!(!r.is_complete());
+        assert_eq!(r.segment_name(), Some("seg-0"));
+        assert_eq!(r.size(), 64);
+        r.status = ReplicaStatus::Complete;
+        assert!(r.is_complete());
+    }
+
+    #[test]
+    fn replica_round_trips_through_serde() {
+        let r = mem(7, 128);
+        let json = serde_json::to_string(&r).unwrap();
+        let back: Replica = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, 7);
+        assert_eq!(back.segment_name(), Some("seg-0"));
+        // A disk replica (the crash-consistent tier) also round-trips.
+        let disk = Replica::new(
+            1,
+            ReplicaData::Disk {
+                file_path: "/pool/obj-1".into(),
+                object_size: 4096,
+            },
+        );
+        let back: Replica = serde_json::from_str(&serde_json::to_string(&disk).unwrap()).unwrap();
+        assert!(back.data.is_disk());
+        assert_eq!(back.size(), 4096);
+    }
+}

--- a/crates/quillcache-store/src/types.rs
+++ b/crates/quillcache-store/src/types.rs
@@ -1,0 +1,86 @@
+//! Store data model (Mooncake's `mooncake-store/include/types.h`).
+//!
+//! Object keys are **opaque strings** whose value is independent of the key
+//! (Mooncake does not content-address — unlike Redis); the prefix-hash chaining
+//! that maps KV-cache blocks to keys lives in the integration / connector layer.
+
+use serde::{Deserialize, Serialize};
+
+/// An opaque object key (Mooncake's `ObjectKey`).
+pub type ObjectKey = String;
+/// A mounted RAM segment's name (Mooncake's segment name).
+pub type SegmentName = String;
+/// A replica's id within an object's [`crate::replica::ReplicaList`].
+pub type ReplicaId = u32;
+
+/// A contiguous byte range to read into / write from (Mooncake's `Slice`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Slice {
+    pub offset: u64,
+    pub size: u64,
+}
+
+/// How an object should be replicated (Mooncake's `ReplicateConfig`): how many
+/// copies, and whether to soft-/hard-pin them against eviction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplicateConfig {
+    pub replica_num: usize,
+    pub with_soft_pin: bool,
+    pub with_hard_pin: bool,
+    pub preferred_segment: Option<SegmentName>,
+}
+
+impl Default for ReplicateConfig {
+    fn default() -> Self {
+        Self {
+            replica_num: 1,
+            with_soft_pin: false,
+            with_hard_pin: false,
+            preferred_segment: None,
+        }
+    }
+}
+
+impl ReplicateConfig {
+    /// `n` replicas, no pinning.
+    pub fn replicas(n: usize) -> Self {
+        Self {
+            replica_num: n.max(1),
+            ..Default::default()
+        }
+    }
+}
+
+/// Store error codes (a representative subset of Mooncake's `ErrorCode`).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ErrorCode {
+    #[error("object not found")]
+    ObjectNotFound,
+    #[error("object already exists")]
+    ObjectAlreadyExists,
+    #[error("object is being written (not yet readable)")]
+    ObjectNotReady,
+    #[error("segment not found")]
+    SegmentNotFound,
+    #[error("no segment has enough free space")]
+    NoAvailableSegment,
+    #[error("buffer overflow")]
+    BufferOverflow,
+    #[error("invalid replica")]
+    InvalidReplica,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replicate_config_defaults_to_one_unpinned_replica() {
+        let cfg = ReplicateConfig::default();
+        assert_eq!(cfg.replica_num, 1);
+        assert!(!cfg.with_soft_pin && !cfg.with_hard_pin);
+        assert_eq!(ReplicateConfig::replicas(3).replica_num, 3);
+        // `replicas(0)` is clamped to a usable single replica.
+        assert_eq!(ReplicateConfig::replicas(0).replica_num, 1);
+    }
+}


### PR DESCRIPTION
**Phase 2a** of rebuilding `quillcache-store` to mirror [`mooncake-store`](https://github.com/kvcache-ai/Mooncake). The object/replica data model + the buffer allocator — all unit-tested with no transfer engine yet.

| module | mirrors | contents |
| --- | --- | --- |
| `types` | `types.h` | `ObjectKey` (opaque string), `SegmentName`, `ReplicaId`, `Slice`, `ReplicateConfig`, `ErrorCode` |
| `replica` | `replica.h` | `Replica{id,status,ref_count,data}`, `ReplicaStatus` (the two-phase-Put lifecycle), `ReplicaData::{Memory,Disk}`, `ReplicaList` |
| `allocator` | `allocator.h` + `offset_allocator/` | `AllocatedBuffer`, `BufferAllocator` trait, `OffsetBufferAllocator` |
| `allocation_strategy` | `allocation_strategy.h` | `AllocationStrategy` trait, `Random` (default) + `FreeRatioFirst` + factory |

## Notes on faithfulness

- `ReplicaData::Disk` is **QuillCache's crash-consistent persistent tier** — Mooncake's pool is volatile DRAM, so this is one of our two differentiators, slotted into the replica variant where it belongs.
- `OffsetBufferAllocator` is a first-fit free-list with **coalescing-on-free** — same `allocate`/`deallocate`/`largest_free_region` contract as Mooncake's O(1) bin allocator, simpler internals (documented).
- `RandomAllocationStrategy` keeps the invariant that matters — **one distinct segment per replica** — deterministically (Mooncake shuffles for spread; documented).

## Verified

- `OffsetBufferAllocator`: split on allocate, fail when too fragmented, **coalesce** two halves back to one region on out-of-order free.
- `AllocationStrategy`: distinct segment per replica, `excluded` honored, not-enough-segments → `NoAvailableSegment`, `FreeRatioFirst` picks the emptiest.
- `Replica` round-trips through serde (incl. the Disk tier).
- Workspace **57 tests** (store 20, +9 new); `fmt` + `clippy` clean.

**Next (2b):** `MasterService` — two-phase `Put` (`PutStart`→write→`PutEnd`/`PutRevoke`), identity-guarded `GetReplicaList`, `Mount`/`Unmount`, eviction (LRU + lease + soft/hard pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced multiple object replica placement strategies for optimized storage distribution across segments
  * Added configurable replication system supporting soft and hard pinning preferences
  * Enhanced storage infrastructure with improved buffer allocation and replica lifecycle management capabilities
  * Extended public API with replica and allocator abstractions for better storage layer control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->