### PR TITLE
feat(transfer-engine): real etcd metadata backend + NVLink transport seam; honest CUDA mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           cargo test -p quillcache-core --features holt
           cargo build -p quillcache --features holt
 
+      - name: etcd metadata backend — compile-check (no etcd server needed)
+        run: cargo check -p quillcache-transfer-engine --features etcd
+
   rocksdb:
     name: rocksdb backend (LSM)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,12 +107,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -94,7 +155,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -105,10 +166,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -364,10 +445,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0452bcc559431b16f472b7ab86e2f9ccd5f3c2da3795afbd6b773665e047fe"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -472,6 +587,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +698,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -586,6 +727,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +756,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -709,6 +863,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -846,6 +1010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1063,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -925,6 +1101,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nom"
@@ -977,6 +1159,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,10 +1238,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quillcache"
 version = "1.0.0-alpha.1"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "bytes",
  "clap",
  "futures-util",
@@ -1067,6 +1341,7 @@ version = "1.0.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "etcd-client",
  "serde",
  "serde_json",
  "thiserror",
@@ -1086,7 +1361,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -1102,7 +1377,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -1123,7 +1398,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1145,12 +1420,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1160,7 +1456,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1240,7 +1545,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1286,6 +1591,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "rustls"
@@ -1412,7 +1730,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1461,6 +1779,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1519,6 +1847,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1586,7 +1927,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.1",
 ]
@@ -1613,6 +1954,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1975,70 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1653,7 +2069,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ differentiation on top:
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma}`) | ✅ TCP / ⊙ RDMA reserved |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA · NVLink reserved |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
-| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend` (`InMemoryMetadata`) | ✅ / ⊙ etcd pluggable |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory / ⊙ etcd (real, needs a server) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
-| Dynamo KVBM tiers (G1/G2/G3) | `StoreDataPlane` (HBM/DRAM/SSD) | ✅ moves real bytes |
+| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
+| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |
 | Dynamo KV-Cache Indexer | residency index (Holt ART) | ✅ persistent |
 | — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
 
@@ -92,10 +93,11 @@ how far each piece is integrated:
   two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
   recovery. All covered by tests (and the `cluster` demo); wiring them into the
   live gateway needs an engine KV-connector for the engine⟷store byte handoff.
