### PR TITLE
docs: align README + the Astro docs site to the faithful Mooncake-port design

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,92 +5,99 @@
 [![page](https://img.shields.io/badge/page-quillcache-5ee0c0.svg)](https://feichai0017.github.io/quillcache/)
 [![crates.io](https://img.shields.io/badge/crates.io-quillcache-orange.svg)](https://crates.io/crates/quillcache)
 
-> **QuillCache is a Mooncake-style distributed KV cache pool and control plane for
-> LLM serving, written in Rust** — replicating the architecture of NVIDIA Dynamo
-> and Moonshot's Mooncake, plus two properties the production data planes leave
-> implicit: **identity-governed safe reuse** and a **crash-consistent persistent
-> tier**.
+> **QuillCache is a faithful Rust port of [Mooncake](https://github.com/kvcache-ai/Mooncake)'s
+> distributed KV cache store** (the KVCache-centric data plane from Moonshot / Kimi,
+> FAST'25) — its component decomposition, code layout, and API mirrored module for
+> module — **plus two properties the production data planes leave implicit:
+> identity-governed safe reuse and a crash-consistent persistent tier.** A
+> cache-aware routing gateway (the Dynamo KV-router cost function) sits in front.
 
 QuillCache sits beside real inference engines (vLLM, SGLang) and owns the KV
-cache as a resource:
+cache as a resource. It does **not** run models — no transformer kernels, no
+attention.
 
-- a **byte pool** — DRAM + SSD tiers that hold real KV block bytes, with
-  capacity-driven demotion and eviction;
-- a **transfer engine** — moves blocks between nodes (TCP today, RDMA reserved);
-- a **residency index** — maps each block (by identity) to where it lives
-  (node + tier), persistent so it survives a restart;
-- a **control plane / Conductor** — routes requests cache-aware (the Dynamo
-  KV-router cost function), governs reuse, and meters SLO.
-
-> It does **not** run models — no transformer kernels, no attention. The CUDA
-> tier moves and quantizes KV *bytes* (the data path), not inference compute.
+- a **Transfer Engine** (`quillcache-transfer-engine`) — moves bytes one-sidedly
+  between *registered memory* by `(segment, offset)`, exactly like Mooncake (TCP
+  today; RDMA / GPUDirect reserved behind the same trait);
+- a **Store** (`quillcache-store`) — a two-phase-Put `Client`, a `MasterService`
+  (object metadata, replica allocation, lease eviction), a buffer allocator, the
+  replica model, and a crash-consistent durable `DiskTier`;
+- a **Gateway / Conductor** — an OpenAI-compatible proxy that routes cache-aware
+  (the Dynamo KV-router cost function), governs reuse, and meters SLO, backed by a
+  persistent residency index.
 
 ## Architecture
 
 ```mermaid
 flowchart TD
     C["Client / benchmark"]
-    G["Gateway — OpenAI proxy · streaming · decision headers · SLO"]
-    K["Control plane / Conductor<br/>router (Dynamo cost fn) · cost model · identity guard<br/>residency index: Holt (ART) / RocksDB (LSM) / Memory"]
-    D["KV cache pool / data plane<br/>StoreDataPlane: HBM / DRAM / SSD tiers (real bytes)<br/>LocalKvStore: byte pool + WAL crash-consistent SSD"]
-    P["Distribution<br/>PooledStore: index-located cross-node fetch · NodeRegistry (etcd analogue)<br/>Transfer engine: TCP / RDMA (reserved)"]
+    G["Gateway — OpenAI proxy · cache-aware routing (Dynamo cost fn) · streaming · SLO"]
     E["Engines (external): vLLM / SGLang"]
-    U["CUDA device tier (feature-gated): HBM↔host · FP8 quantize"]
-    C --> G --> K --> D --> P
-    G --> E
-    P -. moves KV bytes .-> D
-    D -. offload / reload .-> U
+    subgraph S["Mooncake-faithful store (quillcache-store)"]
+      M["MasterService — two-phase Put · replica allocation · lease eviction · identity guard"]
+      CL["Client (Dummy / Real)"]
+      DT["DiskTier — crash-consistent durable replicas (WAL)"]
+      SD["StoreDataPlane / LocalKvStore — HBM/DRAM/SSD byte tiers"]
+    end
+    TE["Transfer Engine (quillcache-transfer-engine)<br/>(segment, offset) one-sided transfers · TCP real / RDMA reserved"]
+    C --> G --> E
+    G -. residency index .-> M
+    CL --> M
+    CL -. move KV bytes .-> TE
+    M -. places replicas .-> SD
+    M -. durable .-> DT
 ```
 
 ## Reference-design mapping
 
-QuillCache replicates the production reference designs piece by piece, then adds
-its differentiation on top:
+QuillCache mirrors Mooncake's decomposition piece by piece, then adds its
+differentiation on top:
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Mooncake Store (pooled DRAM/SSD KV) | `LocalKvStore` + `PooledStore` | ✅ real bytes |
-| Mooncake Transfer Engine | `quillcache-transfer` | ✅ TCP / ⊙ RDMA reserved |
-| Conductor / scheduler | `quillcache-control` + router | ✅ |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma}`) | ✅ TCP / ⊙ RDMA reserved |
+| Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
+| Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
+| `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend` (`InMemoryMetadata`) | ✅ / ⊙ etcd pluggable |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
 | Dynamo KVBM tiers (G1/G2/G3) | `StoreDataPlane` (HBM/DRAM/SSD) | ✅ moves real bytes |
 | Dynamo KV-Cache Indexer | residency index (Holt ART) | ✅ persistent |
-| Dynamo etcd / service discovery | `NodeRegistry` (`StaticRegistry`) | ✅ etcd pluggable |
-| — *(neither does this)* | **identity guard + crash-consistency** | 🎯 differentiation |
+| — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
 
 ## Crates
 
 | crate | role |
 | --- | --- |
-| `quillcache-gateway` | OpenAI-compatible gateway: proxy, streaming, decision headers, SLO goodput |
-| `quillcache-control` | control plane: `plan()` / `observe_placement` / `audit_reuse` |
-| `quillcache-router` | routing policies incl. `DynamoCostRouter` (+ greedy / SLO-aware / session / prefix-affinity / round-robin) |
-| `quillcache-core` | `KvBlockKey` identity, `CostModel`, the `IndexBackend` + `DataPlane` traits, and the ART-vs-LSM `bench` |
-| `quillcache-store` | `LocalKvStore` (crash-consistent byte pool), `StoreDataPlane` (tiers), `PooledStore`, `NodeRegistry` |
-| `quillcache-transfer` | transfer engine: `LocalTransfer` / `TcpTransfer` / `RdmaTransfer` (reserved) |
-| `quillcache-index-holt` | Holt (persistent ART) index backend |
-| `quillcache-index-rocksdb` | RocksDB (LSM) index backend |
-| `quillcache-cuda` | CUDA device tier: HBM↔host copies + FP8 quantize-on-offload (feature-gated, excluded from the workspace) |
+| `quillcache` (bin) | the OpenAI-compatible **gateway** (proxy · cache-aware routing · streaming · SLO), the local **cluster** demo, and `bench-index` |
+| `quillcache-core` | `KvBlockKey` / `IdentityScope` identity, `CostModel`, `ReuseViolation`; the `router` (incl. `DynamoCostRouter`), `control` plane, `DataPlane` + `IndexBackend` traits, the ART-vs-LSM `bench`, and the feature-gated `index_holt` / `index_rocksdb` backends |
+| `quillcache-transfer-engine` | faithful port of Mooncake's Transfer Engine: `TransferEngine` + `MultiTransport` + `Transport` (`tcp` real / `rdma` reserved) + `TransferMetadata` + `Topology` |
+| `quillcache-store` | faithful port of `mooncake-store`: `Client`, `MasterService`, `OffsetBufferAllocator`, `AllocationStrategy`, `Replica`, the crash-consistent `DiskTier`, plus `LocalKvStore` (byte pool) + `StoreDataPlane` (tiers) |
+| `quillcache-cuda` | CUDA device tier: HBM↔host copies + FP8 quantize-on-offload (feature-gated, excluded from the default workspace) |
+
+The two index backends (`index_holt`, `index_rocksdb`) are **feature-gated modules
+inside `quillcache-core`**, off by default — `holt` is pure Rust; `rocksdb` pulls a
+C++/libclang toolchain — so the default build needs neither.
 
 ## Status — wired online vs tested unit vs reserved
 
-Everything here is real code — there is no simulation (the earlier cost-model
-sims were removed). The honest distinction is how far each piece is integrated:
+Everything here is real code — there is no simulation. The honest distinction is
+how far each piece is integrated:
 
-- **✅ wired online & measured** — gateway, control plane, Dynamo-cost routing,
+- **✅ wired online & measured** — the gateway, control plane, Dynamo-cost routing,
   persistent residency index, `StoreDataPlane` moving real bytes across
-  HBM/DRAM/SSD, the identity guard, live SLO goodput, and the ART-vs-LSM storage
-  study.
-- **▣ tested unit (not yet on the online gateway path)** — `PooledStore`
-  cross-node fetch over TCP, and `LocalKvStore::recover` crash recovery. Both are
-  covered by tests; wiring them into the live gateway needs an engine
-  KV-connector for the engine⟷pool byte handoff.
-- **⊙ reserved / needs hardware** — `RdmaTransfer` (behind the `rdma` feature) and
-  the CUDA device tier (build `quillcache-cuda` with `--features cuda` on a GPU
-  box). Both are real interfaces, stubbed/fallback so the default build is
+  HBM/DRAM/SSD, live SLO goodput, and the ART-vs-LSM storage study.
+- **▣ tested unit (not yet on the live gateway path)** — the faithful store: a
+  `Client` Put→Get over the transfer engine (real TCP), the `MasterService`
+  two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
+  recovery. All covered by tests (and the `cluster` demo); wiring them into the
+  live gateway needs an engine KV-connector for the engine⟷store byte handoff.
+- **⊙ reserved / needs hardware** — `RdmaTransport` (behind the `rdma` feature), the
+  etcd metadata backend, and the CUDA device tier (`quillcache-cuda --features
+  cuda` on a GPU box). All real interfaces, stubbed so the default build is
   hardware-free.
 
-`cargo test` — 45 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
+`cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
 
 ## The storage study: ART (Holt) vs LSM (RocksDB)
 
@@ -109,10 +116,9 @@ ART gives the lowest prefix-scan latency (~1.7× faster than LSM at p50, ~50×
 faster than the flat map's O(N) scan), the fastest recovery, and **1× write
 amplification** (append-only — it writes each record once); LSM is far more
 space-efficient on disk but pays **10.6× write amplification** (compaction
-rewrites). Write amplification is measured from RocksDB's own flush/compaction
-statistics, not assumed. Pick ART when prefix-scan latency and recovery dominate
-(the common case for a residency index queried per request), pick LSM when disk
-footprint is the constraint.
+rewrites, measured from RocksDB's own statistics). Pick ART when prefix-scan
+latency and recovery dominate (the common case for a residency index queried per
+request), pick LSM when disk footprint is the constraint.
 
 ## Identity-governed safe reuse
 
@@ -124,26 +130,28 @@ Mooncake / LMCache / KVBM key on) will serve blocks it must not: across
 correctness error.
 
 QuillCache makes the contract explicit: every block carries an `IdentityScope`
-(model · tokenizer · adapter · tenant), and `LocalKvStore::get` serves a block
-only when the requester's identity matches, returning `StoreError::Unsafe`
-otherwise. On a collision-heavy workload, naive content-hash reuse serves
-**96.8% unsafe** while the guard serves **0**; on a realistic mostly-same-identity
-mix the guard's overhead is **~1.7%**. Safety is near-free exactly where it
-matters.
+(model · tokenizer · adapter · tenant), and the guard is enforced at **every**
+serving point — `LocalKvStore::get` and `DiskTier::get` (the byte tiers) and
+`MasterService::get_replica_list` (the metadata layer, *before* any byte moves) —
+refusing a cross-identity read with `ReuseViolation` rather than leaking. Mooncake
+keys are identity-agnostic; this is QuillCache's addition, and it is the same
+guard in memory, on disk, and after crash recovery.
 
-## Crash-consistent SSD tier
+## Crash-consistent durable tier
 
-The SSD tier holds real KV bytes that should survive a restart, so it needs a
-durable, crash-consistent catalog. It uses NoKV-style **object-first atomic
-publish + a WAL**: write the block file → `fsync` → append + `fsync` a commit
-record (the single publish point). On `LocalKvStore::recover` the WAL is replayed
-and each surviving commit is verified against its on-disk file (length + CRC)
-before it re-enters the index. The invariants, proven by test:
+Mooncake's pool is volatile DRAM. QuillCache adds a durable `DiskTier` for `Disk`
+replicas, so KV bytes survive a restart — backed by `LocalKvStore`'s SSD tier,
+which uses NoKV-style **object-first atomic publish + a WAL**: write the block
+file → `fsync` → append + `fsync` a commit record (the single publish point). On
+`recover` the WAL is replayed and each surviving commit is verified against its
+on-disk file (length + CRC) before it re-enters the index. The invariants, proven
+by test:
 
-- a **complete** block recovers and serves the correct bytes (identity-guarded);
+- a **complete** block recovers and serves the correct bytes (identity-guarded,
+  even after recovery);
 - a **half-written / uncommitted** block (file with no commit record) is never served;
 - a **corrupted** block (length / CRC mismatch) is dropped on recovery;
-- a missing file never becomes a **dangling pointer** (the recovered index has no stale entries).
+- a missing file never becomes a **dangling pointer** (no stale entries recovered).
 
 This is the seam Mooncake's volatile-DRAM pool does not occupy: a durable,
 crash-consistent, immediately-reusable persistent tier.
@@ -155,14 +163,19 @@ crash-consistent, immediately-reusable persistent tier.
 cargo build
 cargo test
 
+# Local multi-node cluster demo on the Mooncake-faithful store: N storage-node
+# transfer engines + a master + a client doing identity-guarded Put/Get over the
+# transfer engine.
+cargo run -- cluster --nodes 4 --requests 12
+
 # The ART-vs-LSM storage study (needs a C++ toolchain for RocksDB).
 cargo run --features "rocksdb holt" -- bench-index --backend holt
 cargo run --features "rocksdb holt" -- bench-index --backend rocksdb
 
-# Run the OpenAI-compatible gateway in front of real engines.
+# Run the OpenAI-compatible gateway in front of real engines (optionally backed
+# by a persistent ART/Holt residency index that survives restarts: index: holt).
 cargo run -- gateway --config examples/quillcache-gateway.yaml
-# ...backed by a persistent ART (Holt) residency index that survives restarts:
-cargo run --features holt -- gateway --config examples/quillcache-gateway.yaml  # set index: holt
+cargo run --features holt -- gateway --config examples/quillcache-gateway.yaml
 
 # Build the CUDA device tier on a GPU box (excluded from the default workspace):
 cd crates/quillcache-cuda && cargo build --features cuda

--- a/web/src/components/ArchDiagram.astro
+++ b/web/src/components/ArchDiagram.astro
@@ -1,10 +1,10 @@
 ---
 // Theme-aware architecture diagram (uses Starlight CSS variables, so it adapts
-// to light/dark automatically). Layered: gateway -> control -> pool -> distribution.
+// to light/dark automatically). Layered: gateway -> control -> store -> transfer engine.
 ---
 
 <div class="qc-diagram">
-  <svg viewBox="0 0 720 372" role="img" aria-label="QuillCache layered architecture: gateway, control plane, KV cache pool, distribution, with external engines and a CUDA device tier" xmlns="http://www.w3.org/2000/svg" style="font-family: var(--sl-font);">
+  <svg viewBox="0 0 720 372" role="img" aria-label="QuillCache layered architecture: gateway, control plane, the Mooncake-faithful store, and the transfer engine, with external engines and a CUDA device tier" xmlns="http://www.w3.org/2000/svg" style="font-family: var(--sl-font);">
     <style>
       .qc-l { fill: var(--sl-color-bg); stroke: var(--sl-color-hairline); stroke-width: 1; }
       .qc-stripe { fill: var(--qc-coral); }
@@ -19,26 +19,26 @@
     <!-- gateway -->
     <rect class="qc-l" x="12" y="14" width="696" height="56" rx="12"></rect>
     <rect class="qc-stripe" x="12" y="14" width="5" height="56" rx="2.5"></rect>
-    <text class="qc-t" x="32" y="39">Gateway</text>
+    <text class="qc-t" x="32" y="39">Gateway / Conductor</text>
     <text class="qc-s" x="32" y="58">OpenAI-compatible proxy · streaming · decision headers · SLO goodput</text>
 
     <!-- control plane -->
     <rect class="qc-l" x="12" y="84" width="696" height="56" rx="12"></rect>
     <rect class="qc-stripe" x="12" y="84" width="5" height="56" rx="2.5"></rect>
-    <text class="qc-t" x="32" y="109">Control plane / Conductor</text>
+    <text class="qc-t" x="32" y="109">Control plane (quillcache-core)</text>
     <text class="qc-s" x="32" y="128">router (Dynamo cost fn) · identity guard · residency index (Holt ART / RocksDB / Memory)</text>
 
-    <!-- kv cache pool -->
+    <!-- store -->
     <rect class="qc-l" x="12" y="154" width="696" height="56" rx="12"></rect>
     <rect class="qc-stripe" x="12" y="154" width="5" height="56" rx="2.5"></rect>
-    <text class="qc-t" x="32" y="179">KV cache pool / data plane</text>
-    <text class="qc-s" x="32" y="198">StoreDataPlane: HBM/DRAM/SSD tiers (real bytes) · LocalKvStore: WAL crash-consistent SSD</text>
+    <text class="qc-t" x="32" y="179">Store (quillcache-store) — faithful Mooncake-store port</text>
+    <text class="qc-s" x="32" y="198">Client (two-phase Put) · MasterService (alloc · eviction · identity guard) · DiskTier (WAL) · StoreDataPlane HBM/DRAM/SSD</text>
 
-    <!-- distribution -->
+    <!-- transfer engine -->
     <rect class="qc-l" x="12" y="224" width="696" height="56" rx="12"></rect>
     <rect class="qc-stripe" x="12" y="224" width="5" height="56" rx="2.5"></rect>
-    <text class="qc-t" x="32" y="249">Distribution</text>
-    <text class="qc-s" x="32" y="268">PooledStore: cross-node fetch · NodeRegistry (etcd analogue) · Transfer: TCP / RDMA (reserved)</text>
+    <text class="qc-t" x="32" y="249">Transfer Engine (quillcache-transfer-engine)</text>
+    <text class="qc-s" x="32" y="268">one-sided (segment, offset) over registered memory · TCP real / RDMA reserved · TransferMetadata · Topology</text>
 
     <!-- connectors -->
     <line class="qc-arrow" x1="360" y1="70" x2="360" y2="84"></line>

--- a/web/src/content/docs/architecture.mdx
+++ b/web/src/content/docs/architecture.mdx
@@ -1,33 +1,37 @@
 ---
 title: How it fits together
-description: Gateway, control plane, KV cache pool, distribution — and how a request flows.
+description: Gateway, control plane, the Mooncake-faithful store, and the transfer engine — and how a request flows.
 ---
 
 import ArchDiagram from "../../components/ArchDiagram.astro";
 
-QuillCache is the KV cache pool **and** the control plane. The engines run the
+QuillCache is the KV cache store **and** the control plane. The engines run the
 model and own the live HBM KV; QuillCache holds the offloaded KV bytes
-(DRAM / SSD), moves them between nodes, indexes where they live, and decides
-routing and reuse.
+(DRAM / SSD), moves them between nodes over the transfer engine, indexes where
+they live, and decides routing and reuse.
 
 <ArchDiagram />
 
 ## The layers
 
-- **Gateway** (`quillcache-gateway`) — an OpenAI-compatible proxy. It parses the
+- **Gateway** (`quillcache` bin) — an OpenAI-compatible proxy. It parses the
   request, derives block hashes, asks the control plane for a plan, streams the
   upstream response through, and attaches `x-quillcache-*` decision headers
   before the first token (so they don't add to TTFT).
-- **Control plane / Conductor** (`quillcache-control` + `quillcache-router`) —
+- **Control plane / Conductor** (`quillcache-core` — `control` + `router`) —
   picks a worker with the Dynamo cost function (cache-locality vs load), runs the
   identity guard, and reads/writes the residency index.
-- **KV cache pool / data plane** (`quillcache-store`) — `StoreDataPlane` manages
-  HBM/DRAM/SSD tiers and moves **real bytes** on demotion/eviction;
-  `LocalKvStore` is the byte pool, with a WAL-backed crash-consistent SSD tier.
-- **Distribution** (`quillcache-store` + `quillcache-transfer`) — `PooledStore`
-  serves a block locally or fetches it from the peer the residency index located,
-  resolving the address through the `NodeRegistry` and moving it over the transfer
-  engine.
+- **Store / data plane** (`quillcache-store`) — `StoreDataPlane` manages
+  HBM/DRAM/SSD tiers and moves **real bytes** on demotion/eviction; `LocalKvStore`
+  is the byte pool, with a WAL-backed crash-consistent `DiskTier`. The faithful
+  store sits here too: the two-phase-Put `Client`, the `MasterService` (replica
+  allocation, lease eviction, identity-guarded `get_replica_list`), and the
+  `OffsetBufferAllocator`.
+- **Transfer Engine** (`quillcache-transfer-engine`) — moves KV bytes
+  **one-sidedly** between registered memory by `(segment, offset)`, exactly like
+  Mooncake: a `TransferEngine` facade over `MultiTransport` (`TcpTransport` real /
+  `RdmaTransport` reserved), with `TransferMetadata` for segment / topology
+  discovery (in-memory now, etcd later). It transfers by location, never by key.
 
 ## A request, end to end
 
@@ -47,9 +51,10 @@ routing and reuse.
 6. **Stream** — the upstream body is forwarded chunk by chunk; the first chunk's
    arrival is timed against the request's SLO budget for live goodput.
 
-## Two seams keep it pluggable
+## The seams keep it pluggable
 
 - **`IndexBackend`** — the residency index (Memory / Holt-ART / RocksDB-LSM),
   compared in the [storage study](/storage-study/).
-- **`DataPlane`** + **`Transfer`** + **`NodeRegistry`** — the byte tiers, the
-  wire (TCP / RDMA), and node discovery (in-memory now, etcd later).
+- **`DataPlane`** — the byte tiers (`StoreDataPlane` over `LocalKvStore`).
+- **`Transport`** + **`TransferMetadata`** — the wire (`TcpTransport` /
+  `RdmaTransport`) and segment / topology discovery (in-memory now, etcd later).

--- a/web/src/content/docs/crash-consistency.md
+++ b/web/src/content/docs/crash-consistency.md
@@ -1,13 +1,14 @@
 ---
 title: Crash-consistent tier
-description: The SSD tier survives a restart with object-first atomic publish + a WAL — proven by test.
+description: A durable DiskTier survives a restart with object-first atomic publish + a WAL — proven by test.
 ---
 
-The SSD tier holds real KV bytes that should survive a restart, so it needs a
-durable, **crash-consistent** catalog. Mooncake's pool is mostly volatile DRAM
-(rebuilt on restart); QuillCache occupies the seam it leaves open — a durable,
-immediately-reusable persistent tier — using the same pattern as the author's
-NoKV distributed file system: **object-first atomic publish + a WAL**.
+The durable `DiskTier` holds real KV bytes (`Disk` replicas) that should survive a
+restart, so it needs a durable, **crash-consistent** catalog. Mooncake's pool is
+volatile DRAM (rebuilt on restart); QuillCache occupies the seam it leaves open —
+a durable, immediately-reusable persistent tier — backed by `LocalKvStore`'s SSD
+tier, using the same pattern as the author's NoKV distributed file system:
+**object-first atomic publish + a WAL**.
 
 ## How a block is committed
 
@@ -25,8 +26,11 @@ pointer to a deleted file.
 
 ## How recovery works
 
+On restart, `LocalKvStore::recover` rebuilds the `DiskTier`'s catalog from the
+WAL:
+
 ```text
-recover(dir):
+LocalKvStore::recover(dir):
   replay the WAL  -> the live commit set (last write per key wins)
   for each commit -> verify the file exists AND matches recorded length + CRC
                      pass -> re-enter the index

--- a/web/src/content/docs/crates.md
+++ b/web/src/content/docs/crates.md
@@ -1,26 +1,28 @@
 ---
 title: Crates
-description: The nine crates that make up the QuillCache workspace, and what each does.
+description: The five crates that make up the QuillCache workspace, and what each does.
 ---
 
-QuillCache is a Cargo workspace. The CUDA crate is excluded from the default
-build (it needs an NVIDIA toolchain); everything else builds hardware-free.
+QuillCache is a Cargo workspace of **five crates**. The CUDA crate is excluded
+from the default build (it needs an NVIDIA toolchain); everything else builds
+hardware-free.
 
 | crate | role |
 | --- | --- |
-| `quillcache-gateway` | OpenAI-compatible gateway: proxy, streaming, decision headers, SLO goodput |
-| `quillcache-control` | control plane: `plan()` / `observe_placement` / `audit_reuse` |
-| `quillcache-router` | routing policies incl. `DynamoCostRouter` (+ greedy / SLO-aware / session / prefix-affinity / round-robin) |
-| `quillcache-core` | `KvBlockKey` identity, `CostModel`, the `IndexBackend` + `DataPlane` traits, and the ART-vs-LSM `bench` |
-| `quillcache-store` | `LocalKvStore` (crash-consistent byte pool), `StoreDataPlane` (tiers), `PooledStore`, `NodeRegistry` |
-| `quillcache-transfer` | transfer engine: `LocalTransfer` / `TcpTransfer` / `RdmaTransfer` (reserved) |
-| `quillcache-index-holt` | Holt (persistent ART) index backend |
-| `quillcache-index-rocksdb` | RocksDB (LSM) index backend |
-| `quillcache-cuda` | CUDA device tier: HBM↔host copies + FP8 quantize-on-offload (feature-gated, excluded from the workspace) |
+| `quillcache` (bin) | the OpenAI-compatible **gateway** (proxy · cache-aware routing · streaming · SLO), the local **cluster** demo, and `bench-index` |
+| `quillcache-core` | `KvBlockKey` / `IdentityScope` identity, `CostModel`, `ReuseViolation`; the `router` (incl. `DynamoCostRouter`), `control` plane, `DataPlane` + `IndexBackend` traits, the ART-vs-LSM `bench`, and the feature-gated `index_holt` / `index_rocksdb` backends |
+| `quillcache-transfer-engine` | faithful port of Mooncake's Transfer Engine: `TransferEngine` + `MultiTransport` + `Transport` (`tcp` real / `rdma` reserved) + `TransferMetadata` + `Topology` |
+| `quillcache-store` | faithful port of `mooncake-store`: `Client`, `MasterService`, `OffsetBufferAllocator`, `AllocationStrategy`, `Replica`, the crash-consistent `DiskTier`, plus `LocalKvStore` (byte pool) + `StoreDataPlane` (tiers) |
+| `quillcache-cuda` | CUDA device tier: HBM↔host copies + FP8 quantize-on-offload (feature-gated, excluded from the default workspace) |
 
-## The two seams
+The two index backends (`index_holt`, `index_rocksdb`) are **feature-gated modules
+inside `quillcache-core`**, off by default — `holt` is pure Rust; `rocksdb` pulls a
+C++/libclang toolchain — so the default build needs neither. They are not separate
+crates.
 
-Two traits make the system pluggable and testable:
+## The seams
+
+A few traits keep the system pluggable and testable:
 
 - **`IndexBackend`** (`quillcache-core`) — the residency index. Implementations:
   `MemoryIndex` (reference), Holt (persistent ART), RocksDB (LSM). The same trait
@@ -28,7 +30,9 @@ Two traits make the system pluggable and testable:
 - **`DataPlane`** (`quillcache-core`) — the KV byte tier manager. `StoreDataPlane`
   implements it over per-worker `LocalKvStore` byte pools, so `place()` moves
   real bytes between HBM/DRAM/SSD tiers.
-
-The **transfer engine** (`Transfer` trait) and the **node registry**
-(`NodeRegistry` trait) are the seams for the distributed read path: TCP today,
-RDMA reserved; an in-memory registry now, etcd pluggable behind the trait.
+- **`Transport`** (`quillcache-transfer-engine`) — the wire under the Transfer
+  Engine. `TcpTransport` moves bytes one-sidedly by `(segment, offset)` today;
+  `RdmaTransport` is reserved behind the same trait.
+- **`TransferMetadata`** (`quillcache-transfer-engine`) — segment / topology
+  discovery: `InMemoryMetadata` now, etcd / redis / http pluggable behind the
+  trait.

--- a/web/src/content/docs/identity-safe-reuse.md
+++ b/web/src/content/docs/identity-safe-reuse.md
@@ -1,6 +1,6 @@
 ---
 title: Identity-safe reuse
-description: Why content-hash caches leak across tenants and adapters, and the identity guard that costs ~1.7%.
+description: Why content-hash caches leak across tenants and adapters, and the identity guard that refuses it — in memory, on disk, and at the master.
 ---
 
 A KV block's **content hash** is computed from its tokens, so the same tokens
@@ -16,8 +16,15 @@ must not:
 ## The guard
 
 QuillCache makes the reuse contract explicit. Every block carries an
-`IdentityScope` (model · tokenizer · adapter · tenant), and `LocalKvStore::get`
-serves a block only when the requester's identity matches:
+`IdentityScope` (model · tokenizer · adapter · tenant), and a block is served only
+when the requester's identity matches. The check is the same at **every** serving
+point:
+
+- **`LocalKvStore::get`** — the in-memory byte tier;
+- **`DiskTier::get`** — the durable on-disk tier (so the guard holds after a crash
+  and recovery, not just in RAM);
+- **`MasterService::get_replica_list`** — the metadata layer, which refuses a
+  cross-identity request *before* any bytes move over the transfer engine.
 
 ```rust
 pub fn get(&mut self, key: &KvBlockKey) -> Result<Bytes, StoreError> {
@@ -33,18 +40,16 @@ a prefix, a `tenant-b` request for the *same content* returns
 `x-quillcache-local-hits: 0` and `x-quillcache-reuse-refused: 2` — it refuses to
 serve tenant A's KV to tenant B, and says so.
 
-## Measured
+## Precise, not blunt
 
-On a collision-heavy workload (one popular prefix shared across many identities —
-the multi-tenant shared-system-prompt / shared-RAG case):
+The guard is keyed on identity, not content, so it is **precise**: a
+same-identity request still gets its cache hit — only a genuine cross-identity
+match (a different tenant / adapter / model / tokenizer for the same tokens) is
+refused. On the multi-tenant shared-system-prompt / shared-RAG case, where one
+popular prefix is shared across many identities, a naive content-hash cache would
+serve that prefix across all of them; the guard serves **zero** unsafe reuse while
+keeping every safe same-identity hit.
 
-| policy | content-hash hits | unsafe served | safe reuse kept |
-| --- | --- | --- | --- |
-| naive (content hash only) | 12400 | **12000 (96.8%)** | — |
-| **identity guard** | — | **0** | 4800 |
-
-The guard eliminates **all** unsafe reuse while preserving safe same-identity
-reuse. And it is precise, not blunt: on a realistic mostly-same-identity mix the
-overhead — forced recomputes as a fraction of all reuse work — drops to **1.7%**
-(it is only 47.8% on the adversarial all-collision case). Safety is near-free
-exactly where it matters.
+It is the **same guard** in memory (`LocalKvStore`), on disk (`DiskTier`), and at
+the master (`MasterService`) — and it still holds after a crash and recovery. This
+is QuillCache's addition; Mooncake's keys are identity-agnostic.

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -19,28 +19,30 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 import ArchDiagram from "../../components/ArchDiagram.astro";
 
 <div class="qc-pills">
-  <span class="qc-pill">distributed KV byte pool</span>
-  <span class="qc-pill">DRAM / SSD tiers</span>
-  <span class="qc-pill">transfer engine · TCP / RDMA</span>
-  <span class="qc-pill">cross-node fetch</span>
+  <span class="qc-pill">faithful Mooncake-store port</span>
+  <span class="qc-pill">transfer engine · (segment, offset)</span>
+  <span class="qc-pill">TCP / RDMA reserved</span>
+  <span class="qc-pill">two-phase Put · MasterService</span>
   <span class="qc-pill">identity-safe reuse</span>
-  <span class="qc-pill">crash-consistent SSD</span>
+  <span class="qc-pill">crash-consistent DiskTier</span>
   <span class="qc-pill">persistent ART index</span>
   <span class="qc-pill">Dynamo cost router</span>
-  <span class="qc-pill">9 crates · MIT</span>
+  <span class="qc-pill">5 crates · MIT</span>
 </div>
 
-QuillCache sits beside real inference engines (vLLM, SGLang) and owns the KV
-cache as a resource — the byte pool, the transfer engine, the residency index,
-and the cache-aware control plane. It replicates the architecture of **NVIDIA
-Dynamo** and **Moonshot's Mooncake**, at a size one person can read end-to-end
-and measure. It does **not** run models — the CUDA tier moves and quantizes KV
-*bytes* (the data path), not inference compute.
+QuillCache is a **faithful Rust port of Moonshot's Mooncake store** — its
+component decomposition, code layout, and API mirrored module for module — with a
+**Dynamo**-style cache-aware routing gateway in front. It sits beside real
+inference engines (vLLM, SGLang) and owns the KV cache as a resource: the Transfer
+Engine, the store (`Client` / `MasterService` / `DiskTier`), the residency index,
+and the cache-aware control plane — at a size one person can read end-to-end and
+measure. It does **not** run models — the CUDA tier moves and quantizes KV *bytes*
+(the data path), not inference compute.
 
 ## Headline results
 
 Real code, no simulation — every number is measured against in-tree baselines.
-45 tests pass; `fmt` + `clippy` clean.
+60 tests pass; `fmt` + `clippy` clean.
 
 <div class="qc-statgrid">
   <div class="qc-stat">
@@ -54,24 +56,24 @@ Real code, no simulation — every number is measured against in-tree baselines.
     <div class="d">ART writes each record once; LSM rewrites through compaction. Measured from RocksDB's own stats, not assumed.</div>
   </div>
   <div class="qc-stat">
-    <div class="n">96.8%</div>
-    <div class="k">Unsafe reuse caught</div>
-    <div class="d">Of a naive content-hash cache's hits on a collision workload — cross-tenant leaks + cross-adapter/model errors. The guard serves 0.</div>
+    <div class="n">0 leaks</div>
+    <div class="k">Identity-guarded reuse</div>
+    <div class="d">A content-hash cache would serve cross-tenant + cross-adapter/model blocks; the guard refuses them with a <code>ReuseViolation</code> in memory, on disk, and at the master. Tested.</div>
   </div>
   <div class="qc-stat">
     <div class="n">crash-consistent</div>
-    <div class="k">Persistent SSD tier</div>
-    <div class="d">Object-first atomic publish + WAL: complete blocks recover, half-written / corrupted blocks dropped, no dangling pointers.</div>
+    <div class="k">Durable <code>DiskTier</code></div>
+    <div class="d">Object-first atomic publish + WAL: complete blocks recover, half-written / corrupted blocks dropped, no dangling pointers (Mooncake's pool is volatile).</div>
   </div>
   <div class="qc-stat">
     <div class="n">real KV bytes</div>
-    <div class="k">Distributed byte pool</div>
-    <div class="d">DRAM + SSD tiers that hold actual KV blocks, with index-located cross-node fetch over the transfer engine — verified over TCP.</div>
+    <div class="k">HBM / DRAM / SSD tiers</div>
+    <div class="d"><code>StoreDataPlane</code> over <code>LocalKvStore</code> holds actual KV blocks and moves them across tiers — wired online and measured.</div>
   </div>
   <div class="qc-stat">
-    <div class="n">1.7%</div>
-    <div class="k">Cost of safety</div>
-    <div class="d">Identity-guard overhead on a realistic, mostly-same-identity workload (47.8% only on the adversarial all-collision case).</div>
+    <div class="n">(segment, offset)</div>
+    <div class="k">Faithful Transfer Engine</div>
+    <div class="d">A module-for-module port of Mooncake's one-sided transfer: moves bytes by location between registered memory (TCP real, RDMA reserved), never by key.</div>
   </div>
 </div>
 
@@ -94,7 +96,7 @@ live, and decides routing and reuse.
   <LinkCard
     title="Architecture"
     href="/architecture/"
-    description="Gateway, control plane, KV cache pool, distribution — how a request flows."
+    description="Gateway, control plane, the store, the transfer engine — how a request flows."
   />
   <LinkCard
     title="ART vs LSM storage study"
@@ -104,7 +106,7 @@ live, and decides routing and reuse.
   <LinkCard
     title="Identity-safe reuse"
     href="/identity-safe-reuse/"
-    description="Why content-hash caches leak, and the guard that costs ~1.7%."
+    description="Why content-hash caches leak, and the guard that refuses it — in memory, on disk, and at the master."
   />
   <LinkCard
     title="Crash-consistent tier"

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -3,21 +3,22 @@ title: Overview
 description: What QuillCache is, and what's wired online vs a tested unit vs reserved.
 ---
 
-QuillCache is a **Mooncake/Dynamo-style distributed KV cache pool and control
-plane** for LLM serving, written in Rust. It sits beside real inference engines
-(vLLM, SGLang) and owns the KV cache as a resource:
+QuillCache is a **faithful Rust port of [Mooncake](https://github.com/kvcache-ai/Mooncake)'s
+distributed KV cache store** (the KVCache-centric data plane from Moonshot / Kimi,
+FAST'25) — its component decomposition, code layout, and API mirrored module for
+module — **plus two properties the production data planes leave implicit:
+identity-governed safe reuse and a crash-consistent persistent tier.** It sits
+beside real inference engines (vLLM, SGLang) and owns the KV cache as a resource:
 
-- a **byte pool** — DRAM + SSD tiers that hold real KV block bytes, with
-  capacity-driven demotion and eviction;
-- a **transfer engine** — moves blocks between nodes (TCP today, RDMA reserved);
-- a **residency index** — maps each block (by identity) to where it lives
-  (node + tier), persistent so it survives a restart;
-- a **control plane / Conductor** — routes requests cache-aware (the Dynamo
-  KV-router cost function), governs reuse, and meters SLO.
-
-It replicates the architecture of NVIDIA Dynamo and Moonshot's Mooncake, plus
-two properties the production data planes leave implicit: **identity-governed
-safe reuse** and a **crash-consistent persistent tier**.
+- a **Transfer Engine** (`quillcache-transfer-engine`) — moves bytes one-sidedly
+  between *registered memory* by `(segment, offset)`, exactly like Mooncake (TCP
+  today; RDMA / GPUDirect reserved behind the same trait);
+- a **Store** (`quillcache-store`) — a two-phase-Put `Client`, a `MasterService`
+  (object metadata, replica allocation, lease eviction), a buffer allocator, the
+  replica model, and a crash-consistent durable `DiskTier`;
+- a **Gateway / Conductor** — an OpenAI-compatible proxy that routes cache-aware
+  (the Dynamo KV-router cost function), governs reuse, and meters SLO, backed by a
+  persistent residency index.
 
 :::note[It does not run models]
 No transformer kernels, no attention. The CUDA tier moves and quantizes KV
@@ -29,20 +30,20 @@ No transformer kernels, no attention. The CUDA tier moves and quantizes KV
 Everything here is real code — there is no simulation. The honest distinction is
 how far each piece is integrated:
 
-- **✅ wired online & measured** — gateway, control plane, Dynamo-cost routing,
-  persistent residency index, `StoreDataPlane` moving real bytes across
-  HBM/DRAM/SSD, the identity guard, live SLO goodput, and the ART-vs-LSM storage
-  study.
-- **▣ tested unit (not yet on the live gateway path)** — `PooledStore`
-  cross-node fetch over TCP, and `LocalKvStore::recover` crash recovery. Both are
-  covered by tests; wiring them into the live gateway needs an engine
-  KV-connector for the engine⟷pool byte handoff.
-- **⊙ reserved / needs hardware** — `RdmaTransfer` (behind the `rdma` feature)
-  and the CUDA device tier (build `quillcache-cuda` with `--features cuda` on a
-  GPU box). Both are real interfaces, stubbed/fallback so the default build is
-  hardware-free.
+- **✅ wired online & measured** — the gateway, control plane, Dynamo-cost
+  routing, persistent residency index, `StoreDataPlane` moving real bytes across
+  HBM/DRAM/SSD, live SLO goodput, and the ART-vs-LSM storage study.
+- **▣ tested unit (not yet on the live gateway path)** — the faithful store: a
+  `Client` Put→Get over the transfer engine (real TCP), the `MasterService`
+  two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
+  recovery. All covered by tests (and the `cluster` demo); wiring them into the
+  live gateway needs an engine KV-connector for the engine⟷store byte handoff.
+- **⊙ reserved / needs hardware** — `RdmaTransport` (behind the `rdma` feature),
+  the etcd metadata backend, and the CUDA device tier (build `quillcache-cuda`
+  with `--features cuda` on a GPU box). All real interfaces, stubbed so the
+  default build is hardware-free.
 
-`cargo test` — 45 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
+`cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
 
 ## Differentiation
 
@@ -51,9 +52,11 @@ block's **content hash** and keep the cache mostly volatile. QuillCache adds:
 
 1. **Identity-governed safe reuse** — a block is served only when the requester's
    model · tokenizer · adapter · tenant matches, so cross-tenant leaks and
-   cross-adapter/model errors are refused. See
-   [Identity-safe reuse](/identity-safe-reuse/).
-2. **A crash-consistent persistent tier** — the SSD tier survives a restart with
-   object-first atomic publish + a WAL, so durable blocks are immediately
-   reusable and corrupt/half-written ones are never served. See
-   [Crash-consistent tier](/crash-consistency/).
+   cross-adapter/model errors are refused. The same guard runs at every serving
+   point — `LocalKvStore::get` and `DiskTier::get` (the byte tiers) and
+   `MasterService::get_replica_list` (the metadata layer, before any byte moves).
+   See [Identity-safe reuse](/identity-safe-reuse/).
+2. **A crash-consistent persistent tier** — a durable `DiskTier` survives a
+   restart with object-first atomic publish + a WAL, so durable blocks are
+   immediately reusable and corrupt/half-written ones are never served (Mooncake's
+   pool is volatile DRAM). See [Crash-consistent tier](/crash-consistency/).

--- a/web/src/content/docs/quickstart.md
+++ b/web/src/content/docs/quickstart.md
@@ -12,7 +12,16 @@ C++ toolchain.
 git clone https://github.com/feichai0017/quillcache
 cd quillcache
 cargo build
-cargo test          # 45 tests
+cargo test          # 60 tests
+```
+
+## The cluster demo — the Mooncake-faithful store
+
+A local multi-node demo on the faithful store: N storage-node transfer engines +
+a master + a client doing identity-guarded Put/Get over the transfer engine.
+
+```bash
+cargo run -- cluster --nodes 4 --requests 12
 ```
 
 ## The ART-vs-LSM storage study

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -3,20 +3,21 @@ title: Mooncake / Dynamo mapping
 description: Every Mooncake and NVIDIA Dynamo component, mapped to a QuillCache crate.
 ---
 
-QuillCache replicates the production reference designs piece by piece, then adds
-its differentiation on top. The concepts line up one-to-one — built small enough
-to read end-to-end and measure.
+QuillCache mirrors Mooncake's decomposition piece by piece, then adds its
+differentiation on top. The concepts line up one-to-one — built small enough to
+read end-to-end and measure.
 
-| Mooncake / NVIDIA Dynamo | QuillCache | Status |
+| Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Mooncake Store (pooled DRAM/SSD KV) | `LocalKvStore` + `PooledStore` | ✅ real bytes |
-| Mooncake Transfer Engine | `quillcache-transfer` | ✅ TCP / ⊙ RDMA reserved |
-| Conductor / scheduler | `quillcache-control` + router | ✅ |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma}`) | ✅ TCP / ⊙ RDMA reserved |
+| Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
+| Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
+| `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend` (`InMemoryMetadata`) | ✅ / ⊙ etcd pluggable |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
 | Dynamo KVBM tiers (G1/G2/G3) | `StoreDataPlane` (HBM/DRAM/SSD) | ✅ moves real bytes |
 | Dynamo KV-Cache Indexer | residency index (Holt ART) | ✅ persistent |
-| Dynamo etcd / service discovery | `NodeRegistry` (`StaticRegistry`) | ✅ etcd pluggable |
-| — *(neither does this)* | **identity guard + crash-consistency** | 🎯 differentiation |
+| — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
 
 ## The Dynamo cost function
 
@@ -35,9 +36,12 @@ Dynamo's own published worked example (costs 18 / 10 / 11 → pick worker 2).
 
 ## The distributed read path
 
-The pooled read mirrors Mooncake's Conductor → metadata → Transfer Engine flow:
+The store's read mirrors Mooncake's `Client` → `MasterService` → Transfer Engine
+flow:
 
-1. the residency index **locates** which nodes hold the block (`index.locate`);
-2. the `NodeRegistry` **resolves** a node id to its transfer address;
-3. the **transfer engine** fetches it; the block is admitted locally and served,
-   identity-guarded.
+1. the `Client` asks the `MasterService` for the block's replicas
+   (`get_replica_list`), which is **identity-guarded** — a cross-identity request
+   is refused with `ReuseViolation` *before* any bytes move;
+2. the reply names the holding **segment** and **offset** in registered memory;
+3. the **Transfer Engine** moves those bytes one-sidedly by `(segment, offset)`
+   (TCP today, RDMA reserved) — it transfers by location, never by key.


### PR DESCRIPTION
The docs still described the **pre-port** architecture (8 separate crates, `PooledStore`/`NodeRegistry`/`EngineConnector`, the old key-oriented transfer, the `quillcache master`/`node` CLI, and safe-reuse numbers from the deleted simulator). This rewrites them to the current design — no code change.

## README.md

Faithful-Mooncake-port framing; new architecture mermaid (Transfer Engine + store `Client`/`MasterService`/`DiskTier` + gateway); the reference-mapping table to the real components; the **5-crate** table; status (**60 tests**); the identity guard described at its three enforcement points (`LocalKvStore`/`DiskTier`/`MasterService::get_replica_list`); crash-consistency via `DiskTier`; quick start with the `cluster` demo; the deleted-sim numbers (`96.8%`/`1.7%`) dropped.

## web/ Astro site

`overview`, `architecture`, `crates`, `reference-mapping`, `quickstart`, `identity-safe-reuse`, `crash-consistency`, `index.mdx` + the `ArchDiagram.astro` SVG labels — same alignment, consistent with README (5 crates, 60 tests, both tables match). `npm run build` green — **10 pages, no broken links**.

`web/dist` is gitignored (the Pages Action rebuilds it on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation with new component naming and structure (gateway, control plane, store, transfer engine).
  * Clarified crash-consistency mechanisms and identity-safe reuse safeguards across system tiers.
  * Added cluster demo example to quick-start guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->