### PR TITLE
ci: give the etcd backend its own job with protobuf-compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
           cargo test -p quillcache-core --features holt
           cargo build -p quillcache --features holt
 
-      - name: etcd metadata backend — compile-check (no etcd server needed)
-        run: cargo check -p quillcache-transfer-engine --features etcd
-
   rocksdb:
     name: rocksdb backend (LSM)
     runs-on: ubuntu-latest
@@ -67,3 +64,24 @@ jobs:
 
       - name: build CLI with rocksdb feature
         run: cargo build -p quillcache --features rocksdb
+
+  etcd:
+    name: etcd metadata backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protobuf-compiler (etcd-client build.rs / prost)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Compile + lint the etcd backend (the integration test is #[ignore]: it
+      # needs a running etcd, so CI does not run it).
+      - name: clippy + compile-check
+        run: cargo clippy -p quillcache-transfer-engine --features etcd --all-targets -- -D warnings


### PR DESCRIPTION
The etcd compile-check failed in CI: `etcd-client v0.14`'s `build.rs` compiles proto files via `prost-build`, which needs **`protoc`** — present on my Mac locally but not on the GitHub ubuntu runner.

Moved the etcd check out of the no-toolchain `check` job into a dedicated `etcd` job that installs `protobuf-compiler` first (mirroring how the `rocksdb` job installs `clang`). The job runs `clippy --all-targets --features etcd` (compile + lint); the integration test stays `#[ignore]` (needs a live etcd).

Fixes the failing `ci` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized continuous integration workflow to improve code quality assurance and build reliability processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->