### PR TITLE
docs: etcd backend run-verified against a real etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ differentiation on top:
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
-| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory / ⊙ etcd (real, needs a server) |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
 | Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
 | Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |
@@ -93,11 +93,14 @@ how far each piece is integrated:
   two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
   recovery. All covered by tests (and the `cluster` demo); wiring them into the
   live gateway needs an engine KV-connector for the engine⟷store byte handoff.
-- **⊙ reserved / needs infra** — `RdmaTransport` / `NvlinkTransport` (behind
-  `rdma` / `nvlink`), the `EtcdMetadata` backend (behind `etcd` — real etcd-client
-  code + a background-watch-synced cache, compile-checked in CI, needs a running
-  etcd to run), and the CUDA device tier (`quillcache-cuda --features cuda` on a
-  GPU box). All real interfaces; the default build is hardware-free.
+- **◑ real, behind a feature / needs infra to run** — the `EtcdMetadata` backend
+  (behind `etcd` — real etcd-client code + a background-watch-synced cache,
+  compile-checked in CI and **verified against a real etcd in Docker**: two
+  backends discover a segment via the etcd watch; the integration test is
+  `#[ignore]` since CI has no etcd).
+- **⊙ reserved / needs hardware** — `RdmaTransport` / `NvlinkTransport` (behind
+  `rdma` / `nvlink`) and the CUDA device tier (`quillcache-cuda --features cuda` on
+  a GPU box). Real interfaces, stubbed so the default build is hardware-free.
 
 `cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
 

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -13,7 +13,7 @@ read end-to-end and measure.
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
-| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory / ⊙ etcd (real, needs a server) |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
 | Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
 | Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |


### PR DESCRIPTION
Ran the `#[ignore]` etcd integration test against a real etcd (Docker): two `EtcdMetadata` backends — one publishes a segment, the other discovers it via the etcd **watch** (and a remove propagates too) — **passed**. Upgrades the docs from "compile-checked, needs a server to run" to **verified against a real etcd**.

- README status: split "◑ real behind a feature / needs infra (etcd — verified vs real etcd; `#[ignore]` in CI)" from "⊙ reserved / needs hardware (rdma/nvlink/cuda)".
- reference-mapping etcd row → "✅ etcd (verified vs real etcd)".

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata backend documentation to clearly confirm that both in-memory and etcd backends are verified and operational
  * Revised status mappings and descriptions for transport layer options and CUDA tier features to better reflect actual support levels
  * Improved documentation clarity regarding hardware requirements and specialized setup needs for advanced capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->