### PR TITLE
feat(bridge): faithful engine connector on the transfer engine + store master (Phase 4b)

### DIFF
--- a/bridge/quillcache_store_client.py
+++ b/bridge/quillcache_store_client.py
@@ -1,0 +1,109 @@
+"""QuillCache Python client for the Mooncake-faithful store — talk to the store
+`MasterService` (HTTP) and to a Transfer Engine storage node (the `(segment,
+offset)` TCP wire). Stdlib only, so it runs inside a vLLM container.
+
+Two services back this (run them with the `quillcache` binary):
+  - `quillcache store-master`   — the MasterService (two-phase Put, identity-guarded Get)
+  - `quillcache transfer-node`  — a storage node serving one named RAM segment
+
+The transfer wire mirrors quillcache-transfer-engine/src/transport/tcp.rs:
+    read  : [u8 0][u64 offset][u64 len]            -> [u8 status][u64 len][data]
+    write : [u8 1][u64 offset][u64 len][data]      -> [u8 status]
+all integers big-endian; status 0 = ok, 2 = error.
+"""
+
+import json
+import socket
+import struct
+import urllib.request
+
+OP_READ, OP_WRITE = 0, 1
+ST_OK = 0
+
+
+def identity(model_id, tokenizer_id, tenant_id, adapter_id=None):
+    """An IdentityScope dict matching quillcache_core::IdentityScope's JSON."""
+    return {
+        "model_id": model_id,
+        "tokenizer_id": tokenizer_id,
+        "adapter_id": adapter_id,
+        "tenant_id": tenant_id,
+    }
+
+
+def _recv_exact(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("transfer node closed the connection")
+        buf += chunk
+    return buf
+
+
+class TransferEngineClient:
+    """Move bytes to / from a storage node's RAM segment by `(offset, length)`."""
+
+    def read(self, endpoint, offset, length):
+        host, port = endpoint.rsplit(":", 1)
+        with socket.create_connection((host, int(port))) as sock:
+            sock.sendall(struct.pack(">BQQ", OP_READ, offset, length))
+            status = _recv_exact(sock, 1)[0]
+            if status != ST_OK:
+                raise IOError("transfer node read out of segment bounds")
+            (n,) = struct.unpack(">Q", _recv_exact(sock, 8))
+            return _recv_exact(sock, n)
+
+    def write(self, endpoint, offset, data):
+        host, port = endpoint.rsplit(":", 1)
+        with socket.create_connection((host, int(port))) as sock:
+            sock.sendall(struct.pack(">BQQ", OP_WRITE, offset, len(data)) + data)
+            if _recv_exact(sock, 1)[0] != ST_OK:
+                raise IOError("transfer node write failed")
+
+
+class StoreMasterClient:
+    """The store MasterService over HTTP (`quillcache store-master`)."""
+
+    def __init__(self, base_url):
+        self.base = base_url.rstrip("/")
+
+    def _post(self, path, payload):
+        req = urllib.request.Request(
+            self.base + path,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read() or "null")
+
+    def mount(self, name, capacity):
+        return self._post("/v1/mount", {"name": name, "capacity": capacity})
+
+    def put_start(self, key, identity_scope, size, replica_num=1):
+        # -> [{"segment_name", "offset", "size"}, ...] (the allocated replica buffers)
+        return self._post(
+            "/v1/put_start",
+            {"key": key, "identity": identity_scope, "size": size, "replica_num": replica_num},
+        )["buffers"]
+
+    def put_end(self, key):
+        return self._post("/v1/put_end", {"key": key})
+
+    def put_revoke(self, key):
+        return self._post("/v1/put_revoke", {"key": key})
+
+    def get_replica_list(self, key, identity_scope):
+        # -> [{"id","status","ref_count","data":{"Memory":{segment_name,offset,size}}}, ...]
+        # Raises urllib HTTPError 403 if the identity guard refuses the request.
+        return self._post(
+            "/v1/get_replica_list", {"key": key, "identity": identity_scope}
+        )["replicas"]
+
+    def remove(self, key, force=False):
+        return self._post("/v1/remove", {"key": key, "force": force})
+
+    def state(self):
+        with urllib.request.urlopen(self.base + "/v1/state") as resp:
+            return json.loads(resp.read())

--- a/bridge/vllm_quillcache_connector.py
+++ b/bridge/vllm_quillcache_connector.py
@@ -1,0 +1,83 @@
+"""A vLLM KV connector on the Mooncake-faithful QuillCache store. SKELETON.
+
+- offload (prefill done): `master.put_start` → WRITE each replica's bytes to its
+  `(segment, offset)` over the transfer engine → `master.put_end`.
+- load (prefix hit): `master.get_replica_list` — **identity-guarded**, refused
+  before any byte moves — → READ a replica over the transfer engine.
+
+The store master + the transfer wire are REAL: run `quillcache store-master` +
+`quillcache transfer-node` (see docs/real-engine-pool.md) and the offload/load
+round-trip works with no GPU. What needs a GPU + a pinned vLLM version is the
+`KVConnectorBase_V1` hooks + the KV-tensor (de)serialization — left as documented
+TODOs at the bottom.
+"""
+
+from quillcache_store_client import StoreMasterClient, TransferEngineClient, identity
+
+
+class QuillCacheConnector:
+    """QuillCache-backed external KV store for one vLLM worker."""
+
+    def __init__(self, master_url, segment_endpoints, model_id, tokenizer_id, tenant_id="default"):
+        self.master = StoreMasterClient(master_url)
+        self.transfer = TransferEngineClient()
+        # {segment_name: "host:port"} — the transfer node serving each segment.
+        self.segment_endpoints = dict(segment_endpoints)
+        self.identity = identity(model_id, tokenizer_id, tenant_id)
+        # Mount each storage segment on the master (so put_start can allocate on it).
+        for name in self.segment_endpoints:
+            self.master.mount(name, 1 << 30)
+
+    def offload(self, key, data, replica_num=1):
+        """Two-phase Put: allocate replicas, WRITE the bytes to each, commit."""
+        buffers = self.master.put_start(key, self.identity, len(data), replica_num)
+        for buffer in buffers:
+            endpoint = self.segment_endpoints[buffer["segment_name"]]
+            self.transfer.write(endpoint, buffer["offset"], data)
+        self.master.put_end(key)
+
+    def load(self, key):
+        """Identity-guarded Get: locate a replica, READ its bytes. None on miss.
+
+        Raises urllib HTTPError 403 if the request's identity doesn't match the
+        writer's (the guard refuses before any byte moves)."""
+        replicas = self.master.get_replica_list(key, self.identity)
+        for replica in replicas:
+            memory = replica["data"].get("Memory")
+            if memory:
+                endpoint = self.segment_endpoints[memory["segment_name"]]
+                return self.transfer.read(endpoint, memory["offset"], memory["size"])
+        return None
+
+    # ---- vLLM KVConnectorBase_V1 hooks — wire to YOUR vLLM version ----
+    #
+    # def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kw):
+    #     serialize the freshly computed block → offload(block_key, kv_bytes, ...)
+    #     (quantize to FP8 here to match quillcache-cuda's device tier).
+    # def start_load_kv(self, forward_context, **kw):
+    #     for each prefix block → load(block_key) → copy bytes into vLLM's paged-KV
+    #     slots (the HBM<->bytes layout is the GPU-specific part).
+    # def get_num_new_matched_tokens(self, request, num_computed_tokens):
+    #     sum token_count over the prefix blocks master.get_replica_list resolves,
+    #     so the scheduler skips recomputing that prefix.
+    # See vllm/distributed/kv_transfer/kv_connector/v1/base.py (version-specific).
+
+
+if __name__ == "__main__":
+    # No-GPU round trip against a running store-master + transfer-node:
+    #   quillcache transfer-node --addr 127.0.0.1:8100 --segment seg-0
+    #   quillcache store-master  --addr 127.0.0.1:7777
+    #   python bridge/vllm_quillcache_connector.py
+    import sys
+
+    master_url = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:7777"
+    node = sys.argv[2] if len(sys.argv) > 2 else "127.0.0.1:8100"
+    conn = QuillCacheConnector(
+        master_url,
+        segment_endpoints={"seg-0": node},
+        model_id="Qwen/Qwen2.5-0.5B",
+        tokenizer_id="Qwen/Qwen2.5-0.5B",
+        tenant_id="demo",
+    )
+    conn.offload("prefix-block-0", b"fake-kv-bytes-over-the-faithful-store")
+    print("loaded back:", conn.load("prefix-block-0"))

--- a/docs/real-engine-pool.md
+++ b/docs/real-engine-pool.md
@@ -1,0 +1,79 @@
+# Real engine ↔ the KV store (the data plane)
+
+The faithful Mooncake **Store** data path: a real engine offloads/loads KV bytes
+to/from the distributed pool via the store `MasterService` + the Transfer Engine.
+(For the **control plane** — the gateway routing requests cache-aware — see
+[m3-real-vllm.md](m3-real-vllm.md).)
+
+The pieces (all in this repo):
+
+| piece | what it is |
+| --- | --- |
+| `quillcache store-master` | the `MasterService` over HTTP — two-phase Put, identity-guarded Get, Mount (`src/store_master_http.rs`) |
+| `quillcache transfer-node` | a Transfer Engine storage node serving one named RAM segment over the `(segment, offset)` wire (`src/transfer_node.rs`) |
+| `bridge/quillcache_store_client.py` | stdlib client: the store master (HTTP) + the transfer wire (TCP) |
+| `bridge/vllm_quillcache_connector.py` | a vLLM KV-connector skeleton on the above |
+
+The flow is Mooncake's: **put** = `put_start` (master allocates replica buffers)
+→ WRITE the bytes to each `(segment, offset)` over the transfer engine →
+`put_end`; **get** = `get_replica_list` (identity-guarded — refused *before* any
+byte moves) → READ a replica over the transfer engine. No object bytes ever flow
+through the master.
+
+## Local dry run — no GPU, all real (verified)
+
+Three terminals. This moves **real bytes** through the **real** store; only the
+"KV" payload is fake (a GPU supplies the real tensor bytes).
+
+```bash
+# 1) a storage node — a Transfer Engine segment served over TCP
+cargo run -- transfer-node --addr 127.0.0.1:8100 --segment seg-0
+
+# 2) the store master — metadata, two-phase Put, the identity guard
+cargo run -- store-master --addr 127.0.0.1:7777
+
+# 3) the connector demo — offload a block, load it back through the store
+python3 bridge/vllm_quillcache_connector.py     # run from the bridge/ dir
+#   -> loaded back: b'fake-kv-bytes-over-the-faithful-store'
+curl -s http://127.0.0.1:7777/v1/state
+#   -> {"objects":1,"segments":1,"capacity":...,"allocated":37}
+```
+
+Add more storage nodes (`--addr ... --segment seg-1`, register them in the
+connector's `segment_endpoints` + `--replica-num 2`) and a Put replicates across
+distinct segments. A Get under a different `tenant_id` is refused with HTTP 403
+(the identity guard, over the wire).
+
+## On a GPU (Modal) — wire the connector to vLLM
+
+The connector's store logic (put_start → transfer WRITE → put_end; get_replica_list
+→ transfer READ; identity guard) is real and tested above. What needs a real
+GPU + a pinned vLLM version is the **KV-tensor (de)serialization** and the
+`KVConnectorBase_V1` **hook signatures** — documented TODOs in
+`bridge/vllm_quillcache_connector.py`:
+
+1. Run `store-master` somewhere reachable, and a `transfer-node` co-located with
+   each vLLM worker (same box → `localhost`, no network hop for the warm path).
+2. Register `QuillCacheConnector` as the vLLM KV connector; wire its hooks:
+   - `save_kv_layer` → `offload(block_key, kv_bytes)` (quantize to FP8 to match
+     `quillcache-cuda`'s device tier);
+   - `start_load_kv` → `load(block_key)` (copy pool bytes into vLLM's paged-KV);
+   - `get_num_new_matched_tokens` → how many prefix tokens the store can serve, so
+     the scheduler skips recomputing that prefix.
+3. Measure prefix-cache **hit rate** + **TTFT** with the connector on vs off, under
+   a shared-prefix workload (`bench/run_trace.py`).
+
+## Status — what's real vs what needs hardware
+
+| piece | status |
+| --- | --- |
+| `store-master` (MasterService over HTTP) | **real, tested** (`cargo test`) |
+| `transfer-node` (Transfer Engine segment server) | **real, tested** (the engine's TCP round-trip) |
+| `quillcache_store_client.py` (master HTTP + transfer wire) | **real, tested** (the local e2e above) |
+| connector offload / load (two-phase Put, identity-guarded Get) | **real, tested** (the local e2e above) |
+| vLLM `KVConnectorBase_V1` hooks + KV-tensor (de)serialization | **skeleton** — wire to your vLLM + GPU |
+| RDMA / GPUDirect transfer (vs the TCP wire) | **reserved** — `--features rdma/nvlink`, needs a NIC/GPU |
+
+This mirrors the project's honesty rule: the store + the byte-moving transfer
+engine + the connector path are real and verified on a laptop; the GPU-resident
+tensor plumbing is a clearly-marked seam you complete on your own hardware.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cluster;
 mod gateway;
 mod store_master_http;
+mod transfer_node;
 
 use crate::gateway::run_from_config_path;
 use clap::{Parser, Subcommand};
@@ -64,6 +65,15 @@ enum Command {
         #[arg(long, default_value = "random")]
         strategy: String,
     },
+    /// Run a standalone Transfer Engine storage node serving one named RAM
+    /// segment over the (segment, offset) wire — where a store client / engine
+    /// connector reads & writes KV bytes (bridge/).
+    TransferNode {
+        #[arg(long, default_value = "127.0.0.1:8100")]
+        addr: String,
+        #[arg(long, default_value = "seg-0")]
+        segment: String,
+    },
 }
 
 #[tokio::main]
@@ -82,6 +92,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
         Command::StoreMaster { addr, strategy } => {
             store_master_http::run_store_master(addr, strategy).await?
+        }
+        Command::TransferNode { addr, segment } => {
+            transfer_node::run_transfer_node(addr, segment).await?
         }
         Command::BenchIndex {
             backend,

--- a/src/transfer_node.rs
+++ b/src/transfer_node.rs
@@ -1,0 +1,27 @@
+//! A standalone Transfer Engine storage node: serves one named RAM segment over
+//! TCP (the `(segment, offset)` wire). This is the target a store client / a real
+//! engine's KV connector (`bridge/`) writes KV bytes to and reads them from — the
+//! Mooncake-faithful replacement for the old key-oriented pool node. Run it with
+//! `quillcache transfer-node --addr ... --segment ...`.
+
+use quillcache_transfer_engine::{InMemoryMetadata, MetadataBackend, TransferEngine};
+use std::sync::Arc;
+
+pub async fn run_transfer_node(
+    addr: String,
+    segment: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // A standalone node uses in-memory metadata (the connector addresses it
+    // directly by endpoint); init binds `addr` and serves the segment over TCP.
+    let metadata: Arc<dyn MetadataBackend> = Arc::new(InMemoryMetadata::new());
+    let _engine = TransferEngine::init(segment.clone(), metadata, &addr).await?;
+    println!(
+        "QuillCache transfer node — segment '{segment}' serving the (segment, offset) wire on {addr}"
+    );
+    println!(
+        "  a store client writes/reads KV bytes here at master-allocated offsets; killed to stop"
+    );
+    // The serve loop runs as a task spawned by init; keep the process alive.
+    std::future::pending::<()>().await;
+    Ok(())
+}


### PR DESCRIPTION
Completes **Phase 4** (Mooncake's integration layer): a real engine offloads/loads KV bytes to/from the distributed pool via the store `MasterService` + the Transfer Engine — the Mooncake-faithful replacement for the retired path-B.

- **`quillcache transfer-node`** (`src/transfer_node.rs`) — a standalone Transfer Engine storage node serving one named RAM segment over the `(segment, offset)` wire (where a connector reads/writes KV bytes).
- **`bridge/quillcache_store_client.py`** — stdlib client: the store master (HTTP: `mount`/`put_start`/`put_end`/`get_replica_list`/`remove`) + the transfer wire (TCP, `(segment, offset)` READ/WRITE mirroring `transport/tcp.rs`).
- **`bridge/vllm_quillcache_connector.py`** — a vLLM KV-connector skeleton: `offload` (`put_start` → transfer WRITE → `put_end`) + `load` (`get_replica_list` → transfer READ), **identity-guarded**; the `KVConnectorBase_V1` hooks + KV-tensor (de)serialization are documented GPU/version TODOs.
- **`docs/real-engine-pool.md`** — the faithful data-plane runbook (local no-GPU dry run + GPU wiring + an honest status table).

## Verified (no GPU)

Started `transfer-node` + `store-master`, ran the connector → offloaded a block (two-phase Put + transfer WRITE) and loaded it back:
```
loaded back: b'fake-kv-bytes-over-the-faithful-store'
/v1/state -> {"objects":1,"segments":1,"allocated":37}
```

Workspace **68 tests**; `fmt` + `clippy` clean. This closes Phase 4 — the engine⟷store data path is faithful + runnable, with only the GPU-resident vLLM tensor plumbing left as a marked seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)