### PR TITLE
feat(gateway): route via the Conductor in the live control plane (Phase 3c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ cargo run -- cluster --nodes 4 --requests 12
 cargo run --features "rocksdb holt" -- bench-index --backend holt
 cargo run --features "rocksdb holt" -- bench-index --backend rocksdb
 
-# Run the OpenAI-compatible gateway in front of real engines (optionally backed
-# by a persistent ART/Holt residency index that survives restarts: index: holt).
+# Run the OpenAI-compatible gateway in front of real engines. Options in the
+# config: a persistent ART/Holt residency index that survives restarts
+# (index: holt), and Conductor routing — the Mooncake prefix-cache table + the
+# Dynamo cost function (conductor: true).
 cargo run -- gateway --config examples/quillcache-gateway.yaml
 cargo run --features holt -- gateway --config examples/quillcache-gateway.yaml
 

--- a/crates/quillcache-core/src/control.rs
+++ b/crates/quillcache-core/src/control.rs
@@ -1,11 +1,14 @@
-use crate::router::{GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy};
+use crate::router::{
+    plan_for_worker, GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy,
+};
 use crate::{
-    BlockRemovedEvent, BlockStoredEvent, CacheResidency, CacheTier, DataPlane, DataPlaneAction,
-    DataPlaneUpdate, EngineEndpoint, EngineRole, ExternalKvBlockKey, IdentityScope, IndexBackend,
-    KvBlockKey, KvEvent, KvEventBatch, MemoryIndex, NoDataPlane, RequestShape, ReuseViolation,
-    WorkerState,
+    BlockRemovedEvent, BlockStoredEvent, CacheResidency, CacheTier, Conductor, CostModel,
+    DataPlane, DataPlaneAction, DataPlaneUpdate, EngineEndpoint, EngineRole, ExternalKvBlockKey,
+    IdentityScope, IndexBackend, KvBlockKey, KvCacheEvent, KvEvent, KvEventBatch, MemoryIndex,
+    ModelContext, NoDataPlane, RequestShape, ReuseViolation, WorkerState,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -214,6 +217,13 @@ pub struct ControlPlane {
     router: Box<dyn RoutingPolicy>,
     residency: Box<dyn IndexBackend>,
     data_plane: Box<dyn DataPlane>,
+    /// The Mooncake Conductor's prefix-cache index, fed by the same KV events +
+    /// inferred placement. When `use_conductor` is on, the worker pick comes from
+    /// [`Conductor::route`] (contiguous-prefix overlap → Dynamo cost) instead of
+    /// the residency-snapshot router; the per-block plan still uses residency.
+    conductor: Conductor,
+    use_conductor: bool,
+    cost_model: CostModel,
 }
 
 impl ControlPlane {
@@ -250,6 +260,113 @@ impl ControlPlane {
             router,
             residency,
             data_plane: Box::new(NoDataPlane),
+            conductor: Conductor::new(),
+            use_conductor: false,
+            cost_model: CostModel::default(),
+        }
+    }
+
+    /// Route via the Mooncake Conductor (the prefix-cache table + the Dynamo cost
+    /// function) instead of the residency-snapshot router. Off by default (the
+    /// residency router is unchanged); the gateway turns it on by config
+    /// (`conductor: true`).
+    pub fn with_conductor_routing(mut self, on: bool) -> Self {
+        self.use_conductor = on;
+        self
+    }
+
+    /// The request's `ModelContext` + its prefix-inclusive block hashes — the
+    /// Conductor's query key.
+    fn request_prefix(request: &RequestShape) -> (ModelContext, Vec<String>) {
+        let scope = IdentityScope {
+            model_id: request.model_id.clone(),
+            tokenizer_id: request.tokenizer_id.clone(),
+            adapter_id: request.adapter_id.clone(),
+            tenant_id: request.tenant_id.clone(),
+        };
+        let block_size = request.blocks.first().map_or(0, |block| block.token_count);
+        let prefix_hashes = request
+            .blocks
+            .iter()
+            .map(|block| block.block_hash.clone())
+            .collect();
+        (ModelContext::from_scope(&scope, block_size), prefix_hashes)
+    }
+
+    /// Pick a route: via the Conductor when enabled (its worker pick + the
+    /// residency-based per-block plan), else the residency-snapshot router.
+    fn decide(
+        &self,
+        request: &RequestShape,
+        route_workers: &[WorkerState],
+        residency: &[CacheResidency],
+    ) -> Result<RouteDecision, ControlError> {
+        if self.use_conductor {
+            let (ctx, prefix_hashes) = Self::request_prefix(request);
+            if let Some(worker_id) = self.conductor.route(&ctx, &prefix_hashes, route_workers) {
+                if let Some(target) = route_workers.iter().find(|w| w.id == worker_id) {
+                    let worker_by_id: HashMap<&str, &WorkerState> =
+                        route_workers.iter().map(|w| (w.id.as_str(), w)).collect();
+                    return Ok(plan_for_worker(
+                        &self.cost_model,
+                        request,
+                        target,
+                        &worker_by_id,
+                        residency,
+                    ));
+                }
+            }
+        }
+        self.router
+            .route(request, route_workers, residency)
+            .map_err(ControlError::from)
+    }
+
+    /// Feed the Conductor's prefix table from a KV-event batch (BlockStored +
+    /// AllBlocksCleared). Precise per-block removal from the Conductor is a
+    /// refinement — the residency index already handles precise eviction for the
+    /// per-block plan + the reuse audit; the prefix table refreshes on re-store /
+    /// clear.
+    fn feed_conductor(&mut self, batch: &KvEventBatch) {
+        let Some(engine) = self
+            .engines
+            .iter()
+            .find(|engine| engine.id == batch.engine_id)
+            .cloned()
+        else {
+            return;
+        };
+        for event in &batch.events {
+            match event {
+                KvEvent::BlockStored(stored) => {
+                    let scope = IdentityScope {
+                        model_id: batch
+                            .model_id
+                            .clone()
+                            .unwrap_or_else(|| engine.model_id.clone()),
+                        tokenizer_id: batch
+                            .tokenizer_id
+                            .clone()
+                            .unwrap_or_else(|| engine.tokenizer_id.clone()),
+                        adapter_id: batch.adapter_id.clone().or(stored.lora_name.clone()),
+                        tenant_id: batch
+                            .tenant_id
+                            .clone()
+                            .unwrap_or_else(|| engine.tenant_id.clone()),
+                    };
+                    self.conductor.observe(KvCacheEvent::BlockStored {
+                        ctx: ModelContext::from_scope(&scope, stored.block_size),
+                        prefix_hashes: stored.block_hashes.clone(),
+                        instance: engine.id.clone(),
+                    });
+                }
+                KvEvent::AllBlocksCleared => {
+                    self.conductor.observe(KvCacheEvent::InstanceGone {
+                        instance: engine.id.clone(),
+                    });
+                }
+                KvEvent::BlockRemoved(_) => {}
+            }
         }
     }
 
@@ -267,9 +384,7 @@ impl ControlPlane {
 
     pub fn route(&self, request: &RequestShape) -> Result<RouteDecision, ControlError> {
         let residency = self.residency.snapshot();
-        self.router
-            .route(request, &self.workers, &residency)
-            .map_err(ControlError::from)
+        self.decide(request, &self.workers, &residency)
     }
 
     pub fn plan(&self, request: &RequestShape) -> Result<RequestPlan, ControlError> {
@@ -294,10 +409,7 @@ impl ControlPlane {
         } else {
             decode_workers
         };
-        let route = self
-            .router
-            .route(request, &route_workers, &residency)
-            .map_err(ControlError::from)?;
+        let route = self.decide(request, &route_workers, &residency)?;
         let decode_worker_id = route.worker_id.clone();
         let decode_role = self
             .workers
@@ -406,11 +518,22 @@ impl ControlPlane {
                 actions.extend(self.mirror_data_plane_update(update));
             }
         }
+        // Mirror the inferred placement into the Conductor's prefix table so
+        // cache-aware routing learns from routing too (the floor; KV events refine).
+        let (ctx, prefix_hashes) = Self::request_prefix(request);
+        if !prefix_hashes.is_empty() {
+            self.conductor.observe(KvCacheEvent::BlockStored {
+                ctx,
+                prefix_hashes,
+                instance: engine_id.to_string(),
+            });
+        }
         actions
     }
 
     pub fn ingest(&mut self, batch: KvEventBatch) -> Result<IngestSummary, ControlError> {
         let mut summary = ingest_batch(self.residency.as_mut(), batch.clone(), &self.engines)?;
+        self.feed_conductor(&batch);
         if self.data_plane.name() != "none" {
             let update = self.apply_batch_to_data_plane(&batch)?;
             self.mirror_data_plane_update(update);
@@ -728,6 +851,67 @@ mod tests {
         let decision = control.route(&request).unwrap();
         assert_eq!(decision.worker_id, "vllm-b");
         assert_eq!(decision.local_hits.len(), 1);
+    }
+
+    #[test]
+    fn conductor_routing_picks_the_engine_with_the_cached_prefix() {
+        let mut control = ControlPlane::new(vec![
+            engine(),
+            EngineEndpoint {
+                id: "vllm-b".to_string(),
+                base_url: "http://127.0.0.1:8002".to_string(),
+                locality_domain: "local".to_string(),
+                ..engine()
+            },
+        ])
+        .with_conductor_routing(true);
+        // vllm-b reports (via a KV event) that it cached prefix block "h0" — this
+        // feeds the Conductor's prefix table.
+        control
+            .ingest(KvEventBatch {
+                engine_id: "vllm-b".to_string(),
+                ts_ms: None,
+                model_id: None,
+                tokenizer_id: None,
+                adapter_id: None,
+                tenant_id: None,
+                bytes_per_block: Some(1024),
+                events: vec![KvEvent::BlockStored(BlockStoredEvent {
+                    block_hashes: vec!["h0".to_string()],
+                    parent_block_hash: None,
+                    token_ids: vec![1],
+                    block_size: 1,
+                    medium: Some("gpu".to_string()),
+                    lora_name: None,
+                    group_idx: None,
+                    bytes_per_block: None,
+                })],
+            })
+            .unwrap();
+
+        let request = RequestShape {
+            id: "req-1".to_string(),
+            model_id: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            session_id: None,
+            blocks: vec![KvBlockKey::external_hash(ExternalKvBlockKey {
+                model_id: "Qwen/Qwen3-0.6B".to_string(),
+                tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+                adapter_id: None,
+                tenant_id: "tenant-a".to_string(),
+                prefix_hash: "root".to_string(),
+                block_hash: "h0".to_string(),
+                block_index: 0,
+                token_count: 1,
+            })],
+            estimated_decode_tokens: 16,
+            slo: SloTarget::default(),
+        };
+        // The Conductor (prefix table fed by the KV event) routes to vllm-b.
+        let decision = control.route(&request).unwrap();
+        assert_eq!(decision.worker_id, "vllm-b");
     }
 
     #[test]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -85,6 +85,11 @@ pub struct GatewayConfig {
     /// a Dynamo KVBM bridge.
     #[serde(default)]
     pub action_sink: Option<ActionSinkConfig>,
+    /// Route via the Mooncake Conductor (the prefix-cache table + the Dynamo cost
+    /// function), fed by the same KV events + inferred placement, instead of the
+    /// residency-snapshot router. Off by default.
+    #[serde(default)]
+    pub conductor: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -359,8 +364,10 @@ pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
         .as_ref()
         .map(|sink| sink.snapshot().kind)
         .unwrap_or_else(|| "none".to_string());
+    let use_conductor = config.conductor.unwrap_or(false);
     let control = ControlPlane::with_index_and_policy(config.engines, index, policy)
-        .with_data_plane(data_plane);
+        .with_data_plane(data_plane)
+        .with_conductor_routing(use_conductor);
     tracing::info!(
         policy = %policy_name,
         index = %index_name,
@@ -1057,6 +1064,7 @@ mod tests {
             index_path: None,
             data_plane: None,
             action_sink: None,
+            conductor: None,
         };
         // No backend configured -> in-memory reference.
         assert_eq!(build_index(&base).name(), "memory");


### PR DESCRIPTION
Wires the Conductor into the gateway's routing path. **Opt-in** (default off → the residency-snapshot router is unchanged, so the working path-A gateway is untouched).

- **`ControlPlane`** gains a `Conductor`, fed by the *same* signals as the residency index: `ingest()` (KV `BlockStored` / `AllBlocksCleared` → the prefix table) and `observe_placement()` (inferred placement → `BlockStored`). Precise per-block removal from the prefix table is left as a refinement — the residency index still handles precise eviction for the per-block plan + the reuse audit.
- **`with_conductor_routing(on)`** — when on, the **worker pick** comes from `Conductor::route` (`ModelContext` + contiguous-prefix overlap → Dynamo cost); the **per-block plan** (local hits / transfers / recomputes, decision headers) still uses residency via `plan_for_worker`. `route()`/`plan()` share a `decide()` helper.
- **Gateway config** gains `conductor: bool` → `with_conductor_routing`.

## Verified

`conductor_routing_picks_the_engine_with_the_cached_prefix` — a KV event on `vllm-b` feeds the prefix table, and a matching request routes to `vllm-b`; **all existing control-plane tests pass unchanged** (the default-off path). Workspace **67 tests**; `fmt` + `clippy` clean.

This **completes Phase 3** — the Mooncake OSS Conductor (`PrefixCacheTable` + `ModelContext` + `KVEventHandler` + cost-based routing) is now the gateway's cache-aware router when enabled (`conductor: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)