### PR TITLE
feat(store): expose the store MasterService over HTTP (Phase 4a)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cluster;
 mod gateway;
+mod store_master_http;
 
 use crate::gateway::run_from_config_path;
 use clap::{Parser, Subcommand};
@@ -54,6 +55,15 @@ enum Command {
         #[arg(long, default_value_t = 12)]
         requests: usize,
     },
+    /// Run the store's MasterService over HTTP (Mooncake's master service): the
+    /// two-phase Put, identity-guarded Get, Mount, Remove, for out-of-process
+    /// engine KV connectors. Object bytes still move via the transfer engine.
+    StoreMaster {
+        #[arg(long, default_value = "127.0.0.1:7777")]
+        addr: String,
+        #[arg(long, default_value = "random")]
+        strategy: String,
+    },
 }
 
 #[tokio::main]
@@ -70,6 +80,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Gateway { config } => run_from_config_path(config).await?,
         Command::Plan => print_plan(),
         Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
+        Command::StoreMaster { addr, strategy } => {
+            store_master_http::run_store_master(addr, strategy).await?
+        }
         Command::BenchIndex {
             backend,
             requests,

--- a/src/store_master_http.rs
+++ b/src/store_master_http.rs
@@ -1,0 +1,253 @@
+//! HTTP front for the store's [`MasterService`] (Mooncake's `MasterService` is a
+//! coro_rpc network service; here it is axum/HTTP). Out-of-process clients — a
+//! real engine's KV connector (`bridge/`) — drive the **two-phase Put**, the
+//! identity-guarded **Get**, **Mount**, and **Remove** over the network. No
+//! object bytes flow through here: the master returns `(segment, offset)`
+//! locations and the client moves the bytes via the transfer engine.
+//!
+//! Endpoints:
+//! - `POST /v1/mount`            `{name, capacity}`
+//! - `POST /v1/put_start`        `{key, identity, size, replica_num?}` → `{buffers}`
+//! - `POST /v1/put_end`          `{key}`
+//! - `POST /v1/put_revoke`       `{key}`
+//! - `POST /v1/get_replica_list` `{key, identity}` → `{replicas}` (identity-guarded)
+//! - `POST /v1/remove`           `{key, force?}`
+//! - `GET  /v1/state`
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use quillcache_core::IdentityScope;
+use quillcache_store::{AllocatedBuffer, ErrorCode, MasterService, Replica, ReplicateConfig};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+type Shared = Arc<Mutex<MasterService>>;
+
+/// Map a store error to an HTTP status + message.
+fn http_err(error: ErrorCode) -> (StatusCode, String) {
+    let code = match error {
+        ErrorCode::ObjectNotFound | ErrorCode::SegmentNotFound => StatusCode::NOT_FOUND,
+        ErrorCode::ObjectAlreadyExists | ErrorCode::ObjectNotReady => StatusCode::CONFLICT,
+        // The identity guard: a cross-identity Get is a forbidden reuse.
+        ErrorCode::UnsafeReuse(_) => StatusCode::FORBIDDEN,
+        _ => StatusCode::BAD_REQUEST,
+    };
+    (code, error.to_string())
+}
+
+#[derive(Deserialize)]
+struct MountReq {
+    name: String,
+    capacity: u64,
+}
+
+#[derive(Deserialize)]
+struct PutStartReq {
+    key: String,
+    identity: IdentityScope,
+    size: u64,
+    #[serde(default)]
+    replica_num: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PutStartResp {
+    buffers: Vec<AllocatedBuffer>,
+}
+
+#[derive(Deserialize)]
+struct KeyReq {
+    key: String,
+}
+
+#[derive(Deserialize)]
+struct RemoveReq {
+    key: String,
+    #[serde(default)]
+    force: bool,
+}
+
+#[derive(Deserialize)]
+struct GetReq {
+    key: String,
+    identity: IdentityScope,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GetResp {
+    replicas: Vec<Replica>,
+}
+
+#[derive(Serialize)]
+struct StateResp {
+    objects: usize,
+    segments: usize,
+    capacity: u64,
+    allocated: u64,
+}
+
+async fn mount(State(master): State<Shared>, Json(req): Json<MountReq>) -> Json<bool> {
+    master.lock().unwrap().mount_segment(req.name, req.capacity);
+    Json(true)
+}
+
+async fn put_start(
+    State(master): State<Shared>,
+    Json(req): Json<PutStartReq>,
+) -> Result<Json<PutStartResp>, (StatusCode, String)> {
+    let config = req
+        .replica_num
+        .map(ReplicateConfig::replicas)
+        .unwrap_or_default();
+    let buffers = master
+        .lock()
+        .unwrap()
+        .put_start(req.key, req.identity, req.size, &config)
+        .map_err(http_err)?;
+    Ok(Json(PutStartResp { buffers }))
+}
+
+async fn put_end(
+    State(master): State<Shared>,
+    Json(req): Json<KeyReq>,
+) -> Result<Json<bool>, (StatusCode, String)> {
+    master.lock().unwrap().put_end(&req.key).map_err(http_err)?;
+    Ok(Json(true))
+}
+
+async fn put_revoke(
+    State(master): State<Shared>,
+    Json(req): Json<KeyReq>,
+) -> Result<Json<bool>, (StatusCode, String)> {
+    master
+        .lock()
+        .unwrap()
+        .put_revoke(&req.key)
+        .map_err(http_err)?;
+    Ok(Json(true))
+}
+
+async fn get_replica_list(
+    State(master): State<Shared>,
+    Json(req): Json<GetReq>,
+) -> Result<Json<GetResp>, (StatusCode, String)> {
+    let replicas = master
+        .lock()
+        .unwrap()
+        .get_replica_list(&req.key, &req.identity)
+        .map_err(http_err)?;
+    Ok(Json(GetResp { replicas }))
+}
+
+async fn remove(
+    State(master): State<Shared>,
+    Json(req): Json<RemoveReq>,
+) -> Result<Json<bool>, (StatusCode, String)> {
+    master
+        .lock()
+        .unwrap()
+        .remove(&req.key, req.force)
+        .map_err(http_err)?;
+    Ok(Json(true))
+}
+
+async fn state(State(master): State<Shared>) -> Json<StateResp> {
+    let master = master.lock().unwrap();
+    Json(StateResp {
+        objects: master.object_count(),
+        segments: master.segment_count(),
+        capacity: master.capacity(),
+        allocated: master.allocated(),
+    })
+}
+
+fn router(shared: Shared) -> Router {
+    Router::new()
+        .route("/v1/mount", post(mount))
+        .route("/v1/put_start", post(put_start))
+        .route("/v1/put_end", post(put_end))
+        .route("/v1/put_revoke", post(put_revoke))
+        .route("/v1/get_replica_list", post(get_replica_list))
+        .route("/v1/remove", post(remove))
+        .route("/v1/state", get(state))
+        .with_state(shared)
+}
+
+pub async fn run_store_master(
+    addr: String,
+    strategy: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let shared: Shared = Arc::new(Mutex::new(MasterService::new(&strategy)));
+    let socket: SocketAddr = addr.parse()?;
+    let listener = TcpListener::bind(socket).await?;
+    println!("QuillCache store MasterService on http://{socket} (strategy: {strategy})");
+    println!(
+        "  POST /v1/{{mount,put_start,put_end,put_revoke,get_replica_list,remove}} · GET /v1/state"
+    );
+    axum::serve(listener, router(shared)).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn two_phase_put_then_identity_guarded_get_over_http() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shared: Shared = Arc::new(Mutex::new(MasterService::new("random")));
+        tokio::spawn(async move { axum::serve(listener, router(shared)).await.unwrap() });
+        let base = format!("http://{addr}");
+        let http = reqwest::Client::new();
+        let id_a = serde_json::json!({"model_id":"m","tokenizer_id":"t","adapter_id":null,"tenant_id":"ten-a"});
+
+        // Mount a segment.
+        http.post(format!("{base}/v1/mount"))
+            .json(&serde_json::json!({"name":"seg-0","capacity":65536}))
+            .send()
+            .await
+            .unwrap();
+
+        // Two-phase Put: put_start allocates a replica, put_end commits it.
+        let started = http
+            .post(format!("{base}/v1/put_start"))
+            .json(&serde_json::json!({"key":"k","identity":id_a,"size":16,"replica_num":1}))
+            .send()
+            .await
+            .unwrap();
+        assert!(started.status().is_success());
+        let body: PutStartResp = started.json().await.unwrap();
+        assert_eq!(body.buffers.len(), 1);
+        http.post(format!("{base}/v1/put_end"))
+            .json(&serde_json::json!({"key":"k"}))
+            .send()
+            .await
+            .unwrap();
+
+        // Get with the writer's identity → 200.
+        let get = http
+            .post(format!("{base}/v1/get_replica_list"))
+            .json(&serde_json::json!({"key":"k","identity":id_a}))
+            .send()
+            .await
+            .unwrap();
+        assert!(get.status().is_success());
+        let got: GetResp = get.json().await.unwrap();
+        assert_eq!(got.replicas.len(), 1);
+
+        // Get with a different tenant → 403 (the identity guard, over HTTP).
+        let id_b = serde_json::json!({"model_id":"m","tokenizer_id":"t","adapter_id":null,"tenant_id":"ten-b"});
+        let refused = http
+            .post(format!("{base}/v1/get_replica_list"))
+            .json(&serde_json::json!({"key":"k","identity":id_b}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(refused.status(), StatusCode::FORBIDDEN);
+    }
+}


### PR DESCRIPTION
Mooncake's `MasterService` is a coro_rpc **network service**; ours had been in-process. `src/store_master_http.rs` is the axum/HTTP front + a `quillcache store-master` CLI — out-of-process clients (a real engine's KV connector) drive the store over the network. **No object bytes flow through it** (it returns `(segment, offset)` locations; the client moves bytes via the transfer engine).

## Endpoints

`POST /v1/{mount, put_start, put_end, put_revoke, get_replica_list, remove}` + `GET /v1/state`.

- `put_start` returns the allocated replica buffers.
- `get_replica_list` is **identity-guarded** — a cross-identity Get → **403 FORBIDDEN** (the guard over the wire).
- Store errors map to HTTP status (NotFound→404, AlreadyExists/NotReady→409, `UnsafeReuse`→403).

## Verified

`two_phase_put_then_identity_guarded_get_over_http` — mount → `put_start` (1 replica) → `put_end` → get (writer identity) **200** → get (different tenant) **403**, all over real HTTP (reqwest). Workspace **68 tests**; `fmt` + `clippy` clean.

**Next (4b):** a faithful Python engine-connector on this master + the transfer-engine wire (the real vLLM KV-tensor plumbing stays GPU-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added StoreMaster CLI subcommand to run the store's master service over HTTP
  * Configurable HTTP server address (default `127.0.0.1:7777`) and strategy options (default `random`)
  * REST API endpoints for segment management, put/get operations, and state queries
  * Identity-based access control with appropriate error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->