### PR TITLE
feat(core): Conductor routing — PrefixCacheTable overlap → Dynamo cost (Phase 3b)

### DIFF
--- a/crates/quillcache-core/src/conductor.rs
+++ b/crates/quillcache-core/src/conductor.rs
@@ -20,7 +20,8 @@
 //! guard holds at the routing layer too: a request never gets prefix credit for a
 //! different tenant / model / adapter's cache.
 
-use crate::IdentityScope;
+use crate::router::DynamoCostRouter;
+use crate::{IdentityScope, WorkerState};
 use std::collections::{HashMap, HashSet};
 
 /// A serving instance (engine / worker) id.
@@ -192,6 +193,59 @@ impl KVEventHandler {
     }
 }
 
+/// The cache-aware routing **Conductor**: a [`PrefixCacheTable`] (fed by KV events
+/// via the [`KVEventHandler`]) queried by the Dynamo cost function to pick the
+/// instance with the best KV-cache locality, traded off against load. This is
+/// Mooncake's `Conductor` job — "route this request where its prefix is already
+/// cached, unless that instance is too busy".
+#[derive(Debug, Default)]
+pub struct Conductor {
+    events: KVEventHandler,
+    router: DynamoCostRouter,
+}
+
+impl Conductor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply an engine's KV-cache event to the prefix table.
+    pub fn observe(&mut self, event: KvCacheEvent) {
+        self.events.handle(event);
+    }
+
+    pub fn table(&self) -> &PrefixCacheTable {
+        &self.events.table
+    }
+
+    /// Pick the lowest-cost instance for a request: the Dynamo cost over each
+    /// instance's contiguous prefix overlap (from the table) plus its load.
+    pub fn route(
+        &self,
+        ctx: &ModelContext,
+        prefix_hashes: &[PrefixHash],
+        workers: &[WorkerState],
+    ) -> Option<InstanceId> {
+        if workers.is_empty() {
+            return None;
+        }
+        let overlap = self.events.table.query_overlap(ctx, prefix_hashes);
+        let prompt_blocks = prefix_hashes.len();
+        let cost = |w: &WorkerState| {
+            self.router.cost_with_overlap(
+                prompt_blocks,
+                w.queued_prefill_tokens,
+                w.running_decodes,
+                overlap.get(&w.id).copied().unwrap_or(0),
+            )
+        };
+        workers
+            .iter()
+            .min_by(|a, b| cost(a).total_cmp(&cost(b)))
+            .map(|w| w.id.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,5 +319,48 @@ mod tests {
             .table
             .query_overlap(&c, &[ph("p0"), ph("p1")])
             .is_empty());
+    }
+
+    #[test]
+    fn conductor_routes_to_the_instance_with_the_best_cached_prefix() {
+        let mut conductor = Conductor::new();
+        let c = ctx("ten-a");
+        conductor.observe(KvCacheEvent::BlockStored {
+            ctx: c.clone(),
+            prefix_hashes: vec![ph("p0"), ph("p1"), ph("p2")],
+            instance: "gpu-0".into(),
+        });
+        let workers = vec![
+            WorkerState::new("gpu-0", "dc"),
+            WorkerState::new("gpu-1", "dc"),
+        ];
+        let prefix = vec![ph("p0"), ph("p1"), ph("p2")];
+        // gpu-0 has the whole prefix cached → it wins on locality.
+        assert_eq!(
+            conductor.route(&c, &prefix, &workers).as_deref(),
+            Some("gpu-0")
+        );
+    }
+
+    #[test]
+    fn heavy_decode_load_spills_off_the_cache_hot_instance() {
+        let mut conductor = Conductor::new();
+        let c = ctx("ten-a");
+        conductor.observe(KvCacheEvent::BlockStored {
+            ctx: c.clone(),
+            prefix_hashes: vec![ph("p0"), ph("p1")],
+            instance: "gpu-0".into(),
+        });
+        let prefix = vec![ph("p0"), ph("p1")];
+        // gpu-0 has the cache but is swamped (100 running decodes); gpu-1 is idle.
+        // cost(gpu-0) = max(0, 2−2) + 100 = 100; cost(gpu-1) = max(0, 2−0) + 0 = 2.
+        let workers = vec![
+            WorkerState::new("gpu-0", "dc").with_load(0, 100),
+            WorkerState::new("gpu-1", "dc"),
+        ];
+        assert_eq!(
+            conductor.route(&c, &prefix, &workers).as_deref(),
+            Some("gpu-1")
+        );
     }
 }

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod index_holt;
 #[cfg(feature = "rocksdb")]
 pub mod index_rocksdb;
 
-pub use conductor::{KVEventHandler, KvCacheEvent, ModelContext, PrefixCacheTable};
+pub use conductor::{Conductor, KVEventHandler, KvCacheEvent, ModelContext, PrefixCacheTable};
 pub use control::*;
 pub use router::*;
 

--- a/crates/quillcache-core/src/router.rs
+++ b/crates/quillcache-core/src/router.rs
@@ -631,6 +631,25 @@ impl DynamoCostRouter {
         self.config.prefill_load_scale * adjusted_prefill + decode_blocks
     }
 
+    /// Dynamo's per-worker cost from a precomputed **contiguous prefix-overlap**
+    /// block count (the Conductor's [`crate::PrefixCacheTable`] result) instead of
+    /// walking the residency snapshot. The overlap is credited at the device (HBM)
+    /// rate — an engine's prefix cache lives in GPU memory. Lower is better.
+    pub fn cost_with_overlap(
+        &self,
+        prompt_blocks: usize,
+        queued_prefill_tokens: u32,
+        running_decodes: u32,
+        overlap_blocks: usize,
+    ) -> f64 {
+        let block_tokens = self.config.block_tokens.max(1);
+        let queued_blocks = f64::from(queued_prefill_tokens) / f64::from(block_tokens);
+        let raw_prefill_blocks = prompt_blocks as f64 + queued_blocks;
+        let overlap_credit = self.config.overlap_score_credit * overlap_blocks as f64;
+        let adjusted_prefill = (raw_prefill_blocks - overlap_credit).max(0.0);
+        self.config.prefill_load_scale * adjusted_prefill + f64::from(running_decodes)
+    }
+
     pub fn route(
         &self,
         request: &RequestShape,


### PR DESCRIPTION
Ties the Conductor's index to the cost router: pick the instance with the best KV-cache locality, traded off against load — Mooncake's Conductor job.

- **`DynamoCostRouter::cost_with_overlap`** — Dynamo's per-worker cost from a precomputed **contiguous prefix-overlap** block count (the `PrefixCacheTable` result) instead of walking the residency snapshot. Reuses the same cost config; overlap credited at the device (HBM) rate.
- **`Conductor`** — wraps a `KVEventHandler` (→ `PrefixCacheTable`) + a `DynamoCostRouter`: `observe(event)` feeds the table; `route(ctx, prefix_hashes, workers)` picks the min-cost instance from `query_overlap` + the cost fn.

## Verified (2 new tests)

- the **cache-hot instance wins** on locality;
- but a **swamped instance spills** to an idle one (`cost(gpu-0) = max(0, 2−2) + 100 = 100` vs `cost(gpu-1) = max(0, 2−0) + 0 = 2`) — the cache-vs-load tradeoff.

Workspace **66 tests**; `fmt` + `clippy` clean.

**Next (3c):** adopt the `Conductor` as the gateway's live router (build `ModelContext` + prefix hashes per request, feed the table from `/v1/kv-events`) in place of the residency-snapshot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache-aware routing component that observes KV cache events and intelligently routes requests to instances by combining contiguous prefix cache matches with per-worker load metrics for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->