-- **⊙ reserved / needs hardware** — `RdmaTransport` (behind the `rdma` feature), the
-  etcd metadata backend, and the CUDA device tier (`quillcache-cuda --features
-  cuda` on a GPU box). All real interfaces, stubbed so the default build is
-  hardware-free.
+- **⊙ reserved / needs infra** — `RdmaTransport` / `NvlinkTransport` (behind
+  `rdma` / `nvlink`), the `EtcdMetadata` backend (behind `etcd` — real etcd-client
+  code + a background-watch-synced cache, compile-checked in CI, needs a running
+  etcd to run), and the CUDA device tier (`quillcache-cuda --features cuda` on a
+  GPU box). All real interfaces; the default build is hardware-free.
 
 `cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
 

--- a/crates/quillcache-cuda/src/lib.rs
+++ b/crates/quillcache-cuda/src/lib.rs
@@ -1,14 +1,16 @@
-//! CUDA device tier for QuillCache — the GPU side of the KV store.
+//! CUDA device tier for QuillCache — the GPU HBM tier of the KV store.
 //!
-//! The HBM tier of a Mooncake-style store lives in GPU memory. This crate is the
-//! seam that (a) copies KV blocks between GPU HBM and host memory (the offload /
-//! reload path) and (b) quantizes FP16 → FP8 on offload to halve the DRAM
-//! footprint of a cooled block. The real path is behind the `cuda` feature and
-//! is built on a GPU box; without it, a host-only stub keeps callers compiling
-//! on machines with no NVIDIA GPU.
+//! **Mapping note:** this is NOT a 1:1 Mooncake component. Mooncake puts GPU in
+//! its *Transfer Engine* (GPUDirect-RDMA HBM↔NIC, NVLink, cuFile/GDS — see the
+//! `rdma` / `nvlink` reserved transports in `quillcache-transfer-engine`) and has
+//! no quantize tier. This crate is the **NVIDIA-Dynamo-KVBM-style G1 (HBM) tier**:
+//! it (a) copies KV blocks between GPU HBM and host memory (offload / reload) and
+//! (b) quantizes FP16 → FP8 on offload (an LMCache / KVBM idea) to halve a cooled
+//! block's footprint. The real path is behind the `cuda` feature, built on a GPU
+//! box; a host-only stub keeps callers compiling without an NVIDIA GPU.
 //!
-//! This crate is excluded from the workspace so the default build never resolves
-//! `cudarc`. Build it standalone: `cargo build --features cuda` on a GPU box.
+//! Excluded from the workspace so the default build never resolves `cudarc`.
+//! Build standalone: `cargo build --features cuda` on a GPU box.
 
 /// The FP16 → FP8 (E4M3) quantize-on-offload kernel source. Compiled with `nvcc`
 /// on a GPU box and loaded by the device tier; embedded here as the reference.

--- a/crates/quillcache-transfer-engine/Cargo.toml
+++ b/crates/quillcache-transfer-engine/Cargo.toml
@@ -13,11 +13,17 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "rt"] }
+etcd-client = { version = "0.14", optional = true }
 
 [features]
-# RDMA transport backend (ibverbs / GPUDirect-RDMA). Reserved seam — the trait
-# is implemented as an Unsupported stub until an RDMA NIC is wired.
+# RDMA / GPU transport backends (ibverbs / GPUDirect-RDMA / NVLink). Reserved
+# seams — implemented as Unsupported stubs until the hardware is wired.
 rdma = []
+nvlink = []
+# etcd-backed metadata (Mooncake's etcd:// MetadataStoragePlugin) — the production
+# distributed metadata path. Off by default; needs a running etcd cluster (like
+# `rdma` needs a NIC). Pulls etcd-client (gRPC over tonic).
+etcd = ["dep:etcd-client"]
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util", "time"] }

--- a/crates/quillcache-transfer-engine/src/lib.rs
+++ b/crates/quillcache-transfer-engine/src/lib.rs
@@ -27,12 +27,16 @@
 
 pub mod engine;
 pub mod metadata;
+#[cfg(feature = "etcd")]
+pub mod metadata_etcd;
 pub mod multi_transport;
 pub mod topology;
 pub mod transport;
 
 pub use engine::TransferEngine;
 pub use metadata::{BufferDesc, InMemoryMetadata, MetadataBackend, SegmentDesc};
+#[cfg(feature = "etcd")]
+pub use metadata_etcd::EtcdMetadata;
 pub use multi_transport::MultiTransport;
 pub use topology::Topology;
 pub use transport::{

--- a/crates/quillcache-transfer-engine/src/metadata_etcd.rs
+++ b/crates/quillcache-transfer-engine/src/metadata_etcd.rs
@@ -1,0 +1,188 @@
+//! etcd-backed metadata (Mooncake's `etcd://` `MetadataStoragePlugin`) — the
+//! production distributed metadata path. Segment descriptors live in etcd under a
+//! key prefix; a background **watch** keeps a local cache fresh so the sync
+//! [`MetadataBackend`] reads stay fast (this is how a real distributed metadata
+//! cache works — Mooncake caches segment metadata locally and syncs). Behind the
+//! `etcd` feature; needs a running etcd cluster (like the RDMA backend needs a
+//! NIC).
+
+use crate::metadata::{MetadataBackend, SegmentDesc};
+use etcd_client::{Client, EventType, GetOptions, WatchOptions};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// etcd metadata backend: a local cache fed by an etcd watch, with writes pushed
+/// to etcd so peers' watches pick them up.
+pub struct EtcdMetadata {
+    client: Client,
+    prefix: String,
+    cache: Arc<Mutex<HashMap<String, SegmentDesc>>>,
+}
+
+impl std::fmt::Debug for EtcdMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EtcdMetadata")
+            .field("prefix", &self.prefix)
+            .field("cached_segments", &self.cache.lock().unwrap().len())
+            .finish()
+    }
+}
+
+impl EtcdMetadata {
+    /// Connect to etcd, load existing segments under `prefix`, and start a watch
+    /// that keeps the local cache in sync. Must be called from within a Tokio
+    /// runtime (the watch + writes run as spawned tasks).
+    pub async fn connect(
+        endpoints: Vec<String>,
+        prefix: impl Into<String>,
+    ) -> Result<Self, etcd_client::Error> {
+        let prefix = prefix.into();
+        let mut client = Client::connect(endpoints, None).await?;
+        let cache: Arc<Mutex<HashMap<String, SegmentDesc>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        // Initial load: every descriptor already under the prefix.
+        let resp = client
+            .get(prefix.clone(), Some(GetOptions::new().with_prefix()))
+            .await?;
+        {
+            let mut guard = cache.lock().unwrap();
+            for kv in resp.kvs() {
+                if let Ok(desc) = serde_json::from_slice::<SegmentDesc>(kv.value()) {
+                    guard.insert(desc.name.clone(), desc);
+                }
+            }
+        }
+
+        // Background watch keeps the cache fresh as peers publish / remove segments.
+        let (watcher, mut stream) = client
+            .watch(prefix.clone(), Some(WatchOptions::new().with_prefix()))
+            .await?;
+        let watch_cache = cache.clone();
+        let watch_prefix = prefix.clone();
+        tokio::spawn(async move {
+            let _watcher = watcher; // dropping it cancels the watch — keep it alive
+            while let Ok(Some(resp)) = stream.message().await {
+                for event in resp.events() {
+                    let Some(kv) = event.kv() else { continue };
+                    match event.event_type() {
+                        EventType::Put => {
+                            if let Ok(desc) = serde_json::from_slice::<SegmentDesc>(kv.value()) {
+                                watch_cache.lock().unwrap().insert(desc.name.clone(), desc);
+                            }
+                        }
+                        EventType::Delete => {
+                            if let Ok(key) = std::str::from_utf8(kv.key()) {
+                                if let Some(name) = key.strip_prefix(watch_prefix.as_str()) {
+                                    watch_cache.lock().unwrap().remove(name);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            client,
+            prefix,
+            cache,
+        })
+    }
+
+    fn key(&self, name: &str) -> String {
+        format!("{}{}", self.prefix, name)
+    }
+}
+
+impl MetadataBackend for EtcdMetadata {
+    fn put_segment(&self, desc: SegmentDesc) {
+        // Update the local cache now; push to etcd async so peers' watches see it.
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(desc.name.clone(), desc.clone());
+        let mut client = self.client.clone();
+        let key = self.key(&desc.name);
+        let value = serde_json::to_vec(&desc).unwrap_or_default();
+        tokio::spawn(async move {
+            let _ = client.put(key, value, None).await;
+        });
+    }
+
+    fn get_segment(&self, name: &str) -> Option<SegmentDesc> {
+        self.cache.lock().unwrap().get(name).cloned()
+    }
+
+    fn remove_segment(&self, name: &str) {
+        self.cache.lock().unwrap().remove(name);
+        let mut client = self.client.clone();
+        let key = self.key(name);
+        tokio::spawn(async move {
+            let _ = client.delete(key, None).await;
+        });
+    }
+
+    fn segment_names(&self) -> Vec<String> {
+        self.cache.lock().unwrap().keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::BufferDesc;
+    use std::time::Duration;
+
+    // Run a local etcd, then: cargo test -p quillcache-transfer-engine \
+    //   --features etcd -- --ignored
+    //   (e.g. docker run -d -p 2379:2379 quay.io/coreos/etcd:v3.5.13 \
+    //         /usr/local/bin/etcd --advertise-client-urls http://0.0.0.0:2379 \
+    //         --listen-client-urls http://0.0.0.0:2379)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "needs a running etcd on 127.0.0.1:2379"]
+    async fn segment_published_on_one_backend_is_discovered_on_another_via_etcd() {
+        let endpoints = vec!["http://127.0.0.1:2379".to_string()];
+        let prefix = format!("/quillcache-test/{}/", std::process::id());
+
+        // Two independent backends (separate caches) against the same etcd —
+        // like two nodes' transfer engines.
+        let node_a = EtcdMetadata::connect(endpoints.clone(), prefix.clone())
+            .await
+            .unwrap();
+        let node_b = EtcdMetadata::connect(endpoints, prefix).await.unwrap();
+
+        // A publishes its segment; B must discover it via the etcd watch.
+        node_a.put_segment(SegmentDesc {
+            name: "node-a".into(),
+            protocol: "tcp".into(),
+            endpoint: "127.0.0.1:9000".into(),
+            buffers: vec![BufferDesc {
+                offset: 0,
+                length: 4096,
+            }],
+        });
+
+        let mut discovered = None;
+        for _ in 0..40 {
+            if let Some(desc) = node_b.get_segment("node-a") {
+                discovered = Some(desc);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let desc = discovered.expect("node-b should discover node-a's segment via etcd");
+        assert_eq!(desc.endpoint, "127.0.0.1:9000");
+
+        // And a remove on A propagates to B too.
+        node_a.remove_segment("node-a");
+        let mut gone = false;
+        for _ in 0..40 {
+            if node_b.get_segment("node-a").is_none() {
+                gone = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(gone, "node-b should see node-a's segment removed via etcd");
+    }
+}

--- a/crates/quillcache-transfer-engine/src/transport.rs
+++ b/crates/quillcache-transfer-engine/src/transport.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 
+pub mod nvlink;
 pub mod rdma;
 pub mod tcp;
 

--- a/crates/quillcache-transfer-engine/src/transport/nvlink.rs
+++ b/crates/quillcache-transfer-engine/src/transport/nvlink.rs
@@ -1,0 +1,51 @@
+//! NVLink / GPUDirect transport (Mooncake's `nvlink_transport` + `transport/device`)
+//! — the GPU-resident data path: NVLink for intra-node GPU↔GPU, GPUDirect-RDMA
+//! for HBM↔NIC zero-copy. **This is where "CUDA" lives in Mooncake's Transfer
+//! Engine** — moving KV bytes to / from / between GPU HBM without staging through
+//! host memory — not a separate quantize-on-offload tier. Reserved seam: needs an
+//! NVIDIA GPU (CUDA + NVLink / IBGDA), stubbed until hardware is wired; the real
+//! impl lands behind `--features nvlink` and nothing above the [`Transport`] trait
+//! changes.
+//!
+//! (`quillcache-cuda` is a *different* concern — the Dynamo-KVBM HBM tier with
+//! FP16→FP8 quantize-on-offload, an LMCache/KVBM-flavored idea Mooncake does not
+//! have. GPUDirect-RDMA itself rides the `rdma` backend; cuFile / GDS would be an
+//! `nvmeof` backend.)
+
+use super::{LinkClass, TransferError, Transport};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+#[derive(Debug, Default)]
+pub struct NvlinkTransport;
+
+const NEEDS_GPU: &str = "NVLink/GPUDirect transport requires an NVIDIA GPU (reserved; build with --features nvlink once CUDA + NVLink/IBGDA is wired)";
+
+#[async_trait]
+impl Transport for NvlinkTransport {
+    fn name(&self) -> &str {
+        "nvlink"
+    }
+
+    fn link_class(&self) -> LinkClass {
+        LinkClass::Nvlink
+    }
+
+    async fn read_remote(
+        &self,
+        _endpoint: &str,
+        _offset: u64,
+        _length: u64,
+    ) -> Result<Bytes, TransferError> {
+        Err(TransferError::Unsupported(NEEDS_GPU))
+    }
+
+    async fn write_remote(
+        &self,
+        _endpoint: &str,
+        _offset: u64,
+        _data: Bytes,
+    ) -> Result<(), TransferError> {
+        Err(TransferError::Unsupported(NEEDS_GPU))
+    }
+}

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -9,15 +9,21 @@ read end-to-end and measure.
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma}`) | ✅ TCP / ⊙ RDMA reserved |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA · NVLink reserved |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
-| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend` (`InMemoryMetadata`) | ✅ / ⊙ etcd pluggable |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory / ⊙ etcd (real, needs a server) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
-| Dynamo KVBM tiers (G1/G2/G3) | `StoreDataPlane` (HBM/DRAM/SSD) | ✅ moves real bytes |
+| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
+| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |
 | Dynamo KV-Cache Indexer | residency index (Holt ART) | ✅ persistent |
 | — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
+
+> `quillcache-cuda` is the one piece that is **not** a 1:1 Mooncake component:
+> Mooncake puts GPU in the Transfer Engine (the `rdma` / `nvlink` transports
+> above); the HBM-tier + FP8-quantize crate mirrors NVIDIA Dynamo's KVBM, not
+> Mooncake.
 
 ## The Dynamo cost function
 
@@ -44,4 +50,4 @@ flow:
    is refused with `ReuseViolation` *before* any bytes move;
 2. the reply names the holding **segment** and **offset** in registered memory;
 3. the **Transfer Engine** moves those bytes one-sidedly by `(segment, offset)`
-   (TCP today, RDMA reserved) — it transfers by location, never by key.
+   (TCP today, RDMA / NVLink reserved) — it transfers by location, never by key.


### PR DESCRIPTION
Addresses two faithfulness gaps surfaced by review: **(1) CUDA didn't map 1:1 to Mooncake**, and **(2) etcd wasn't wired** (only in-memory metadata).

## etcd — the production distributed-metadata path

`EtcdMetadata` (feature `etcd`, `etcd-client`) implements `MetadataBackend` with a **background-watch-synced local cache**: reads hit the cache (sync, fast), writes push to etcd, and an etcd **watch** keeps peers' caches fresh — how a real distributed metadata cache works (the sync `MetadataBackend` trait + async etcd reconciled cleanly). 

- **Compile-verified** (`cargo check --features etcd`, clippy clean) + added to **CI** as a compile-check so it can't bit-rot.
- An `#[ignore]` integration test (two backends discover a segment via a real etcd) runs against a local etcd. It **needs a running etcd to run** — the Docker daemon was down on this machine, so it's compile-verified but not run-tested here. Same honest posture as RDMA (real interface, needs infra).

## CUDA / GPU faithfulness

Mooncake puts GPU **in the Transfer Engine**, not a separate quantize tier. So:
- Added `transport::nvlink::NvlinkTransport` (reserved, feature `nvlink`) — the GPU-resident data path (NVLink intra-node, GPUDirect-RDMA HBM↔NIC) where "CUDA" actually lives in Mooncake. (GPUDirect rides `rdma`; cuFile/GDS would be `nvmeof`.)
- Documented `quillcache-cuda` honestly as the **NVIDIA-Dynamo-KVBM-style HBM (G1) tier + FP8 quantize** — *not* a 1:1 Mooncake component.
- README + web reference-mapping updated: the metadata row (`InMemoryMetadata` / `EtcdMetadata`), a **GPU-data-path** row, the KVBM row split into DRAM/SSD (real) + HBM/cuda (GPU box), and a note that cuda mirrors Dynamo KVBM, not Mooncake.

## Verified

Default workspace **60 tests**; `fmt` + `clippy` clean (default **and** `--features etcd`); web build green (10 pages, no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional etcd metadata backend support
  * Added NVLink transport support (reserved)

* **Documentation**
  * Updated architecture reference mapping and status documentation
  * Clarified CUDA tier capabilities and infrastructure requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->