### PR TITLE
vLLM KV connector + disaggregated P/D, Mooncake-aligned store internals, CUDA tier, Claude-style docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,23 @@ jobs:
       # needs a running etcd, so CI does not run it).
       - name: clippy + compile-check
         run: cargo clippy -p quillcache-transfer-engine --features etcd --all-targets -- -D warnings
+
+  cuda:
+    name: cuda device tier (compile-check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      # The real CUDA device tier uses cudarc with `dynamic-loading`, so it
+      # COMPILES with no CUDA toolkit or GPU (libcuda is dlopen'd at runtime).
+      # The GPU round-trip tests are #[ignore]: run them on a GPU box via
+      # deploy/modal_cuda_verify.py.
+      - name: clippy + compile-check (--features cuda)
+        run: cargo clippy -p quillcache-cuda --features cuda --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           cargo clippy -p quillcache-transfer-engine --features etcd --all-targets -- -D warnings
           cargo clippy -p quillcache-store --features etcd --all-targets -- -D warnings
+          cargo clippy -p quillcache --features etcd -- -D warnings
 
   cuda:
     name: cuda device tier (compile-check)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # Compile + lint the etcd backend (the integration test is #[ignore]: it
-      # needs a running etcd, so CI does not run it).
+      # Compile + lint the etcd backends — the transfer-engine metadata backend
+      # and the store master's leader election. Both integration tests are
+      # #[ignore] (they need a running etcd), so CI only compile-checks them.
       - name: clippy + compile-check
-        run: cargo clippy -p quillcache-transfer-engine --features etcd --all-targets -- -D warnings
+        run: |
+          cargo clippy -p quillcache-transfer-engine --features etcd --all-targets -- -D warnings
+          cargo clippy -p quillcache-store --features etcd --all-targets -- -D warnings
 
   cuda:
     name: cuda device tier (compile-check)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -396,6 +396,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "cudarc"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+dependencies = [
+ "libloading 0.9.0",
+]
 
 [[package]]
 name = "dashmap"
@@ -983,6 +992,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillcache-cuda"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "bytes",
+ "cudarc",
+ "quillcache-core",
+]
+
+[[package]]
 name = "quillcache-store"
 version = "1.0.0-alpha.1"
 dependencies = [
@@ -1341,6 +1369,7 @@ version = "1.0.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "cudarc",
  "etcd-client",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ version = "1.0.0-alpha.1"
 dependencies = [
  "bytes",
  "crc32fast",
+ "etcd-client",
  "quillcache-core",
  "quillcache-transfer-engine",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,19 @@ members = [
     "crates/quillcache-core",
     "crates/quillcache-store",
     "crates/quillcache-transfer-engine",
+    "crates/quillcache-cuda",
 ]
 default-members = [
     ".",
     "crates/quillcache-core",
     "crates/quillcache-store",
     "crates/quillcache-transfer-engine",
+    "crates/quillcache-cuda",
 ]
-# The CUDA device tier is excluded so the default build never resolves/compiles
-# cudarc on a machine with no NVIDIA GPU. Build it standalone on a GPU box:
-#   cd crates/quillcache-cuda && cargo build --features cuda
-exclude = ["crates/quillcache-cuda"]
+# quillcache-cuda is a workspace member, but its DEFAULT build is a host-only stub
+# (no cudarc), so `cargo build`/`test`/CI never need a CUDA toolkit. The real GPU
+# tier compiles with `--features cuda` — cudarc's `dynamic-loading` builds even
+# without CUDA present (it dlopen's libcuda at runtime) and executes on a GPU box.
 resolver = "2"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,6 @@ rocksdb = ["quillcache-core/rocksdb"]
 # the installed binary minimal. Also lets the online gateway back its residency
 # index with Holt (`index: holt` in the gateway config).
 holt = ["quillcache-core/holt"]
+# Multi-master HA for the store-master binary: etcd leader election. Forwards to
+# quillcache-store's etcd feature (pulls etcd-client, build needs protoc).
+etcd = ["quillcache-store/etcd"]

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ cargo test
 # transfer engine.
 cargo run -- cluster --nodes 4 --requests 12
 
+# Disaggregated prefill/decode demo: the control plane emits a Disaggregated
+# plan, then the freshly-prefilled KV moves prefill-node → decode-node over the
+# transfer engine (identity-guarded). Mooncake's P/D data path, no GPU.
+cargo run -- pd
+
 # The ART-vs-LSM storage study (needs a C++ toolchain for RocksDB).
 cargo run --features "rocksdb holt" -- bench-index --backend holt
 cargo run --features "rocksdb holt" -- bench-index --backend rocksdb

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ differentiation on top:
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA · NVLink reserved |
+| Transfer Engine (`TransferEngine` + `Transport`; host **& GPU HBM** segments) | `quillcache-transfer-engine` (`engine` · `transport::{tcp,rdma,nvlink}` · `device_segment`) | ✅ TCP · ✅ **GPU HBM segment** (L4) / ⊙ RDMA · NVLink reserved |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
 | `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
-| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
-| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |
+| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ✅ **HBM H2D/D2H** (L4) · FP8 quantize (GPU+NVRTC) |
+| Mooncake GPU data path (device segment · GPUDirect-RDMA · NVLink · GDS) | `device_segment` (HBM, cudaMemcpy) · `rdma`/`nvlink` (zero-copy) | ✅ **HBM segment** (L4) · ⊙ GPUDirect/NVLink need a NIC/multi-GPU |
 | Mooncake Conductor / Dynamo KV-Cache Indexer | `conductor` (`PrefixCacheTable` + `ModelContext` + `KVEventHandler`) + residency index (Holt ART) | ✅ longest-prefix overlap · persistent |
 | — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
 
@@ -72,9 +72,9 @@ differentiation on top:
 | --- | --- |
 | `quillcache` (bin) | the OpenAI-compatible **gateway** (proxy · cache-aware routing · streaming · SLO), the local **cluster** demo, and `bench-index` |
 | `quillcache-core` | `KvBlockKey` / `IdentityScope` identity, `CostModel`, `ReuseViolation`; the `router` (incl. `DynamoCostRouter`), `control` plane, `DataPlane` + `IndexBackend` traits, the ART-vs-LSM `bench`, and the feature-gated `index_holt` / `index_rocksdb` backends |
-| `quillcache-transfer-engine` | faithful port of Mooncake's Transfer Engine: `TransferEngine` + `MultiTransport` + `Transport` (`tcp` real / `rdma` reserved) + `TransferMetadata` + `Topology` |
+| `quillcache-transfer-engine` | faithful port of Mooncake's Transfer Engine: `TransferEngine` + `MultiTransport` + `Transport` (`tcp` real · `rdma`/`nvlink` reserved) + `device_segment` (GPU HBM segment, `--features cuda`, **L4-verified**) + `TransferMetadata` + `Topology` |
 | `quillcache-store` | faithful port of `mooncake-store`: `Client`, `MasterService`, `OffsetBufferAllocator`, `AllocationStrategy`, `Replica`, the crash-consistent `DiskTier`, plus `LocalKvStore` (byte pool) + `StoreDataPlane` (tiers) |
-| `quillcache-cuda` | CUDA device tier: HBM↔host copies + FP8 quantize-on-offload (feature-gated, excluded from the default workspace) |
+| `quillcache-cuda` | CUDA device tier (Dynamo-KVBM G1): real HBM↔host copies + FP8 quantize-on-offload via **cudarc 0.19**. Workspace member; default build is a host-only **stub**, `--features cuda` is the real path (cudarc `dynamic-loading` → compiles with no CUDA toolkit; **L4-verified**) |
 
 The two index backends (`index_holt`, `index_rocksdb`) are **feature-gated modules
 inside `quillcache-core`**, off by default — `holt` is pure Rust; `rocksdb` pulls a
@@ -98,11 +98,20 @@ how far each piece is integrated:
   compile-checked in CI and **verified against a real etcd in Docker**: two
   backends discover a segment via the etcd watch; the integration test is
   `#[ignore]` since CI has no etcd).
+- **◑ real, behind a feature / verified on a GPU** — the CUDA device tier
+  (`quillcache-cuda --features cuda`: HBM↔host H2D/D2H, FP8 quantize via NVRTC) and
+  the Transfer Engine **GPU HBM device segment** (`quillcache-transfer-engine
+  --features cuda`: register HBM, serve it over the one-sided `(offset,len)` wire so
+  an *unmodified* TCP peer reads/writes GPU-resident bytes). Both **verified on a
+  Modal NVIDIA L4** (`deploy/modal_cuda_verify.py`); cudarc `dynamic-loading` means
+  they compile with no CUDA toolkit (CI compile-checks both), GPU tests `#[ignore]`.
 - **⊙ reserved / needs hardware** — `RdmaTransport` / `NvlinkTransport` (behind
-  `rdma` / `nvlink`) and the CUDA device tier (`quillcache-cuda --features cuda` on
-  a GPU box). Real interfaces, stubbed so the default build is hardware-free.
+  `rdma` / `nvlink`): GPUDirect-RDMA / NVLink *zero-copy* needs a NIC / multi-GPU.
+  Real interfaces, stubbed so the default build stays hardware-free.
 
-`cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
+`cargo test` — 68 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
+CUDA paths add 2 GPU tests (`#[ignore]`, L4-verified) and a `--features cuda`
+compile-check job in CI.
 
 ## The storage study: ART (Holt) vs LSM (RocksDB)
 
@@ -184,8 +193,12 @@ cargo run --features "rocksdb holt" -- bench-index --backend rocksdb
 cargo run -- gateway --config examples/quillcache-gateway.yaml
 cargo run --features holt -- gateway --config examples/quillcache-gateway.yaml
 
-# Build the CUDA device tier on a GPU box (excluded from the default workspace):
-cd crates/quillcache-cuda && cargo build --features cuda
+# The CUDA paths: the device tier (HBM↔host + FP8 quantize) and the Transfer
+# Engine GPU HBM segment. cudarc `dynamic-loading` compiles them with no CUDA
+# toolkit; the GPU round-trip tests are `#[ignore]`, so run them on a GPU box.
+cargo build -p quillcache-cuda --features cuda
+cargo build -p quillcache-transfer-engine --features cuda
+modal run deploy/modal_cuda_verify.py   # verified on a Modal NVIDIA L4
 ```
 
 ## Non-goals

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ how far each piece is integrated:
   `rdma` / `nvlink`): GPUDirect-RDMA / NVLink *zero-copy* needs a NIC / multi-GPU.
   Real interfaces, stubbed so the default build stays hardware-free.
 
-`cargo test` — 72 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
+`cargo test` — 73 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
 CUDA paths add 2 GPU tests (`#[ignore]`, L4-verified) and a `--features cuda`
 compile-check job in CI.
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ how far each piece is integrated:
 - **▣ tested unit (not yet on the live gateway path)** — the faithful store: a
   `Client` Put→Get over the transfer engine (real TCP), the `MasterService`
   two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
-  recovery. All covered by tests (and the `cluster` demo); wiring them into the
-  live gateway needs an engine KV-connector for the engine⟷store byte handoff.
+  recovery. All covered by tests (and the `cluster` + `pd` demos); the engine⟷store
+  byte handoff is the vLLM KV connector below (GPU-verified).
 - **◑ real, behind a feature / needs infra to run** — the `EtcdMetadata` backend
   (behind `etcd` — real etcd-client code + a background-watch-synced cache,
   compile-checked in CI and **verified against a real etcd in Docker**: two
@@ -109,6 +109,13 @@ how far each piece is integrated:
   an *unmodified* TCP peer reads/writes GPU-resident bytes). Both **verified on a
   Modal NVIDIA L4** (`deploy/modal_cuda_verify.py`); cudarc `dynamic-loading` means
   they compile with no CUDA toolkit (CI compile-checks both), GPU tests `#[ignore]`.
+- **◑ real, verified on a GPU (Modal L4)** — the vLLM 0.22.1 KV connector
+  (`bridge/quillcache_v1_connector.py`, a real `KVConnectorBase_V1`): a prompt's KV
+  is offloaded to the store and **reused** on a later request
+  (`deploy/modal_vllm_connector.py`), and — **disaggregated** — prefill on GPU 0 →
+  store → decode on GPU 1, KV computed on one instance reused by another over the
+  transfer engine (`deploy/modal_vllm_pd.py`). The store is the same identity-guarded
+  `MasterService`; the local (no-GPU) form is `cargo run -- pd`.
 - **⊙ reserved / needs hardware** — `RdmaTransport` / `NvlinkTransport` (behind
   `rdma` / `nvlink`): GPUDirect-RDMA / NVLink *zero-copy* needs a NIC / multi-GPU.
   Real interfaces, stubbed so the default build stays hardware-free.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ differentiation on top:
 | --- | --- | --- |
 | Transfer Engine (`TransferEngine` + `Transport`; host **& GPU HBM** segments) | `quillcache-transfer-engine` (`engine` · `transport::{tcp,rdma,nvlink}` · `device_segment`) | ✅ TCP · ✅ **GPU HBM segment** (L4) / ⊙ RDMA · NVLink reserved |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
-| Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
+| Store `MasterService` (two-phase Put, eviction, **HA**) | `MasterService` + snapshot/recovery + heartbeat health + `MasterElection` | ✅ alloc · lease evict · **crash-safe snapshot + failover** · etcd leader-election (verified) |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
 | `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
@@ -97,7 +97,11 @@ how far each piece is integrated:
   (behind `etcd` — real etcd-client code + a background-watch-synced cache,
   compile-checked in CI and **verified against a real etcd in Docker**: two
   backends discover a segment via the etcd watch; the integration test is
-  `#[ignore]` since CI has no etcd).
+  `#[ignore]` since CI has no etcd). The **master's HA** rides the same seam:
+  `MasterService` snapshot/recovery (atomic) + heartbeat segment-health are unit
+  tested, and `MasterElection` (multi-master etcd leader election + lease
+  failover, `--features etcd`) is **verified against a real etcd in Docker**
+  (`#[ignore]`).
 - **◑ real, behind a feature / verified on a GPU** — the CUDA device tier
   (`quillcache-cuda --features cuda`: HBM↔host H2D/D2H, FP8 quantize via NVRTC) and
   the Transfer Engine **GPU HBM device segment** (`quillcache-transfer-engine
@@ -109,7 +113,7 @@ how far each piece is integrated:
   `rdma` / `nvlink`): GPUDirect-RDMA / NVLink *zero-copy* needs a NIC / multi-GPU.
   Real interfaces, stubbed so the default build stays hardware-free.
 
-`cargo test` — 68 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
+`cargo test` — 72 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
 CUDA paths add 2 GPU tests (`#[ignore]`, L4-verified) and a `--features cuda`
 compile-check job in CI.
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,17 @@ how far each piece is integrated:
   is offloaded to the store and **reused** on a later request
   (`deploy/modal_vllm_connector.py`), and — **disaggregated** — prefill on GPU 0 →
   store → decode on GPU 1, KV computed on one instance reused by another over the
-  transfer engine (`deploy/modal_vllm_pd.py`). The store is the same identity-guarded
-  `MasterService`; the local (no-GPU) form is `cargo run -- pd`.
+  transfer engine (`deploy/modal_vllm_pd.py`). This includes **true vLLM-native P/D**
+  (`deploy/modal_vllm_disagg.py`): prefill as `kv_producer`, decode as `kv_consumer`,
+  and `pd-proxy` as the router minting a `transfer_id` for vLLM's `kv_transfer_params`
+  handshake — the consumer pulls the producer's KV *by id* and skips prefill, with
+  output matching a monolithic run token-for-token. The store is the same
+  identity-guarded `MasterService`; the local (no-GPU) form is `cargo run -- pd`.
 - **⊙ reserved / needs hardware** — `RdmaTransport` / `NvlinkTransport` (behind
   `rdma` / `nvlink`): GPUDirect-RDMA / NVLink *zero-copy* needs a NIC / multi-GPU.
   Real interfaces, stubbed so the default build stays hardware-free.
 
-`cargo test` — 73 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
+`cargo test` — 79 tests pass; `cargo fmt --check` and `cargo clippy` are clean. The
 CUDA paths add 2 GPU tests (`#[ignore]`, L4-verified) and a `--features cuda`
 compile-check job in CI.
 

--- a/bridge/quillcache_store_client.py
+++ b/bridge/quillcache_store_client.py
@@ -101,6 +101,27 @@ class StoreMasterClient:
             "/v1/get_replica_list", {"key": key, "identity": identity_scope}
         )["replicas"]
 
+    # ---- batch APIs (Mooncake BatchPut / BatchGet — one round-trip for many
+    # keys; a prefix's layers offload/load as a batch instead of N calls) ----
+
+    def batch_put_start(self, items, replica_num=1):
+        # items: [(key, identity_scope, size), ...]  -> [[buffer, ...], ...]
+        payload = [{"key": k, "identity": i, "size": s} for (k, i, s) in items]
+        return self._post(
+            "/v1/batch_put_start", {"items": payload, "replica_num": replica_num}
+        )["buffers"]
+
+    def batch_put_end(self, keys):
+        return self._post("/v1/batch_put_end", {"keys": list(keys)})
+
+    def batch_get_replica_list(self, keys, identity_scope):
+        # -> [[replica, ...], ...] aligned with `keys`. Raises HTTPError 403 if the
+        # identity guard refuses (the whole batch is refused).
+        return self._post(
+            "/v1/batch_get_replica_list",
+            {"keys": list(keys), "identity": identity_scope},
+        )["replicas"]
+
     def remove(self, key, force=False):
         return self._post("/v1/remove", {"key": key, "force": force})
 

--- a/bridge/quillcache_store_demo.py
+++ b/bridge/quillcache_store_demo.py
@@ -1,15 +1,16 @@
-"""A vLLM KV connector on the Mooncake-faithful QuillCache store. SKELETON.
+"""No-GPU demo of the QuillCache store offload/load path.
+
+NOTE: this is NOT the vLLM connector — the real `KVConnectorBase_V1` implementation
+is `bridge/quillcache_v1_connector.py` (GPU-verified on Modal). This file is a
+minimal, GPU-free illustration of the store data path that connector rides:
 
 - offload (prefill done): `master.put_start` → WRITE each replica's bytes to its
   `(segment, offset)` over the transfer engine → `master.put_end`.
 - load (prefix hit): `master.get_replica_list` — **identity-guarded**, refused
   before any byte moves — → READ a replica over the transfer engine.
 
-The store master + the transfer wire are REAL: run `quillcache store-master` +
-`quillcache transfer-node` (see docs/real-engine-pool.md) and the offload/load
-round-trip works with no GPU. What needs a GPU + a pinned vLLM version is the
-`KVConnectorBase_V1` hooks + the KV-tensor (de)serialization — left as documented
-TODOs at the bottom.
+Run `quillcache store-master` + `quillcache transfer-node` (see
+docs/real-engine-pool.md) and the offload/load round-trip below works with no GPU.
 """
 
 from quillcache_store_client import StoreMasterClient, TransferEngineClient, identity

--- a/bridge/quillcache_v1_connector.py
+++ b/bridge/quillcache_v1_connector.py
@@ -1,0 +1,446 @@
+"""A REAL vLLM v1 KV connector backed by the QuillCache store.
+
+This subclasses vLLM's `KVConnectorBase_V1` (verified against the exact API of
+the deployed vllm 0.22.1 — see deploy/modal_vllm_introspect.py) and is modelled
+on vLLM's own reference `ExampleConnector`. It keeps vLLM's paged-KV slot-mapping
+extract/inject logic *verbatim* (so the GPU tensor layout is correct for MLA /
+Triton / default attention backends) and swaps the reference's
+safetensors-on-local-disk for the **QuillCache distributed store**:
+
+  - save  (offload): extract a layer's KV for the new prefix blocks → serialize
+    (safetensors in-memory) → two-phase Put into the store (`put_start` → WRITE
+    each replica over the transfer engine → `put_end`).
+  - load  (prefix hit): **identity-guarded** `get_replica_list` (refused, HTTP
+    403, *before any byte moves*, if the requester's identity doesn't match the
+    writer's) → READ a replica over the transfer engine → deserialize → inject
+    into vLLM's paged KV buffer.
+
+The store master + transfer wire are the same real, tested QuillCache services
+used by docs/real-engine-pool.md. The identity guard is QuillCache's
+differentiator over a vanilla shared-storage connector: cross-tenant / cross-model
+KV reuse is refused at the store, not merely by convention.
+
+Run it (see deploy/modal_vllm_connector.py for the full Modal recipe):
+
+    vllm serve <model> \
+      --no-enable-prefix-caching \           # force prefix hits to come via the store
+      --disable-hybrid-kv-cache-manager \    # this connector is not HMA-aware (like ExampleConnector)
+      --kv-transfer-config '{
+        "kv_connector": "QuillCacheV1Connector",
+        "kv_connector_module_path": "quillcache_v1_connector",
+        "kv_role": "kv_both",
+        "kv_connector_extra_config": {
+          "master_url": "http://127.0.0.1:7777",
+          "segment_endpoints": {"seg-0": "127.0.0.1:8100"},
+          "tenant_id": "default",
+          "replica_num": 1
+        }
+      }'
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import safetensors.torch
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
+from vllm.utils.hashing import safe_hash
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+
+# The QuillCache store clients (stdlib; the master over HTTP + the transfer wire over TCP).
+from quillcache_store_client import StoreMasterClient, TransferEngineClient, identity
+
+if TYPE_CHECKING:
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+def align_to_block_size(num_tokens: int, block_size: int) -> int:
+    """Largest block-aligned token count strictly below `num_tokens` (vLLM's rule)."""
+    return max(0, (num_tokens - 1) // block_size * block_size)
+
+
+def _prefix_hash(token_ids: list[int], block_size: int, mm_hashes: list[str]) -> tuple[str, int]:
+    """Canonical (hash, aligned_len) for the block-aligned prompt prefix.
+
+    Computed identically scheduler-side (match check + meta build) so save and
+    load address the same store keys. Mirrors ExampleConnector's foldername hash.
+    """
+    aligned = align_to_block_size(len(token_ids), block_size)
+    token_bytes = torch.tensor(token_ids[:aligned], dtype=torch.long).numpy().tobytes()
+    if mm_hashes:
+        token_bytes += ("-".join(mm_hashes)).encode("utf-8")
+    digest = safe_hash(token_bytes, usedforsecurity=False).hexdigest()
+    return digest, aligned
+
+
+@dataclass
+class ReqMeta:
+    # Block-aligned prompt-prefix tokens this op covers.
+    token_ids: torch.Tensor
+    # Paged-KV slot for each token (same length as token_ids).
+    slot_mapping: torch.Tensor
+    # True = save (offload) this prefix; False = load it from the store.
+    is_store: bool
+    # Canonical store-key prefix (identity + prompt-prefix hash), computed scheduler-side.
+    prefix_hash: str
+
+    @staticmethod
+    def make_meta(
+        token_ids: list[int],
+        block_ids: list[int],
+        block_size: int,
+        is_store: bool,
+        prefix_hash: str,
+    ) -> "ReqMeta":
+        valid_num_tokens = align_to_block_size(len(token_ids), block_size)
+        token_ids_tensor = torch.tensor(token_ids)[:valid_num_tokens]
+        block_ids_tensor = torch.tensor(block_ids)
+        num_blocks = block_ids_tensor.shape[0]
+        block_offsets = torch.arange(0, block_size)
+        slot_mapping = (
+            block_offsets.reshape((1, block_size))
+            + block_ids_tensor.reshape((num_blocks, 1)) * block_size
+        )
+        slot_mapping = slot_mapping.flatten()[:valid_num_tokens]
+        return ReqMeta(
+            token_ids=token_ids_tensor,
+            slot_mapping=slot_mapping,
+            is_store=is_store,
+            prefix_hash=prefix_hash,
+        )
+
+
+@dataclass
+class QuillCacheConnectorMetadata(KVConnectorMetadata):
+    requests: list[ReqMeta] = field(default_factory=list)
+
+    def add_request(
+        self,
+        token_ids: list[int],
+        block_ids: list[int],
+        block_size: int,
+        is_store: bool,
+        prefix_hash: str,
+    ) -> None:
+        self.requests.append(
+            ReqMeta.make_meta(token_ids, block_ids, block_size, is_store, prefix_hash)
+        )
+
+
+class QuillCacheV1Connector(KVConnectorBase_V1):
+    """vLLM v1 KV connector whose external store is the QuillCache pool."""
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        self._block_size = vllm_config.cache_config.block_size
+
+        cfg = self._kv_transfer_config
+        model = vllm_config.model_config.model
+        tokenizer = getattr(vllm_config.model_config, "tokenizer", None) or model
+        # Identity = QuillCache IdentityScope. The store enforces it on every Get.
+        self._identity = identity(
+            model_id=cfg.get_from_extra_config("model_id", model),
+            tokenizer_id=cfg.get_from_extra_config("tokenizer_id", tokenizer),
+            tenant_id=cfg.get_from_extra_config("tenant_id", "default"),
+            adapter_id=cfg.get_from_extra_config("adapter_id", None),
+        )
+        self._master = StoreMasterClient(
+            cfg.get_from_extra_config("master_url", "http://127.0.0.1:7777")
+        )
+        self._transfer = TransferEngineClient()
+        # {segment_name: "host:port"} — the transfer node serving each segment.
+        endpoints = cfg.get_from_extra_config("segment_endpoints", {"seg-0": "127.0.0.1:8100"})
+        if isinstance(endpoints, str):
+            endpoints = json.loads(endpoints)
+        self._segment_endpoints = dict(endpoints)
+        self._replica_num = int(cfg.get_from_extra_config("replica_num", 1))
+
+        # Scheduler-side: requests for which a prefix hit was found and blocks
+        # were allocated, so the worker must load them next forward pass.
+        self._requests_need_load: dict[str, Request] = {}
+        # Worker-side: prefixes saved this step -> aligned token count (for manifest).
+        self._saved_this_step: dict[str, int] = {}
+
+        # The worker owns byte movement; it registers the storage segments on the
+        # master so put_start can allocate on them. Idempotent-tolerant.
+        if role == KVConnectorRole.WORKER:
+            for name in self._segment_endpoints:
+                try:
+                    self._master.mount(name, 1 << 30)
+                except Exception as e:  # already mounted, or master not up yet
+                    logger.info("segment %s mount skipped: %s", name, e)
+
+        logger.info(
+            "QuillCacheV1Connector role=%s master=%s segments=%s identity=%s",
+            role,
+            self._master.base,
+            list(self._segment_endpoints),
+            self._identity,
+        )
+
+    # ==============================
+    # Store primitives (the real QuillCache data path)
+    # ==============================
+
+    def _layer_key(self, prefix_hash: str, layer_name: str) -> str:
+        return f"qc/{prefix_hash}/{layer_name}"
+
+    def _manifest_key(self, prefix_hash: str) -> str:
+        return f"qc/{prefix_hash}/__manifest__"
+
+    def _put_bytes(self, key: str, data: bytes) -> None:
+        """Two-phase Put: allocate replica buffers, WRITE each, commit."""
+        buffers = self._master.put_start(key, self._identity, len(data), self._replica_num)
+        for buffer in buffers:
+            endpoint = self._segment_endpoints[buffer["segment_name"]]
+            self._transfer.write(endpoint, buffer["offset"], data)
+        self._master.put_end(key)
+
+    def _get_bytes(self, key: str) -> bytes | None:
+        """Identity-guarded Get: locate a replica, READ its bytes. None on miss.
+
+        The store refuses (HTTP 403) before any byte moves if this connector's
+        identity doesn't match the writer's — surfaced here as a logged miss."""
+        try:
+            replicas = self._master.get_replica_list(key, self._identity)
+        except Exception as e:
+            code = getattr(e, "code", None)
+            if code == 403:
+                logger.warning("QuillCache identity guard REFUSED reuse of %s", key)
+            elif code not in (404,):
+                logger.warning("get_replica_list(%s) failed: %s", key, e)
+            return None
+        for replica in replicas:
+            memory = (replica.get("data") or {}).get("Memory")
+            if memory:
+                endpoint = self._segment_endpoints[memory["segment_name"]]
+                return self._transfer.read(endpoint, memory["offset"], memory["size"])
+        return None
+
+    def _exists(self, key: str) -> bool:
+        """Does this prefix's commit manifest exist & is it ours? (no byte move)."""
+        try:
+            return bool(self._master.get_replica_list(key, self._identity))
+        except Exception as e:
+            if getattr(e, "code", None) == 403:
+                logger.warning("QuillCache identity guard REFUSED match on %s", key)
+            return False
+
+    @staticmethod
+    def _serialize(t: torch.Tensor) -> bytes:
+        return safetensors.torch.save({"kv": t.detach().cpu().contiguous()})
+
+    @staticmethod
+    def _deserialize(buf: bytes, device: str) -> torch.Tensor:
+        return safetensors.torch.load(buf)["kv"].to(device)
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        """Inject store-resident KV for each load request into the paged buffer."""
+
+        def inject_kv_into_layer(
+            dst_kv_cache_layer: torch.Tensor,
+            src_kv_cache: torch.Tensor,
+            slot_mapping: torch.Tensor,
+            attn_metadata: AttentionMetadata,
+        ) -> None:
+            # Verbatim from vLLM's ExampleConnector — layout-correct per backend.
+            dst_kv_cache_layer_shape = dst_kv_cache_layer.shape
+            if isinstance(attn_metadata, MLACommonMetadata):
+                num_pages = dst_kv_cache_layer_shape[0]
+                page_size = dst_kv_cache_layer_shape[1]
+                dst_kv_cache_layer = dst_kv_cache_layer.reshape(num_pages * page_size, -1)
+                dst_kv_cache_layer[slot_mapping, ...] = src_kv_cache
+            elif isinstance(attn_metadata, TritonAttentionMetadata):
+                block_idxs = slot_mapping // self._block_size
+                offsets = slot_mapping % self._block_size
+                dst_kv_cache_layer[block_idxs, :, offsets] = src_kv_cache
+            else:
+                num_pages = dst_kv_cache_layer_shape[1]
+                page_size = dst_kv_cache_layer_shape[2]
+                dst_kv_cache_layer = dst_kv_cache_layer.reshape(2, num_pages * page_size, -1)
+                dst_kv_cache_layer[:, slot_mapping, ...] = src_kv_cache
+
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, QuillCacheConnectorMetadata)
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            logger.warning("start_load_kv: attn_metadata is None")
+            return
+
+        for request in metadata.requests:
+            if request.is_store:
+                continue
+            logger.info(
+                "QuillCache: loading %d tokens of KV from the store (prefix %s)",
+                len(request.slot_mapping),
+                request.prefix_hash[:12],
+            )
+            for layer_name in forward_context.no_compile_layers:
+                layer = forward_context.no_compile_layers[layer_name]
+                kv_cache_layer = getattr(layer, "kv_cache", None)
+                if kv_cache_layer is None:
+                    continue  # skip non-attention layers (MLP/MoE)
+                buf = self._get_bytes(self._layer_key(request.prefix_hash, layer_name))
+                if buf is None:
+                    continue  # miss / evicted / refused — vLLM recomputes this layer
+                kv_cache = self._deserialize(buf, str(kv_cache_layer.device))
+                if isinstance(attn_metadata, dict):
+                    inject_kv_into_layer(
+                        kv_cache_layer, kv_cache, request.slot_mapping, attn_metadata[layer_name]
+                    )
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        # Synchronous loads (above) — nothing to await per layer.
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """Extract a layer's KV for each store request and offload it to the pool."""
+
+        def extract_kv_from_layer(layer: torch.Tensor, slot_mapping: torch.Tensor) -> torch.Tensor:
+            # Verbatim from vLLM's ExampleConnector — inverse of inject.
+            if isinstance(attn_metadata, MLACommonMetadata):
+                num_pages, page_size = layer.shape[0], layer.shape[1]
+                return layer.reshape(num_pages * page_size, -1)[slot_mapping, ...]
+            elif isinstance(attn_metadata, TritonAttentionMetadata):
+                block_idxs = slot_mapping // self._block_size
+                offsets = slot_mapping % self._block_size
+                return layer[block_idxs, :, offsets]
+            num_pages, page_size = layer.shape[1], layer.shape[2]
+            return layer.reshape(2, num_pages * page_size, -1)[:, slot_mapping, ...]
+
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, QuillCacheConnectorMetadata)
+        for request in metadata.requests:
+            if not request.is_store:
+                continue
+            kv_cache = extract_kv_from_layer(kv_layer, request.slot_mapping)
+            self._put_bytes(self._layer_key(request.prefix_hash, layer_name), self._serialize(kv_cache))
+            self._saved_this_step[request.prefix_hash] = int(request.token_ids.numel())
+
+    def wait_for_save(self) -> None:
+        """Commit a manifest per saved prefix — the marker a later match check reads."""
+        for prefix_hash, num_tokens in self._saved_this_step.items():
+            manifest = json.dumps({"tokens": num_tokens, "block_size": self._block_size}).encode()
+            self._put_bytes(self._manifest_key(prefix_hash), manifest)
+            logger.info(
+                "QuillCache: committed %d-token prefix %s to the store",
+                num_tokens,
+                prefix_hash[:12],
+            )
+        self._saved_this_step.clear()
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        """How many *additional* prefix tokens the store can serve for this request."""
+        token_ids = list(request.prompt_token_ids or [])
+        mm_hashes = [f.identifier for f in request.mm_features]
+        prefix_hash, aligned = _prefix_hash(token_ids, self._block_size, mm_hashes)
+        if aligned <= num_computed_tokens:
+            return 0, False
+        if not self._exists(self._manifest_key(prefix_hash)):
+            return 0, False
+        logger.info("QuillCache: external cache HIT for prefix %s", prefix_hash[:12])
+        # Synchronous load (we inject during the forward pass), so async=False.
+        return aligned - num_computed_tokens, False
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ) -> None:
+        if num_external_tokens > 0:
+            self._requests_need_load[request.request_id] = request
+
+    def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:
+        meta = QuillCacheConnectorMetadata()
+        total_need_load = 0
+
+        for new_req in scheduler_output.scheduled_new_reqs:
+            token_ids = new_req.prompt_token_ids or []
+            mm_hashes = [f.identifier for f in new_req.mm_features]
+            prefix_hash, _ = _prefix_hash(list(token_ids), self._block_size, mm_hashes)
+            if new_req.req_id in self._requests_need_load:
+                meta.add_request(
+                    token_ids=list(token_ids),
+                    block_ids=new_req.block_ids[0],
+                    block_size=self._block_size,
+                    is_store=False,
+                    prefix_hash=prefix_hash,
+                )
+                total_need_load += 1
+            elif not self._exists(self._manifest_key(prefix_hash)):
+                # Not already in the store -> save this prefix after the forward.
+                meta.add_request(
+                    token_ids=list(token_ids),
+                    block_ids=new_req.block_ids[0],
+                    block_size=self._block_size,
+                    is_store=True,
+                    prefix_hash=prefix_hash,
+                )
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached_reqs.req_ids):
+            resumed_from_preemption = req_id in cached_reqs.resumed_req_ids
+            if not resumed_from_preemption or req_id not in self._requests_need_load:
+                continue
+            num_computed_tokens = cached_reqs.num_computed_tokens[i]
+            num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            new_block_ids = cached_reqs.new_block_ids[i]
+            request = self._requests_need_load[req_id]
+            total_tokens = num_computed_tokens + num_new_tokens
+            token_ids = request.all_token_ids[:total_tokens]
+            mm_hashes = [f.identifier for f in request.mm_features]
+            prefix_hash, _ = _prefix_hash(list(token_ids), self._block_size, mm_hashes)
+            assert new_block_ids is not None
+            meta.add_request(
+                token_ids=list(token_ids),
+                block_ids=new_block_ids[0],
+                block_size=self._block_size,
+                is_store=False,
+                prefix_hash=prefix_hash,
+            )
+            total_need_load += 1
+
+        assert total_need_load == len(self._requests_need_load)
+        self._requests_need_load.clear()
+        return meta

--- a/bridge/quillcache_v1_connector.py
+++ b/bridge/quillcache_v1_connector.py
@@ -20,6 +20,20 @@ used by docs/real-engine-pool.md. The identity guard is QuillCache's
 differentiator over a vanilla shared-storage connector: cross-tenant / cross-model
 KV reuse is refused at the store, not merely by convention.
 
+Two operating modes, selected by KVTransferConfig.kv_role:
+
+  - `kv_both` (default): single-pool, **content-addressed** reuse. A prefix's KV
+    is keyed by `qc/{identity+prompt-hash}`; any later request with the same
+    prefix transparently loads it. This is the prefix-cache offload path.
+  - `kv_producer` / `kv_consumer`: **true mid-request disaggregation** (vLLM-native
+    P/D). A router mints a `transfer_id` per request and threads it through
+    `kv_transfer_params`: the prefill instance (producer, `do_remote_decode`)
+    offloads the request's KV under `qc-pd/{transfer_id}` and does no decode; the
+    decode instance (consumer, `do_remote_prefill`) pulls that KV by id and skips
+    prefill. The store is the rendezvous, so — unlike a direct RDMA-pull connector
+    — the producer frees its blocks immediately (no delay-free) and the consumer
+    loads synchronously. See src/pd_proxy.rs for the router that mints the id.
+
 Run it (see deploy/modal_vllm_connector.py for the full Modal recipe):
 
     vllm serve <model> \
@@ -97,8 +111,11 @@ class ReqMeta:
     slot_mapping: torch.Tensor
     # True = save (offload) this prefix; False = load it from the store.
     is_store: bool
-    # Canonical store-key prefix (identity + prompt-prefix hash), computed scheduler-side.
-    prefix_hash: str
+    # The store-key namespace for this op's layers + manifest. Either content-
+    # addressed (`qc/{identity-prefix-hash}`, for transparent prefix reuse) or
+    # disaggregation-handshake (`qc-pd/{transfer_id}`, for true mid-request P/D
+    # where a router-minted transfer_id — not the prompt content — names the KV).
+    key_prefix: str
 
     @staticmethod
     def make_meta(
@@ -106,7 +123,7 @@ class ReqMeta:
         block_ids: list[int],
         block_size: int,
         is_store: bool,
-        prefix_hash: str,
+        key_prefix: str,
     ) -> "ReqMeta":
         valid_num_tokens = align_to_block_size(len(token_ids), block_size)
         token_ids_tensor = torch.tensor(token_ids)[:valid_num_tokens]
@@ -122,7 +139,7 @@ class ReqMeta:
             token_ids=token_ids_tensor,
             slot_mapping=slot_mapping,
             is_store=is_store,
-            prefix_hash=prefix_hash,
+            key_prefix=key_prefix,
         )
 
 
@@ -136,10 +153,10 @@ class QuillCacheConnectorMetadata(KVConnectorMetadata):
         block_ids: list[int],
         block_size: int,
         is_store: bool,
-        prefix_hash: str,
+        key_prefix: str,
     ) -> None:
         self.requests.append(
-            ReqMeta.make_meta(token_ids, block_ids, block_size, is_store, prefix_hash)
+            ReqMeta.make_meta(token_ids, block_ids, block_size, is_store, key_prefix)
         )
 
 
@@ -180,10 +197,25 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
         self._segment_endpoints = dict(endpoints)
         self._replica_num = int(cfg.get_from_extra_config("replica_num", 1))
 
+        # Disaggregation role (vLLM KVTransferConfig.kv_role), using vLLM's own
+        # semantics: a pure prefill instance is `kv_producer` (saves a request's
+        # KV for a remote decode), a pure decode instance is `kv_consumer` (loads
+        # it), and `kv_both` is BOTH. The disagg handshake only fires when the
+        # router sets do_remote_* in kv_transfer_params; absent that, a kv_both
+        # instance falls through to single-pool, content-addressed reuse.
+        kv_role = getattr(cfg, "kv_role", None) or "kv_both"
+        self._is_producer = bool(getattr(cfg, "is_kv_producer", False))
+        self._is_consumer = bool(getattr(cfg, "is_kv_consumer", False))
+
         # Scheduler-side: requests for which a prefix hit was found and blocks
         # were allocated, so the worker must load them next forward pass.
         self._requests_need_load: dict[str, Request] = {}
-        # Worker-side: prefixes saved this step -> aligned token count (for manifest).
+        # Scheduler-side disagg handshake: req_id -> router-minted transfer_id.
+        # `_disagg_save` = producer must offload this prefill's KV under the id;
+        # `_disagg_load` = consumer must pull the KV named by the id (not content).
+        self._disagg_save: dict[str, str] = {}
+        self._disagg_load: dict[str, str] = {}
+        # Worker-side: key-prefixes saved this step -> aligned token count (for manifest).
         self._saved_this_step: dict[str, int] = {}
 
         # The worker owns byte movement; it registers the storage segments on the
@@ -196,8 +228,11 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
                     logger.info("segment %s mount skipped: %s", name, e)
 
         logger.info(
-            "QuillCacheV1Connector role=%s master=%s segments=%s identity=%s",
+            "QuillCacheV1Connector role=%s kv_role=%s(producer=%s consumer=%s) master=%s segments=%s identity=%s",
             role,
+            kv_role,
+            self._is_producer,
+            self._is_consumer,
             self._master.base,
             list(self._segment_endpoints),
             self._identity,
@@ -207,11 +242,21 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
     # Store primitives (the real QuillCache data path)
     # ==============================
 
-    def _layer_key(self, prefix_hash: str, layer_name: str) -> str:
-        return f"qc/{prefix_hash}/{layer_name}"
+    @staticmethod
+    def _content_prefix(prefix_hash: str) -> str:
+        """Key namespace for transparent, content-addressed prefix reuse."""
+        return f"qc/{prefix_hash}"
 
-    def _manifest_key(self, prefix_hash: str) -> str:
-        return f"qc/{prefix_hash}/__manifest__"
+    @staticmethod
+    def _pd_prefix(transfer_id: str) -> str:
+        """Key namespace for a disagg P/D handshake (router-minted transfer_id)."""
+        return f"qc-pd/{transfer_id}"
+
+    def _layer_key(self, key_prefix: str, layer_name: str) -> str:
+        return f"{key_prefix}/{layer_name}"
+
+    def _manifest_key(self, key_prefix: str) -> str:
+        return f"{key_prefix}/__manifest__"
 
     def _put_bytes(self, key: str, data: bytes) -> None:
         """Two-phase Put: allocate replica buffers, WRITE each, commit."""
@@ -305,16 +350,16 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
             if request.is_store:
                 continue
             logger.warning(
-                "QC loading %d tokens of KV from the store (prefix %s)",
+                "QC loading %d tokens of KV from the store (%s)",
                 len(request.slot_mapping),
-                request.prefix_hash[:12],
+                request.key_prefix,
             )
             for layer_name in forward_context.no_compile_layers:
                 layer = forward_context.no_compile_layers[layer_name]
                 kv_cache_layer = getattr(layer, "kv_cache", None)
                 if kv_cache_layer is None:
                     continue  # skip non-attention layers (MLP/MoE)
-                buf = self._get_bytes(self._layer_key(request.prefix_hash, layer_name))
+                buf = self._get_bytes(self._layer_key(request.key_prefix, layer_name))
                 if buf is None:
                     continue  # miss / evicted / refused — vLLM recomputes this layer
                 kv_cache = self._deserialize(buf, str(kv_cache_layer.device))
@@ -354,18 +399,22 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
             if not request.is_store:
                 continue
             kv_cache = extract_kv_from_layer(kv_layer, request.slot_mapping)
-            self._put_bytes(self._layer_key(request.prefix_hash, layer_name), self._serialize(kv_cache))
-            self._saved_this_step[request.prefix_hash] = int(request.token_ids.numel())
+            self._put_bytes(self._layer_key(request.key_prefix, layer_name), self._serialize(kv_cache))
+            self._saved_this_step[request.key_prefix] = int(request.token_ids.numel())
 
     def wait_for_save(self) -> None:
-        """Commit a manifest per saved prefix — the marker a later match check reads."""
-        for prefix_hash, num_tokens in self._saved_this_step.items():
+        """Commit a manifest per saved prefix — the marker a later match check reads.
+
+        For a disagg producer (`qc-pd/...`) the consumer pulls by transfer_id and
+        ignores the manifest, but writing it is harmless and keeps the save path
+        uniform (and records the token count for observability)."""
+        for key_prefix, num_tokens in self._saved_this_step.items():
             manifest = json.dumps({"tokens": num_tokens, "block_size": self._block_size}).encode()
-            self._put_bytes(self._manifest_key(prefix_hash), manifest)
+            self._put_bytes(self._manifest_key(key_prefix), manifest)
             logger.warning(
-                "QC committed %d-token prefix %s to the store",
+                "QC committed %d-token prefix to the store (%s)",
                 num_tokens,
-                prefix_hash[:12],
+                key_prefix,
             )
         self._saved_this_step.clear()
 
@@ -380,9 +429,30 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
     ) -> tuple[int | None, bool]:
         """How many *additional* prefix tokens the store can serve for this request."""
         token_ids = list(request.prompt_token_ids or [])
+
+        # --- disagg consumer (decode side): the router told us this request's
+        # prefill was done remotely (`do_remote_prefill`) and named the KV with a
+        # `transfer_id`. Claim the whole block-aligned prefix by id — no content
+        # match, no manifest lookup; the producer guarantees it's in the store. ---
+        params = request.kv_transfer_params or {}
+        if self._is_consumer and params.get("do_remote_prefill"):
+            transfer_id = params.get("transfer_id")
+            aligned = align_to_block_size(len(token_ids), self._block_size)
+            count = aligned - num_computed_tokens
+            if transfer_id and count > 0:
+                self._disagg_load[request.request_id] = str(transfer_id)
+                logger.warning(
+                    "QC disagg consumer: pull %d tokens for transfer_id=%s (req=%s)",
+                    count,
+                    transfer_id,
+                    getattr(request, "request_id", "?"),
+                )
+                return count, False
+            return 0, False
+
         mm_hashes = [f.identifier for f in request.mm_features]
         prefix_hash, aligned = _prefix_hash(token_ids, self._block_size, mm_hashes)
-        exists = self._exists(self._manifest_key(prefix_hash))
+        exists = self._exists(self._manifest_key(self._content_prefix(prefix_hash)))
         logger.warning(
             "QC match-check req=%s prefix=%s manifest=%s num_computed=%d aligned=%d block_size=%d ntok=%d",
             getattr(request, "request_id", "?"),
@@ -406,6 +476,16 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ) -> None:
+        # --- disagg producer (prefill side): the router asked us to make this
+        # request's KV available for a remote decode (`do_remote_decode`) under a
+        # `transfer_id`. Remember it so build_connector_meta emits a save op. ---
+        params = request.kv_transfer_params or {}
+        if self._is_producer and params.get("do_remote_decode"):
+            transfer_id = params.get("transfer_id")
+            if transfer_id:
+                self._disagg_save[request.request_id] = str(transfer_id)
+            else:
+                logger.warning("QC disagg producer: do_remote_decode with no transfer_id")
         if num_external_tokens > 0:
             self._requests_need_load[request.request_id] = request
 
@@ -414,26 +494,52 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
         total_need_load = 0
 
         for new_req in scheduler_output.scheduled_new_reqs:
-            token_ids = new_req.prompt_token_ids or []
-            mm_hashes = [f.identifier for f in new_req.mm_features]
-            prefix_hash, _ = _prefix_hash(list(token_ids), self._block_size, mm_hashes)
-            if new_req.req_id in self._requests_need_load:
+            token_ids = list(new_req.prompt_token_ids or [])
+            req_id = new_req.req_id
+
+            # --- disagg producer: offload this prefill's KV under transfer_id. ---
+            if req_id in self._disagg_save:
                 meta.add_request(
-                    token_ids=list(token_ids),
-                    block_ids=new_req.block_ids[0],
-                    block_size=self._block_size,
-                    is_store=False,
-                    prefix_hash=prefix_hash,
-                )
-                total_need_load += 1
-            elif not self._exists(self._manifest_key(prefix_hash)):
-                # Not already in the store -> save this prefix after the forward.
-                meta.add_request(
-                    token_ids=list(token_ids),
+                    token_ids=token_ids,
                     block_ids=new_req.block_ids[0],
                     block_size=self._block_size,
                     is_store=True,
-                    prefix_hash=prefix_hash,
+                    key_prefix=self._pd_prefix(self._disagg_save[req_id]),
+                )
+                continue
+
+            # --- disagg consumer: pull the KV named by transfer_id, skip prefill. ---
+            if req_id in self._disagg_load:
+                meta.add_request(
+                    token_ids=token_ids,
+                    block_ids=new_req.block_ids[0],
+                    block_size=self._block_size,
+                    is_store=False,
+                    key_prefix=self._pd_prefix(self._disagg_load[req_id]),
+                )
+                total_need_load += 1
+                continue
+
+            # --- content-addressed reuse (single-pool / kv_both default). ---
+            mm_hashes = [f.identifier for f in new_req.mm_features]
+            prefix_hash, _ = _prefix_hash(token_ids, self._block_size, mm_hashes)
+            if req_id in self._requests_need_load:
+                meta.add_request(
+                    token_ids=token_ids,
+                    block_ids=new_req.block_ids[0],
+                    block_size=self._block_size,
+                    is_store=False,
+                    key_prefix=self._content_prefix(prefix_hash),
+                )
+                total_need_load += 1
+            elif not self._exists(self._manifest_key(self._content_prefix(prefix_hash))):
+                # Not already in the store -> save this prefix after the forward.
+                meta.add_request(
+                    token_ids=token_ids,
+                    block_ids=new_req.block_ids[0],
+                    block_size=self._block_size,
+                    is_store=True,
+                    key_prefix=self._content_prefix(prefix_hash),
                 )
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -447,18 +553,46 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
             request = self._requests_need_load[req_id]
             total_tokens = num_computed_tokens + num_new_tokens
             token_ids = request.all_token_ids[:total_tokens]
-            mm_hashes = [f.identifier for f in request.mm_features]
-            prefix_hash, _ = _prefix_hash(list(token_ids), self._block_size, mm_hashes)
             assert new_block_ids is not None
+            # A resumed disagg consumer keeps its transfer_id key; otherwise content.
+            if req_id in self._disagg_load:
+                key_prefix = self._pd_prefix(self._disagg_load[req_id])
+            else:
+                mm_hashes = [f.identifier for f in request.mm_features]
+                prefix_hash, _ = _prefix_hash(list(token_ids), self._block_size, mm_hashes)
+                key_prefix = self._content_prefix(prefix_hash)
             meta.add_request(
                 token_ids=list(token_ids),
                 block_ids=new_block_ids[0],
                 block_size=self._block_size,
                 is_store=False,
-                prefix_hash=prefix_hash,
+                key_prefix=key_prefix,
             )
             total_need_load += 1
 
         assert total_need_load == len(self._requests_need_load)
         self._requests_need_load.clear()
+        self._disagg_save.clear()
+        self._disagg_load.clear()
         return meta
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Disagg producer: confirm the handshake back to the router.
+
+        The prefill's KV is durably in the store (committed during wait_for_save),
+        so we DON'T delay-free the prefill blocks (`False`) — unlike a direct
+        RDMA-pull connector that must hold blocks until the decode side reads
+        them. We return the handshake (`do_remote_prefill` + `transfer_id`) so a
+        router that relays the response's kv_transfer_params can route the decode.
+        """
+        params = request.kv_transfer_params or {}
+        if self._is_producer and params.get("do_remote_decode") and params.get("transfer_id"):
+            return False, {
+                "do_remote_prefill": True,
+                "transfer_id": params["transfer_id"],
+            }
+        return False, None

--- a/bridge/quillcache_v1_connector.py
+++ b/bridge/quillcache_v1_connector.py
@@ -291,16 +291,21 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
 
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, QuillCacheConnectorMetadata)
+        n_load = sum(1 for r in metadata.requests if not r.is_store)
         attn_metadata = forward_context.attn_metadata
         if attn_metadata is None:
-            logger.warning("start_load_kv: attn_metadata is None")
+            if n_load:
+                logger.warning(
+                    "QC start_load_kv: attn_metadata is None but load_reqs=%d — load SKIPPED",
+                    n_load,
+                )
             return
 
         for request in metadata.requests:
             if request.is_store:
                 continue
-            logger.info(
-                "QuillCache: loading %d tokens of KV from the store (prefix %s)",
+            logger.warning(
+                "QC loading %d tokens of KV from the store (prefix %s)",
                 len(request.slot_mapping),
                 request.prefix_hash[:12],
             )
@@ -357,8 +362,8 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
         for prefix_hash, num_tokens in self._saved_this_step.items():
             manifest = json.dumps({"tokens": num_tokens, "block_size": self._block_size}).encode()
             self._put_bytes(self._manifest_key(prefix_hash), manifest)
-            logger.info(
-                "QuillCache: committed %d-token prefix %s to the store",
+            logger.warning(
+                "QC committed %d-token prefix %s to the store",
                 num_tokens,
                 prefix_hash[:12],
             )
@@ -377,11 +382,24 @@ class QuillCacheV1Connector(KVConnectorBase_V1):
         token_ids = list(request.prompt_token_ids or [])
         mm_hashes = [f.identifier for f in request.mm_features]
         prefix_hash, aligned = _prefix_hash(token_ids, self._block_size, mm_hashes)
-        if aligned <= num_computed_tokens:
+        exists = self._exists(self._manifest_key(prefix_hash))
+        logger.warning(
+            "QC match-check req=%s prefix=%s manifest=%s num_computed=%d aligned=%d block_size=%d ntok=%d",
+            getattr(request, "request_id", "?"),
+            prefix_hash[:12],
+            exists,
+            num_computed_tokens,
+            aligned,
+            self._block_size,
+            len(token_ids),
+        )
+        if aligned <= num_computed_tokens or not exists:
             return 0, False
-        if not self._exists(self._manifest_key(prefix_hash)):
-            return 0, False
-        logger.info("QuillCache: external cache HIT for prefix %s", prefix_hash[:12])
+        logger.warning(
+            "QC external cache HIT prefix=%s (+%d tokens)",
+            prefix_hash[:12],
+            aligned - num_computed_tokens,
+        )
         # Synchronous load (we inject during the forward pass), so async=False.
         return aligned - num_computed_tokens, False
 

--- a/crates/quillcache-core/src/control.rs
+++ b/crates/quillcache-core/src/control.rs
@@ -80,6 +80,43 @@ pub struct RequestPlan {
     pub actions: Vec<PlanAction>,
 }
 
+/// The prefill → decode KV handoff a disaggregated plan implies (Mooncake's P/D
+/// data path): the freshly-prefilled blocks the `prefill_worker` computes and
+/// publishes to the store, which the `decode_worker` then reads over the
+/// Transfer Engine before continuing generation. `None` in aggregated mode (the
+/// same worker prefills and decodes, so no KV crosses the wire).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KvHandoff {
+    pub request_id: String,
+    pub prefill_worker_id: String,
+    pub decode_worker_id: String,
+    pub blocks: Vec<KvBlockKey>,
+}
+
+impl RequestPlan {
+    /// The disaggregated prefill → decode KV handoff this plan implies, or `None`
+    /// when serving aggregated. The handoff blocks are the plan's `RunPrefill`
+    /// actions — the KV prefill computes that decode must receive.
+    pub fn kv_handoff(&self) -> Option<KvHandoff> {
+        if self.mode != ServingMode::Disaggregated {
+            return None;
+        }
+        let prefill_worker_id = self.prefill_worker_id.clone()?;
+        let blocks = self
+            .actions
+            .iter()
+            .filter(|action| action.kind == PlanActionKind::RunPrefill)
+            .filter_map(|action| action.key.clone())
+            .collect();
+        Some(KvHandoff {
+            request_id: self.route.request_id.clone(),
+            prefill_worker_id,
+            decode_worker_id: self.decode_worker_id.clone(),
+            blocks,
+        })
+    }
+}
+
 /// Translate a batch of engine KV events into residency updates against any
 /// [`IndexBackend`].
 ///
@@ -1141,5 +1178,42 @@ mod tests {
             .actions
             .iter()
             .any(|action| action.kind == PlanActionKind::Decode));
+
+        // The disaggregated plan implies a concrete prefill→decode KV handoff:
+        // the cold block prefill-a computes is what decode-a must receive.
+        let handoff = plan.kv_handoff().expect("disaggregated plan has a handoff");
+        assert_eq!(handoff.request_id, "req-pd");
+        assert_eq!(handoff.prefill_worker_id, "prefill-a");
+        assert_eq!(handoff.decode_worker_id, "decode-a");
+        assert_eq!(handoff.blocks.len(), 1);
+    }
+
+    #[test]
+    fn aggregated_plan_has_no_kv_handoff() {
+        // A single aggregated worker prefills and decodes in place — no KV
+        // crosses the wire, so there is no prefill→decode handoff.
+        let control = ControlPlane::new(vec![engine()]);
+        let request = RequestShape {
+            id: "req-agg".to_string(),
+            model_id: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            session_id: None,
+            blocks: vec![KvBlockKey::new(
+                "Qwen/Qwen3-0.6B",
+                "Qwen/Qwen3-0.6B",
+                "tenant-a",
+                "root",
+                "cold",
+                0,
+                64,
+            )],
+            estimated_decode_tokens: 16,
+            slo: SloTarget::default(),
+        };
+        let plan = control.plan(&request).unwrap();
+        assert_eq!(plan.mode, ServingMode::Aggregated);
+        assert!(plan.kv_handoff().is_none());
     }
 }

--- a/crates/quillcache-core/src/control.rs
+++ b/crates/quillcache-core/src/control.rs
@@ -80,6 +80,17 @@ pub struct RequestPlan {
     pub actions: Vec<PlanAction>,
 }
 
+/// The control plane's admission decision (Mooncake's overload-oriented early
+/// rejection): admit with a plan, or reject when the SLO can't be met.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AdmissionDecision {
+    Admit(Box<RequestPlan>),
+    Reject {
+        reason: String,
+        best_slo_violation_us: u64,
+    },
+}
+
 /// The prefill → decode KV handoff a disaggregated plan implies (Mooncake's P/D
 /// data path): the freshly-prefilled blocks the `prefill_worker` computes and
 /// publishes to the store, which the `decode_worker` then reads over the
@@ -261,6 +272,10 @@ pub struct ControlPlane {
     conductor: Conductor,
     use_conductor: bool,
     cost_model: CostModel,
+    /// Overload admission: reject a request if the best worker would still
+    /// violate its SLO by more than this many microseconds. `None` admits all
+    /// (Mooncake's overload-oriented early rejection).
+    max_slo_violation_us: Option<u64>,
 }
 
 impl ControlPlane {
@@ -300,6 +315,7 @@ impl ControlPlane {
             conductor: Conductor::new(),
             use_conductor: false,
             cost_model: CostModel::default(),
+            max_slo_violation_us: None,
         }
     }
 
@@ -310,6 +326,33 @@ impl ControlPlane {
     pub fn with_conductor_routing(mut self, on: bool) -> Self {
         self.use_conductor = on;
         self
+    }
+
+    /// Enable overload admission: reject a request when even the best worker
+    /// would violate its SLO by more than `max_violation_us` (Mooncake's
+    /// overload-oriented early rejection). Off by default (admit all).
+    pub fn with_admission_slo_limit(mut self, max_violation_us: u64) -> Self {
+        self.max_slo_violation_us = Some(max_violation_us);
+        self
+    }
+
+    /// Plan the request, then either admit it or **reject it early** if even the
+    /// best worker would violate the SLO past the configured limit (overload).
+    /// With no limit set, always admits.
+    pub fn admit(&self, request: &RequestShape) -> Result<AdmissionDecision, ControlError> {
+        let plan = self.plan(request)?;
+        if let Some(limit) = self.max_slo_violation_us {
+            if plan.route.slo_violation_us > limit {
+                return Ok(AdmissionDecision::Reject {
+                    reason: format!(
+                        "overloaded: best worker '{}' would violate SLO by {}us (limit {}us)",
+                        plan.route.worker_id, plan.route.slo_violation_us, limit
+                    ),
+                    best_slo_violation_us: plan.route.slo_violation_us,
+                });
+            }
+        }
+        Ok(AdmissionDecision::Admit(Box::new(plan)))
     }
 
     /// The request's `ModelContext` + its prefix-inclusive block hashes — the
@@ -1215,5 +1258,49 @@ mod tests {
         let plan = control.plan(&request).unwrap();
         assert_eq!(plan.mode, ServingMode::Aggregated);
         assert!(plan.kv_handoff().is_none());
+    }
+
+    #[test]
+    fn overload_admission_rejects_when_slo_cannot_be_met() {
+        let cold = RequestShape {
+            id: "r".to_string(),
+            model_id: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            session_id: None,
+            blocks: vec![KvBlockKey::new(
+                "Qwen/Qwen3-0.6B",
+                "Qwen/Qwen3-0.6B",
+                "tenant-a",
+                "root",
+                "cold",
+                0,
+                64,
+            )],
+            estimated_decode_tokens: 16,
+            // A zero TTFT/TPOT budget can't be met by any prefill.
+            slo: SloTarget {
+                ttft_ms: 0,
+                tpot_ms: 0,
+            },
+        };
+
+        // With a zero violation budget, the request is rejected early (overload).
+        let strict = ControlPlane::new(vec![engine()]).with_admission_slo_limit(0);
+        match strict.admit(&cold).unwrap() {
+            AdmissionDecision::Reject {
+                best_slo_violation_us,
+                ..
+            } => assert!(best_slo_violation_us > 0),
+            other => panic!("expected Reject, got {other:?}"),
+        }
+
+        // Default (no admission limit) admits the same request.
+        let lenient = ControlPlane::new(vec![engine()]);
+        assert!(matches!(
+            lenient.admit(&cold).unwrap(),
+            AdmissionDecision::Admit(_)
+        ));
     }
 }

--- a/crates/quillcache-cuda/Cargo.toml
+++ b/crates/quillcache-cuda/Cargo.toml
@@ -6,19 +6,29 @@ description = "CUDA device tier for QuillCache: GPU HBM <-> host KV block copies
 license = "MIT"
 repository = "https://github.com/feichai0017/quillcache"
 
-# NOTE: this crate is intentionally EXCLUDED from the workspace (see the root
-# Cargo.toml `exclude`) so the default build/test on a machine with no NVIDIA GPU
-# never resolves or compiles `cudarc`. Build it on a GPU box:
-#     cd crates/quillcache-cuda && cargo build --features cuda
+# This crate is a workspace member, but its DEFAULT build is a host-only stub with
+# no cudarc dependency, so `cargo build`/`test`/CI need no CUDA toolkit. The real
+# GPU tier is behind `--features cuda`: cudarc with `dynamic-loading` compiles even
+# without CUDA installed (it dlopen's libcuda at runtime), so it builds on any host
+# and executes on a GPU box:
+#     cargo build -p quillcache-cuda --features cuda
 
 [dependencies]
 quillcache-core = { version = "1.0.0-alpha.1", path = "../quillcache-core" }
 bytes = "1"
-cudarc = { version = "0.12", optional = true }
+cudarc = { version = "0.19", optional = true, default-features = false, features = [
+    "driver",
+    "nvrtc",
+    "dynamic-loading",
+    # Pin the CUDA API bindings to 13.0 (matches the Modal GPU image: cuda-toolkit
+    # 13.x). dynamic-loading still dlopen's libcuda at runtime; this only selects
+    # which pre-generated sys bindings compile. Bump to match a different target.
+    "cuda-13000",
+] }
 
 [features]
 default = []
-# Real CUDA device tier. Needs the CUDA toolkit + an NVIDIA GPU at build/run time.
+# Real CUDA device tier (alloc + H2D/D2H + FP8 quantize-on-offload). cudarc's
+# dynamic-loading means this still compiles with no CUDA present; it loads libcuda
+# at runtime, so the real path only executes on an NVIDIA GPU box.
 cuda = ["dep:cudarc"]
-
-[workspace]

--- a/crates/quillcache-cuda/src/gpu.rs
+++ b/crates/quillcache-cuda/src/gpu.rs
@@ -1,20 +1,32 @@
-//! Real CUDA device tier (built only with `--features cuda` on a GPU box).
+//! Real CUDA device tier — built with `--features cuda` (cudarc 0.19, with the
+//! `dynamic-loading` feature, so it compiles even where CUDA is absent and loads
+//! libcuda at runtime on a GPU box).
 //!
-//! Copies KV blocks between GPU HBM and host memory via `cudarc`. The async,
-//! multi-stream, GPUDirect-RDMA version is the production path; this is the
-//! single-stream sync core that the store's HBM tier drives.
-//!
-//! Verify the `cudarc` API against your installed version — the 0.12 surface is
-//! used here (`CudaDevice::new`, `htod_sync_copy`, `dtoh_sync_copy`).
+//! The GPU HBM tier of the KV store: it moves block bytes across the PCIe / NVLink
+//! boundary (H2D reload, D2H offload) and runs the FP16 → FP8 (E4M3)
+//! quantize-on-offload kernel (compiled at startup with NVRTC). The store's HBM
+//! tier drives this; GPUDirect-RDMA / NVLink zero-copy is the Transfer Engine's
+//! concern (see `quillcache-transfer-engine`'s device segment).
 
-use cudarc::driver::{CudaDevice, CudaSlice};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-/// The GPU HBM tier of the KV store. Owns a CUDA device handle and moves block
-/// bytes across the PCIe / NVLink boundary.
+use cudarc::driver::{
+    CudaContext, CudaFunction, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
+};
+use cudarc::nvrtc::compile_ptx;
+
+use crate::QUANTIZE_KERNEL_CU;
+
+const QUANTIZE_FN: &str = "quantize_fp16_to_fp8";
+
+/// The GPU HBM tier of the KV store. Owns a CUDA context + stream; moves block
+/// bytes across the host/device boundary. The FP8 quantize kernel is compiled
+/// lazily (NVRTC) on first use, so binding the device needs only the CUDA driver.
 #[derive(Debug)]
 pub struct DeviceTier {
-    device: Arc<CudaDevice>,
+    ctx: Arc<CudaContext>,
+    stream: Arc<CudaStream>,
+    quantize: OnceLock<CudaFunction>,
 }
 
 impl DeviceTier {
@@ -22,22 +34,120 @@ impl DeviceTier {
         true
     }
 
-    /// Bind to CUDA device `ordinal` (0 = first GPU).
+    /// Bind to CUDA device `ordinal` (0 = first GPU). Driver-only — no NVRTC yet.
     pub fn new(ordinal: usize) -> Result<Self, String> {
-        let device = CudaDevice::new(ordinal).map_err(|e| e.to_string())?;
-        Ok(Self { device })
+        let ctx = CudaContext::new(ordinal).map_err(|e| format!("CudaContext::new: {e:?}"))?;
+        let stream = ctx.default_stream();
+        Ok(Self {
+            ctx,
+            stream,
+            quantize: OnceLock::new(),
+        })
+    }
+
+    /// Which CUDA device this tier is bound to.
+    pub fn ordinal(&self) -> usize {
+        self.ctx.ordinal()
+    }
+
+    /// Compile (once, via NVRTC) + cache the FP16→FP8 quantize kernel.
+    fn quantizer(&self) -> Result<&CudaFunction, String> {
+        if let Some(f) = self.quantize.get() {
+            return Ok(f);
+        }
+        let ptx = compile_ptx(QUANTIZE_KERNEL_CU).map_err(|e| format!("nvrtc compile: {e:?}"))?;
+        let module = self
+            .ctx
+            .load_module(ptx)
+            .map_err(|e| format!("load_module: {e:?}"))?;
+        let func = module
+            .load_function(QUANTIZE_FN)
+            .map_err(|e| format!("load_function {QUANTIZE_FN}: {e:?}"))?;
+        let _ = self.quantize.set(func); // first writer wins on a race
+        Ok(self.quantize.get().unwrap())
     }
 
     /// Reload a cooled block from host memory back into GPU HBM (H2D copy).
     pub fn reload_to_device(&self, host: &[u8]) -> Result<CudaSlice<u8>, String> {
-        self.device.htod_sync_copy(host).map_err(|e| e.to_string())
+        let dev = self
+            .stream
+            .clone_htod(host)
+            .map_err(|e| format!("h2d: {e:?}"))?;
+        self.stream.synchronize().map_err(|e| format!("{e:?}"))?;
+        Ok(dev)
     }
 
     /// Offload a block from GPU HBM to host memory (D2H copy) — the first hop of
     /// demotion to the DRAM / SSD tiers.
     pub fn offload_to_host(&self, device_buf: &CudaSlice<u8>) -> Result<Vec<u8>, String> {
-        self.device
-            .dtoh_sync_copy(device_buf)
-            .map_err(|e| e.to_string())
+        let host = self
+            .stream
+            .clone_dtoh(device_buf)
+            .map_err(|e| format!("d2h: {e:?}"))?;
+        self.stream.synchronize().map_err(|e| format!("{e:?}"))?;
+        Ok(host)
+    }
+
+    /// FP16 → FP8 (E4M3) quantize-on-offload, on the GPU. `fp16` is the raw
+    /// little-endian FP16 bytes of a (cooled) KV block; returns the FP8 bytes,
+    /// i.e. half the size. Halves a cooled block's host/DRAM footprint.
+    pub fn quantize_fp16_to_fp8(&self, fp16: &[u8], scale: f32) -> Result<Vec<u8>, String> {
+        if fp16.len() & 1 != 0 {
+            return Err("fp16 byte length must be even (2 bytes per __half)".into());
+        }
+        let n = (fp16.len() / 2) as i32; // number of __half elements
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+        // Upload the FP16 bytes (the kernel reinterprets the buffer as __half*),
+        // allocate the FP8 output (1 byte per element), launch, copy back.
+        let d_in: CudaSlice<u8> = self
+            .stream
+            .clone_htod(fp16)
+            .map_err(|e| format!("h2d in: {e:?}"))?;
+        let mut d_out: CudaSlice<u8> = self
+            .stream
+            .alloc_zeros(n as usize)
+            .map_err(|e| format!("alloc out: {e:?}"))?;
+        let cfg = LaunchConfig::for_num_elems(n as u32);
+        let func = self.quantizer()?;
+        let mut builder = self.stream.launch_builder(func);
+        builder.arg(&d_in).arg(&mut d_out).arg(&n).arg(&scale);
+        unsafe { builder.launch(cfg) }.map_err(|e| format!("launch: {e:?}"))?;
+        let out = self
+            .stream
+            .clone_dtoh(&d_out)
+            .map_err(|e| format!("d2h out: {e:?}"))?;
+        self.stream.synchronize().map_err(|e| format!("{e:?}"))?;
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These need a real NVIDIA GPU; they compile everywhere (dynamic-loading) but
+    // only run on a GPU box: `cargo test -p quillcache-cuda --features cuda -- --ignored`.
+
+    // Driver-only: H2D/D2H round trip preserves the bytes. Needs just libcuda.
+    #[test]
+    #[ignore = "requires an NVIDIA GPU"]
+    fn host_device_roundtrip() {
+        let tier = DeviceTier::new(0).expect("bind GPU 0");
+        let block: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
+        let dev = tier.reload_to_device(&block).expect("h2d");
+        let back = tier.offload_to_host(&dev).expect("d2h");
+        assert_eq!(block, back, "H2D/D2H must round-trip exactly");
+    }
+
+    // NVRTC: FP16 -> FP8 halves the byte count and runs on the GPU. Needs libnvrtc.
+    #[test]
+    #[ignore = "requires an NVIDIA GPU + NVRTC"]
+    fn quantize_kernel() {
+        let tier = DeviceTier::new(0).expect("bind GPU 0");
+        let fp16 = vec![0u8; 2048]; // 1024 __half elements
+        let fp8 = tier.quantize_fp16_to_fp8(&fp16, 1.0).expect("quantize");
+        assert_eq!(fp8.len(), 1024, "FP8 output is one byte per element");
     }
 }

--- a/crates/quillcache-cuda/src/gpu_stub.rs
+++ b/crates/quillcache-cuda/src/gpu_stub.rs
@@ -1,8 +1,11 @@
 //! Host-only fallback for the CUDA device tier.
 //!
 //! Compiled when the `cuda` feature is off (e.g. on a machine with no NVIDIA
-//! GPU), so callers and tests still build. Every operation reports that the GPU
-//! path is unavailable; the real tier lives in `gpu.rs` behind `--features cuda`.
+//! GPU), so callers and tests still build. Construction fails with a clear
+//! message and the byte-based ops report the GPU path is unavailable; the real
+//! tier lives in `gpu.rs` behind `--features cuda`. The `CudaSlice`-returning
+//! ops (reload_to_device / offload_to_host) exist only on the real tier, since
+//! their type comes from `cudarc`.
 
 /// Placeholder for the GPU HBM tier. Without the `cuda` feature there is no GPU
 /// to bind to, so construction fails with a clear message.
@@ -16,5 +19,15 @@ impl DeviceTier {
 
     pub fn new(_ordinal: usize) -> Result<Self, String> {
         Err("built without the `cuda` feature; build with --features cuda on a GPU box".to_string())
+    }
+
+    pub fn ordinal(&self) -> usize {
+        0
+    }
+
+    /// Mirror of the real tier's quantize op so non-CUDA callers type-check; it
+    /// can never run because [`DeviceTier::new`] fails without the `cuda` feature.
+    pub fn quantize_fp16_to_fp8(&self, _fp16: &[u8], _scale: f32) -> Result<Vec<u8>, String> {
+        Err("CUDA quantize unavailable; build with --features cuda on a GPU box".to_string())
     }
 }

--- a/crates/quillcache-cuda/src/lib.rs
+++ b/crates/quillcache-cuda/src/lib.rs
@@ -9,8 +9,12 @@
 //! block's footprint. The real path is behind the `cuda` feature, built on a GPU
 //! box; a host-only stub keeps callers compiling without an NVIDIA GPU.
 //!
-//! Excluded from the workspace so the default build never resolves `cudarc`.
-//! Build standalone: `cargo build --features cuda` on a GPU box.
+//! A workspace member, but the real path is behind the `cuda` feature: cudarc
+//! 0.19 with `dynamic-loading` compiles with no CUDA present (the default build
+//! is a host-only stub, so CI needs no toolkit) and runs on a GPU box. Build it
+//! with `cargo build -p quillcache-cuda --features cuda`; the H2D/D2H + FP8
+//! quantize round-trips are verified on a Modal NVIDIA L4 via
+//! `deploy/modal_cuda_verify.py` (the GPU tests are `#[ignore]`).
 
 /// The FP16 → FP8 (E4M3) quantize-on-offload kernel source. Compiled with `nvcc`
 /// on a GPU box and loaded by the device tier; embedded here as the reference.

--- a/crates/quillcache-store/Cargo.toml
+++ b/crates/quillcache-store/Cargo.toml
@@ -15,6 +15,15 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util"] }
+# etcd-backed master leader election (the `etcd` feature). Off by default; pulls
+# etcd-client (gRPC/prost — build needs protoc), like the transfer engine's etcd
+# metadata backend.
+etcd-client = { version = "0.14", optional = true }
+
+[features]
+# Mooncake's HA mode: multiple master nodes coordinated through an etcd cluster,
+# which elects one leader. Needs a running etcd; the integration test is #[ignore].
+etcd = ["dep:etcd-client"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "net"] }

--- a/crates/quillcache-store/src/allocator.rs
+++ b/crates/quillcache-store/src/allocator.rs
@@ -1,13 +1,16 @@
 //! Buffer allocator (Mooncake's `mooncake-store/include/allocator.h` +
 //! `offset_allocator/`). A mounted RAM segment is a fixed-size byte arena; the
-//! allocator hands out offset ranges within it. [`OffsetBufferAllocator`] is the
-//! default backend — Mooncake's is an O(1) size-binned offset allocator; this is
-//! a first-fit free-list with coalescing-on-free, the same `allocate` /
-//! `deallocate` / `largest_free_region` contract with simpler internals.
+//! allocator hands out offset ranges within it. Two backends behind the
+//! [`BufferAllocator`] trait:
+//! - [`OffsetBufferAllocator`] — a first-fit free-list with coalescing-on-free
+//!   (simple, the default; alloc scans the free list).
+//! - [`BinnedBufferAllocator`] — Mooncake's size-binned design: free regions are
+//!   bucketed by size class and a bitmask finds the smallest fitting bin in O(1)
+//!   (alloc is O(1) bin-select; coalescing on free uses a by-offset index).
 
 use crate::types::SegmentName;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A buffer allocated from a segment (Mooncake's `AllocatedBuffer`): a
 /// `(segment, offset, size)` triple naming where an object's bytes live so the
@@ -160,6 +163,176 @@ impl BufferAllocator for OffsetBufferAllocator {
     }
 }
 
+/// Size-binned offset allocator — Mooncake's O(1)-style design. Free regions are
+/// bucketed by size class (bin `k` holds regions of size in `[2^k, 2^(k+1))`); a
+/// `u64` bitmask of non-empty bins finds the smallest fitting bin in O(1), so
+/// `allocate` does not scan the whole free list. Coalescing on `deallocate` uses
+/// a by-offset index. Same contract as [`OffsetBufferAllocator`].
+#[derive(Debug)]
+pub struct BinnedBufferAllocator {
+    segment_name: SegmentName,
+    capacity: u64,
+    allocated: u64,
+    /// All free regions, `offset -> size` — for O(log n) neighbour coalescing.
+    by_offset: BTreeMap<u64, u64>,
+    /// Per-size-class sets of free-region offsets (bin = floor(log2(size))).
+    bins: Vec<BTreeSet<u64>>,
+    /// Bit `k` set ⇔ bin `k` is non-empty (the O(1) "smallest fitting bin" find).
+    nonempty: u64,
+}
+
+impl BinnedBufferAllocator {
+    pub fn new(segment_name: impl Into<SegmentName>, capacity: u64) -> Self {
+        let mut a = Self {
+            segment_name: segment_name.into(),
+            capacity,
+            allocated: 0,
+            by_offset: BTreeMap::new(),
+            bins: (0..64).map(|_| BTreeSet::new()).collect(),
+            nonempty: 0,
+        };
+        if capacity > 0 {
+            a.add_free(0, capacity);
+        }
+        a
+    }
+
+    /// Bin index for a region of `size` (≥ 1): floor(log2(size)), in 0..=63.
+    fn bin_of(size: u64) -> usize {
+        63 - size.leading_zeros() as usize
+    }
+
+    fn add_free(&mut self, offset: u64, size: u64) {
+        if size == 0 {
+            return;
+        }
+        self.by_offset.insert(offset, size);
+        let b = Self::bin_of(size);
+        self.bins[b].insert(offset);
+        self.nonempty |= 1u64 << b;
+    }
+
+    fn remove_free(&mut self, offset: u64) -> Option<u64> {
+        let size = self.by_offset.remove(&offset)?;
+        let b = Self::bin_of(size);
+        self.bins[b].remove(&offset);
+        if self.bins[b].is_empty() {
+            self.nonempty &= !(1u64 << b);
+        }
+        Some(size)
+    }
+}
+
+impl BufferAllocator for BinnedBufferAllocator {
+    fn segment_name(&self) -> &str {
+        &self.segment_name
+    }
+
+    fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    fn allocated(&self) -> u64 {
+        self.allocated
+    }
+
+    fn allocate(&mut self, size: u64) -> Option<AllocatedBuffer> {
+        if size == 0 {
+            return None;
+        }
+        let floor = Self::bin_of(size);
+        // The floor bin may hold a region big enough — scan just that bin.
+        let mut chosen = None;
+        if (self.nonempty >> floor) & 1 == 1 {
+            for &offset in &self.bins[floor] {
+                if self.by_offset[&offset] >= size {
+                    chosen = Some(offset);
+                    break;
+                }
+            }
+        }
+        // Otherwise the lowest non-empty bin above `floor` is guaranteed to fit
+        // (its regions are ≥ 2^(floor+1) > size) — found in O(1) via the bitmask.
+        if chosen.is_none() {
+            let higher = if floor + 1 >= 64 {
+                0
+            } else {
+                self.nonempty & !((1u64 << (floor + 1)) - 1)
+            };
+            if higher != 0 {
+                let b = higher.trailing_zeros() as usize;
+                chosen = self.bins[b].iter().next().copied();
+            }
+        }
+        let offset = chosen?;
+        let region = self.remove_free(offset).unwrap();
+        if region > size {
+            self.add_free(offset + size, region - size);
+        }
+        self.allocated += size;
+        Some(AllocatedBuffer {
+            segment_name: self.segment_name.clone(),
+            offset,
+            size,
+        })
+    }
+
+    fn deallocate(&mut self, buffer: &AllocatedBuffer) {
+        let mut start = buffer.offset;
+        let mut end = buffer.offset + buffer.size;
+        // Coalesce with the region immediately before / after, if they abut.
+        let prev = self
+            .by_offset
+            .range(..start)
+            .next_back()
+            .map(|(&o, &l)| (o, l));
+        if let Some((p_off, p_len)) = prev {
+            if p_off + p_len == start {
+                start = p_off;
+                self.remove_free(p_off);
+            }
+        }
+        let next = self.by_offset.range(end..).next().map(|(&o, &l)| (o, l));
+        if let Some((n_off, n_len)) = next {
+            if n_off == end {
+                end = n_off + n_len;
+                self.remove_free(n_off);
+            }
+        }
+        self.add_free(start, end - start);
+        self.allocated = self.allocated.saturating_sub(buffer.size);
+    }
+
+    fn largest_free_region(&self) -> u64 {
+        self.by_offset.values().copied().max().unwrap_or(0)
+    }
+
+    fn reserve(&mut self, offset: u64, size: u64) -> bool {
+        if size == 0 {
+            return false;
+        }
+        let end = offset + size;
+        let containing = self
+            .by_offset
+            .range(..=offset)
+            .next_back()
+            .map(|(&o, &l)| (o, l));
+        let (r_off, r_len) = match containing {
+            Some((o, l)) if o + l >= end => (o, l),
+            _ => return false,
+        };
+        self.remove_free(r_off);
+        if offset > r_off {
+            self.add_free(r_off, offset - r_off);
+        }
+        if r_off + r_len > end {
+            self.add_free(end, (r_off + r_len) - end);
+        }
+        self.allocated += size;
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +364,35 @@ mod tests {
         assert_eq!(a.largest_free_region(), 100);
         // And a full-size allocation succeeds again.
         assert_eq!(a.allocate(100).unwrap().offset, 0);
+    }
+
+    #[test]
+    fn binned_allocate_split_then_coalesce() {
+        let mut a = BinnedBufferAllocator::new("seg-0", 100);
+        let b1 = a.allocate(40).unwrap();
+        assert_eq!(b1.offset, 0);
+        let b2 = a.allocate(40).unwrap();
+        assert_eq!(b2.offset, 40);
+        assert_eq!(a.allocated(), 80);
+        // Only 20 contiguous bytes left.
+        assert!(a.allocate(30).is_none());
+        // Free both (out of order) → coalesce back to one 100B region.
+        a.deallocate(&b1);
+        a.deallocate(&b2);
+        assert_eq!(a.allocated(), 0);
+        assert_eq!(a.largest_free_region(), 100);
+        assert_eq!(a.allocate(100).unwrap().offset, 0);
+    }
+
+    #[test]
+    fn binned_reserve_carves_exact_ranges() {
+        let mut a = BinnedBufferAllocator::new("seg-0", 1000);
+        assert!(a.reserve(100, 64)); // carve [100, 164)
+        assert_eq!(a.allocated(), 64);
+        // A range overlapping the reserved one can't be reserved again.
+        assert!(!a.reserve(120, 16));
+        // A fresh allocation never overlaps the reserved range.
+        let b = a.allocate(64).unwrap();
+        assert!(b.offset + 64 <= 100 || b.offset >= 164);
     }
 }

--- a/crates/quillcache-store/src/allocator.rs
+++ b/crates/quillcache-store/src/allocator.rs
@@ -37,6 +37,10 @@ pub trait BufferAllocator: std::fmt::Debug + Send + Sync {
     fn deallocate(&mut self, buffer: &AllocatedBuffer);
     /// The largest single contiguous free region (the biggest allocatable size).
     fn largest_free_region(&self) -> u64;
+    /// Reserve an exact `(offset, size)` range whose layout is already known —
+    /// used to rebuild allocator state from a snapshot on master recovery.
+    /// Returns false if the range is not entirely free.
+    fn reserve(&mut self, offset: u64, size: u64) -> bool;
 }
 
 /// First-fit offset allocator over a sorted free-list of `offset -> length`
@@ -126,6 +130,33 @@ impl BufferAllocator for OffsetBufferAllocator {
 
     fn largest_free_region(&self) -> u64 {
         self.free.values().copied().max().unwrap_or(0)
+    }
+
+    fn reserve(&mut self, offset: u64, size: u64) -> bool {
+        if size == 0 {
+            return false;
+        }
+        let end = offset + size;
+        // The free region containing [offset, end): the one starting at or before
+        // `offset` whose extent covers `end`.
+        let containing = self
+            .free
+            .range(..=offset)
+            .next_back()
+            .map(|(&o, &l)| (o, l));
+        let (r_off, r_len) = match containing {
+            Some((o, l)) if o + l >= end => (o, l),
+            _ => return false,
+        };
+        self.free.remove(&r_off);
+        if offset > r_off {
+            self.free.insert(r_off, offset - r_off); // free remainder before
+        }
+        if r_off + r_len > end {
+            self.free.insert(end, (r_off + r_len) - end); // free remainder after
+        }
+        self.allocated += size;
+        true
     }
 }
 

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -4,6 +4,11 @@
 //! - **`Client`** ([`DummyClient`] / [`RealClient`]) — the two-phase Put/Get API.
 //! - **`MasterService`** ([`MasterService`]) — object metadata, replica
 //!   allocation, the two-phase Put, lease-based eviction. No bytes flow through it.
+//!   - **HA** (Mooncake's high-availability mode): `snapshot` / `recover` (the
+//!     in-memory metadata snapshot, taken so a restarted or newly-elected master
+//!     rebuilds state), heartbeat-based segment health (failure detection), and
+//!     leader election (`master_election`, `--features etcd`) — multiple masters
+//!     coordinated through etcd, one leader serving, lease-backed failover.
 //! - **`BufferAllocator`** ([`OffsetBufferAllocator`]) + **`AllocationStrategy`**
 //!   ([`RandomAllocationStrategy`] / [`FreeRatioFirstAllocationStrategy`]).
 //! - **`Replica`** ([`Replica`], [`ReplicaData`]) — `Memory` (a mounted segment's

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -41,6 +41,8 @@ pub mod allocation_strategy;
 pub mod allocator;
 pub mod client;
 pub mod disk_tier;
+#[cfg(feature = "etcd")]
+pub mod master_election;
 pub mod master_service;
 pub mod replica;
 pub mod types;
@@ -52,7 +54,9 @@ pub use allocation_strategy::{
 pub use allocator::{AllocatedBuffer, BufferAllocator, OffsetBufferAllocator};
 pub use client::{DummyClient, RealClient};
 pub use disk_tier::DiskTier;
-pub use master_service::MasterService;
+#[cfg(feature = "etcd")]
+pub use master_election::{Leadership, MasterElection};
+pub use master_service::{MasterService, MasterSnapshot, ObjectSnapshot, SegmentSnapshot};
 pub use replica::{Replica, ReplicaData, ReplicaList, ReplicaStatus};
 pub use types::{ErrorCode, ObjectKey, ReplicaId, ReplicateConfig, SegmentName, Slice};
 

--- a/crates/quillcache-store/src/master_election.rs
+++ b/crates/quillcache-store/src/master_election.rs
@@ -1,0 +1,140 @@
+//! HA: etcd-backed master leader election — Mooncake's high-availability mode,
+//! where "multiple master nodes [are] coordinated through an etcd cluster … etcd
+//! [elects] a leader … if the current leader fails … the remaining master nodes
+//! automatically perform a new leader election".
+//!
+//! N masters [`MasterElection::campaign`] on a shared election key, each backed by
+//! an etcd **lease**: etcd serializes the campaigns so exactly one is leader at a
+//! time; the rest block (stand by). If the leader's process dies, its lease lapses
+//! and a standby wins — the new leader rebuilds state from the latest
+//! [`crate::MasterSnapshot`]. This is the orchestration on top of snapshot/recovery;
+//! object metadata still lives in-memory in the [`crate::MasterService`].
+//!
+//! Built only with `--features etcd` (pulls `etcd-client`); the integration test
+//! is `#[ignore]` since it needs a running etcd.
+
+use etcd_client::{Client, Error, LeaderKey, ResignOptions};
+
+/// One master's participation in the leader election.
+pub struct MasterElection {
+    client: Client,
+    /// The shared election key every master campaigns on.
+    election: String,
+    /// This master's identity — the value stored when it wins (the leader value).
+    node_id: String,
+    /// The lease backing this master's leadership; lapses if the process dies.
+    lease_id: i64,
+}
+
+/// Proof that this master currently holds leadership — the fencing key to resign.
+pub struct Leadership {
+    leader_key: LeaderKey,
+}
+
+impl MasterElection {
+    /// Connect to the etcd cluster and grant a `lease_ttl_secs` lease that backs
+    /// this master's leadership (the leader must keep it alive; if its process
+    /// dies the lease lapses and a standby is elected).
+    pub async fn join(
+        endpoints: Vec<String>,
+        election: impl Into<String>,
+        node_id: impl Into<String>,
+        lease_ttl_secs: i64,
+    ) -> Result<Self, Error> {
+        let mut client = Client::connect(endpoints, None).await?;
+        let lease = client.lease_grant(lease_ttl_secs, None).await?;
+        Ok(Self {
+            client,
+            election: election.into(),
+            node_id: node_id.into(),
+            lease_id: lease.id(),
+        })
+    }
+
+    /// The lease id backing this master's leadership.
+    pub fn lease_id(&self) -> i64 {
+        self.lease_id
+    }
+
+    /// Campaign for leadership; resolves once this master IS the leader (etcd
+    /// blocks here while another master holds it).
+    pub async fn campaign(&mut self) -> Result<Leadership, Error> {
+        let resp = self
+            .client
+            .campaign(
+                self.election.as_bytes(),
+                self.node_id.as_bytes(),
+                self.lease_id,
+            )
+            .await?;
+        let leader_key = resp
+            .leader()
+            .cloned()
+            .expect("a campaign winner always has a leader key");
+        Ok(Leadership { leader_key })
+    }
+
+    /// The current leader's node id, or `None` if there is no leader yet.
+    pub async fn leader(&mut self) -> Result<Option<String>, Error> {
+        match self.client.leader(self.election.as_bytes()).await {
+            Ok(resp) => Ok(resp
+                .kv()
+                .map(|kv| String::from_utf8_lossy(kv.value()).into_owned())),
+            // etcd returns an error when the election has no leader yet.
+            Err(Error::GRpcStatus(status)) if status.message().contains("no leader") => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Keep this master's lease alive (call on an interval shorter than the TTL)
+    /// so its leadership persists.
+    pub async fn keep_alive(&mut self) -> Result<(), Error> {
+        let (mut keeper, _stream) = self.client.lease_keep_alive(self.lease_id).await?;
+        keeper.keep_alive().await
+    }
+
+    /// Step down from leadership; a standby master is then elected.
+    pub async fn resign(&mut self, leadership: Leadership) -> Result<(), Error> {
+        self.client
+            .resign(Some(
+                ResignOptions::new().with_leader(leadership.leader_key),
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Needs a running etcd:
+    //   docker run -d -p 2379:2379 quay.io/coreos/etcd:v3.5.13 etcd \
+    //     --advertise-client-urls http://0.0.0.0:2379 --listen-client-urls http://0.0.0.0:2379
+    // then: cargo test -p quillcache-store --features etcd -- --ignored
+    #[tokio::test]
+    #[ignore = "requires a running etcd on 127.0.0.1:2379"]
+    async fn two_masters_elect_one_leader_then_fail_over() {
+        let endpoints = vec!["http://127.0.0.1:2379".to_string()];
+        let election = format!("qc-master-election-{}", std::process::id());
+
+        // Master A joins and campaigns → becomes the leader.
+        let mut a = MasterElection::join(endpoints.clone(), election.clone(), "master-a", 10)
+            .await
+            .expect("a joins");
+        let lead_a = a.campaign().await.expect("a campaigns");
+        assert_eq!(a.leader().await.unwrap().as_deref(), Some("master-a"));
+
+        // Master B joins; A is still leader.
+        let mut b = MasterElection::join(endpoints.clone(), election.clone(), "master-b", 10)
+            .await
+            .expect("b joins");
+        assert_eq!(b.leader().await.unwrap().as_deref(), Some("master-a"));
+
+        // A steps down → B wins the next election (failover). The new leader would
+        // rebuild its state from the latest MasterSnapshot.
+        a.resign(lead_a).await.expect("a resigns");
+        let _lead_b = b.campaign().await.expect("b campaigns");
+        assert_eq!(b.leader().await.unwrap().as_deref(), Some("master-b"));
+    }
+}

--- a/crates/quillcache-store/src/master_service.rs
+++ b/crates/quillcache-store/src/master_service.rs
@@ -22,7 +22,9 @@ use crate::allocator::{AllocatedBuffer, BufferAllocator, OffsetBufferAllocator};
 use crate::replica::{Replica, ReplicaData, ReplicaList, ReplicaStatus};
 use crate::types::{ErrorCode, ObjectKey, ReplicaId, ReplicateConfig, SegmentName};
 use quillcache_core::IdentityScope;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// Per-object control-plane metadata (server-side; never sent to clients).
 #[derive(Debug)]
@@ -44,6 +46,42 @@ impl ObjectMetadata {
     }
 }
 
+/// A serializable, consistent copy of the master's in-memory metadata — mounted
+/// segments, object replicas, leases/pins, allocation strategy, and the clock.
+/// Mooncake's periodic metadata snapshot, taken so a restarted master (or a
+/// newly-elected leader, under etcd HA) can rebuild state; changes after the last
+/// snapshot are lost (the same bound Mooncake documents).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MasterSnapshot {
+    pub version: u32,
+    pub strategy: String,
+    pub clock: u64,
+    pub lease_ttl: u64,
+    pub high_watermark: f64,
+    pub eviction_ratio: f64,
+    pub segment_ttl: u64,
+    pub next_replica_id: ReplicaId,
+    pub segments: Vec<SegmentSnapshot>,
+    pub objects: Vec<ObjectSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SegmentSnapshot {
+    pub name: SegmentName,
+    pub capacity: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectSnapshot {
+    pub key: ObjectKey,
+    pub replicas: Vec<Replica>,
+    pub identity: IdentityScope,
+    pub lease_until: u64,
+    pub last_access: u64,
+    pub soft_pinned: bool,
+    pub hard_pinned: bool,
+}
+
 /// The store's metadata / allocation / eviction authority.
 #[derive(Debug)]
 pub struct MasterService {
@@ -51,11 +89,19 @@ pub struct MasterService {
     allocators: Vec<Box<dyn BufferAllocator>>,
     objects: HashMap<ObjectKey, ObjectMetadata>,
     strategy: Box<dyn AllocationStrategy>,
+    /// The allocation-strategy name, kept so a snapshot can rebuild the same one.
+    strategy_name: String,
     next_replica_id: ReplicaId,
     clock: u64,
     lease_ttl: u64,
     high_watermark: f64,
     eviction_ratio: f64,
+    /// Last logical-clock tick each segment's node heartbeated — Mooncake's
+    /// periodic client heartbeats, the basis for failure detection.
+    segment_heartbeat: HashMap<SegmentName, u64>,
+    /// Ticks a segment may miss before it is treated as dead. `0` disables the
+    /// health check (every mounted segment is considered alive).
+    segment_ttl: u64,
 }
 
 impl MasterService {
@@ -64,11 +110,14 @@ impl MasterService {
             allocators: Vec::new(),
             objects: HashMap::new(),
             strategy: create_allocation_strategy(strategy),
+            strategy_name: strategy.to_string(),
             next_replica_id: 0,
             clock: 0,
             lease_ttl: 5,
             high_watermark: 0.95,
             eviction_ratio: 0.1,
+            segment_heartbeat: HashMap::new(),
+            segment_ttl: 0,
         }
     }
 
@@ -82,6 +131,9 @@ impl MasterService {
     // ---- segment lifecycle (Mooncake's MountSegment / UnmountSegment) ----
 
     pub fn mount_segment(&mut self, name: impl Into<SegmentName>, capacity: u64) {
+        let name = name.into();
+        // A freshly-mounted segment is alive as of now.
+        self.segment_heartbeat.insert(name.clone(), self.clock);
         self.allocators
             .push(Box::new(OffsetBufferAllocator::new(name, capacity)));
     }
@@ -96,9 +148,51 @@ impl MasterService {
             obj.replicas.retain(|_, r| r.segment_name() != Some(name));
         }
         self.allocators.retain(|a| a.segment_name() != name);
+        self.segment_heartbeat.remove(name);
         // Objects left with no replicas are gone.
         self.objects.retain(|_, o| !o.replicas.is_empty());
         Ok(())
+    }
+
+    // ---- HA: heartbeat-based segment health (Mooncake's client heartbeats) ----
+
+    /// Enable failure detection: a segment that misses a heartbeat for more than
+    /// `ttl` logical ticks is treated as dead and its replicas are not handed
+    /// out. `0` disables the check (the default — every mounted segment is alive).
+    pub fn set_segment_ttl(&mut self, ttl: u64) {
+        self.segment_ttl = ttl;
+    }
+
+    /// Record a liveness heartbeat from a segment's node. Unknown segment → error.
+    pub fn heartbeat(&mut self, segment: &str) -> Result<(), ErrorCode> {
+        match self.segment_heartbeat.get_mut(segment) {
+            Some(last) => {
+                *last = self.clock;
+                Ok(())
+            }
+            None => Err(ErrorCode::SegmentNotFound),
+        }
+    }
+
+    /// Whether a mounted segment is alive (heartbeated within `segment_ttl`).
+    /// With the check disabled (`segment_ttl == 0`), any mounted segment is alive.
+    pub fn segment_alive(&self, segment: &str) -> bool {
+        match self.segment_heartbeat.get(segment) {
+            Some(&last) => {
+                self.segment_ttl == 0 || self.clock.saturating_sub(last) <= self.segment_ttl
+            }
+            None => false,
+        }
+    }
+
+    /// Mounted segments that have missed heartbeats past the TTL — failure
+    /// detection surfaces them so the control plane can re-replicate / route away.
+    pub fn dead_segments(&self) -> Vec<String> {
+        self.allocators
+            .iter()
+            .map(|a| a.segment_name().to_string())
+            .filter(|name| !self.segment_alive(name))
+            .collect()
     }
 
     // ---- two-phase Put ----
@@ -173,6 +267,14 @@ impl MasterService {
     ) -> Result<Vec<Replica>, ErrorCode> {
         let now = self.clock;
         let lease_ttl = self.lease_ttl;
+        // Failure detection: a Memory replica on a segment whose node stopped
+        // heartbeating is treated as lost; a Disk replica is durable, so kept.
+        let alive: HashSet<String> = self
+            .allocators
+            .iter()
+            .map(|a| a.segment_name().to_string())
+            .filter(|name| self.segment_alive(name))
+            .collect();
         let object = self.objects.get_mut(key).ok_or(ErrorCode::ObjectNotFound)?;
         // QuillCache identity guard: a content-hash key can be requested under a
         // different identity — refuse cross-tenant / cross-adapter / cross-model.
@@ -183,6 +285,10 @@ impl MasterService {
             .replicas
             .values()
             .filter(|r| r.is_complete())
+            .filter(|r| match r.segment_name() {
+                Some(seg) => alive.contains(seg),
+                None => true,
+            })
             .cloned()
             .collect();
         if complete.is_empty() {
@@ -227,6 +333,113 @@ impl MasterService {
     }
     pub fn allocated(&self) -> u64 {
         self.allocators.iter().map(|a| a.allocated()).sum()
+    }
+
+    // ---- HA: snapshot + recovery (Mooncake's metadata snapshot thread) ----
+
+    /// Take a consistent [`MasterSnapshot`] of the current in-memory metadata.
+    pub fn snapshot(&self) -> MasterSnapshot {
+        MasterSnapshot {
+            version: 1,
+            strategy: self.strategy_name.clone(),
+            clock: self.clock,
+            lease_ttl: self.lease_ttl,
+            high_watermark: self.high_watermark,
+            eviction_ratio: self.eviction_ratio,
+            segment_ttl: self.segment_ttl,
+            next_replica_id: self.next_replica_id,
+            segments: self
+                .allocators
+                .iter()
+                .map(|a| SegmentSnapshot {
+                    name: a.segment_name().to_string(),
+                    capacity: a.capacity(),
+                })
+                .collect(),
+            objects: self
+                .objects
+                .iter()
+                .map(|(key, o)| ObjectSnapshot {
+                    key: key.clone(),
+                    replicas: o.replicas.values().cloned().collect(),
+                    identity: o.identity.clone(),
+                    lease_until: o.lease_until,
+                    last_access: o.last_access,
+                    soft_pinned: o.soft_pinned,
+                    hard_pinned: o.hard_pinned,
+                })
+                .collect(),
+        }
+    }
+
+    /// Rebuild a master from a snapshot: re-mount the segments and re-reserve each
+    /// replica's exact `(offset, size)` so the allocator layout matches, then
+    /// restore objects, leases, pins, and the clock.
+    pub fn recover(snapshot: MasterSnapshot) -> Result<Self, ErrorCode> {
+        let mut master = MasterService::new(&snapshot.strategy);
+        master.clock = snapshot.clock;
+        master.lease_ttl = snapshot.lease_ttl;
+        master.high_watermark = snapshot.high_watermark;
+        master.eviction_ratio = snapshot.eviction_ratio;
+        master.segment_ttl = snapshot.segment_ttl;
+        for seg in &snapshot.segments {
+            master.mount_segment(seg.name.clone(), seg.capacity);
+        }
+        for obj in snapshot.objects {
+            // Re-reserve each Memory replica's exact range so the allocator's
+            // free-list reflects the recovered layout (Disk replicas are durable).
+            for replica in &obj.replicas {
+                if let ReplicaData::Memory(buf) = &replica.data {
+                    let allocator = master
+                        .allocators
+                        .iter_mut()
+                        .find(|a| a.segment_name() == buf.segment_name())
+                        .ok_or(ErrorCode::SegmentNotFound)?;
+                    if !allocator.reserve(buf.offset, buf.size) {
+                        return Err(ErrorCode::InvalidReplica);
+                    }
+                }
+            }
+            let mut replicas = ReplicaList::new();
+            for replica in obj.replicas {
+                replicas.insert(replica.id, replica);
+            }
+            master.objects.insert(
+                obj.key,
+                ObjectMetadata {
+                    replicas,
+                    identity: obj.identity,
+                    lease_until: obj.lease_until,
+                    last_access: obj.last_access,
+                    soft_pinned: obj.soft_pinned,
+                    hard_pinned: obj.hard_pinned,
+                },
+            );
+        }
+        master.next_replica_id = snapshot.next_replica_id;
+        Ok(master)
+    }
+
+    /// Persist a snapshot to `path` **atomically** — write a temp file, then
+    /// rename — so a crash mid-write never leaves a torn snapshot (the QuillCache
+    /// crash-consistency discipline applied to the master's metadata).
+    pub fn save_snapshot(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        let path = path.as_ref();
+        let bytes = serde_json::to_vec(&self.snapshot())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let tmp = path.with_extension("snapshot.tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Recover a master from a snapshot file written by [`MasterService::save_snapshot`].
+    pub fn load_snapshot(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let bytes = std::fs::read(path)?;
+        let snapshot: MasterSnapshot = serde_json::from_slice(&bytes)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        Self::recover(snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e:?}")))
     }
 
     // ---- internals ----
@@ -487,5 +700,87 @@ mod tests {
         }
         assert!(m.remove("A", false).is_ok());
         assert!(!m.exist_key("A"));
+    }
+
+    #[test]
+    fn snapshot_recovers_objects_segments_and_allocator_state() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        m.mount_segment("seg-1", 1000);
+        let id = scope("ten-a");
+        m.put_start("a".into(), id.clone(), 64, &ReplicateConfig::replicas(2))
+            .unwrap();
+        m.put_end("a").unwrap();
+        m.put_start("b".into(), id.clone(), 128, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("b").unwrap();
+        let allocated_before = m.allocated();
+
+        // Round-trip through a snapshot (e.g. a restart / leader failover).
+        let mut r = MasterService::recover(m.snapshot()).expect("recover");
+        assert_eq!(r.object_count(), 2);
+        assert_eq!(r.segment_count(), 2);
+        assert_eq!(
+            r.allocated(),
+            allocated_before,
+            "the allocator's allocated bytes are rebuilt exactly"
+        );
+
+        // Recovered objects are readable, still identity-guarded.
+        assert_eq!(r.get_replica_list("a", &id).unwrap().len(), 2);
+        assert!(matches!(
+            r.get_replica_list("a", &scope("ten-b")),
+            Err(ErrorCode::UnsafeReuse(_))
+        ));
+
+        // The rebuilt allocator won't hand out the recovered ranges again: a fresh
+        // Put succeeds without overlapping the reserved offsets.
+        r.put_start("c".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        r.put_end("c").unwrap();
+        assert!(r.get_replica_list("c", &id).is_ok());
+    }
+
+    #[test]
+    fn snapshot_file_round_trip_is_atomic() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        m.put_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("k").unwrap();
+
+        let path = std::env::temp_dir().join(format!("qc-master-snap-{}.json", std::process::id()));
+        m.save_snapshot(&path).unwrap();
+        let mut r = MasterService::load_snapshot(&path).unwrap();
+        assert_eq!(r.get_replica_list("k", &id).unwrap().len(), 1);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn heartbeat_health_hides_replicas_on_a_dead_segment() {
+        let mut m = MasterService::new("random");
+        m.set_segment_ttl(5); // enable failure detection
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        m.put_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("k").unwrap();
+        assert!(m.segment_alive("seg-0"));
+        assert!(m.get_replica_list("k", &id).is_ok());
+
+        // Miss heartbeats past the TTL → the segment is dead and its only replica
+        // is treated as lost, so the object becomes unservable.
+        for _ in 0..6 {
+            m.tick();
+        }
+        assert!(!m.segment_alive("seg-0"));
+        assert_eq!(m.dead_segments(), vec!["seg-0".to_string()]);
+        assert_eq!(m.get_replica_list("k", &id), Err(ErrorCode::ObjectNotReady));
+
+        // A heartbeat brings the node back and its replica is served again.
+        m.heartbeat("seg-0").unwrap();
+        assert!(m.segment_alive("seg-0"));
+        assert!(m.get_replica_list("k", &id).is_ok());
     }
 }

--- a/crates/quillcache-store/src/master_service.rs
+++ b/crates/quillcache-store/src/master_service.rs
@@ -299,6 +299,60 @@ impl MasterService {
         Ok(complete)
     }
 
+    // ---- batch APIs (Mooncake's BatchPut / BatchGet — one round-trip for many
+    // keys; our connector offloads/loads a prefix's layers as one batch) ----
+
+    /// Allocate replicas for many objects in one call. Transactional: if any key
+    /// can't be allocated, the ones already started in this batch are revoked and
+    /// the error is returned (no partial batch is left behind).
+    pub fn batch_put_start(
+        &mut self,
+        items: Vec<(ObjectKey, IdentityScope, u64)>,
+        config: &ReplicateConfig,
+    ) -> Result<Vec<Vec<AllocatedBuffer>>, ErrorCode> {
+        let mut out = Vec::with_capacity(items.len());
+        let mut started: Vec<ObjectKey> = Vec::new();
+        for (key, identity, size) in items {
+            match self.put_start(key.clone(), identity, size, config) {
+                Ok(buffers) => {
+                    out.push(buffers);
+                    started.push(key);
+                }
+                Err(e) => {
+                    for k in &started {
+                        let _ = self.put_revoke(k);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Commit many objects' replicas (flip to readable). Errors on the first key
+    /// that isn't in flight.
+    pub fn batch_put_end(&mut self, keys: &[String]) -> Result<(), ErrorCode> {
+        for key in keys {
+            self.put_end(key)?;
+        }
+        Ok(())
+    }
+
+    /// Identity-guarded Get for many keys. Errors on the first key that is
+    /// missing / not ready / refused (the connector wants all of a prefix's
+    /// layers, or it recomputes the prefix).
+    pub fn batch_get_replica_list(
+        &mut self,
+        keys: &[String],
+        requester: &IdentityScope,
+    ) -> Result<Vec<Vec<Replica>>, ErrorCode> {
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            out.push(self.get_replica_list(key, requester)?);
+        }
+        Ok(out)
+    }
+
     pub fn exist_key(&self, key: &str) -> bool {
         self.objects
             .get(key)
@@ -782,5 +836,48 @@ mod tests {
         m.heartbeat("seg-0").unwrap();
         assert!(m.segment_alive("seg-0"));
         assert!(m.get_replica_list("k", &id).is_ok());
+    }
+
+    #[test]
+    fn batch_put_then_batch_get_round_trips() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 4096);
+        let id = scope("ten-a");
+        let keys: Vec<String> = vec!["k0".into(), "k1".into(), "k2".into()];
+        let items = keys.iter().map(|k| (k.clone(), id.clone(), 64)).collect();
+
+        let buffers = m
+            .batch_put_start(items, &ReplicateConfig::replicas(1))
+            .unwrap();
+        assert_eq!(buffers.len(), 3);
+        m.batch_put_end(&keys).unwrap();
+
+        let got = m.batch_get_replica_list(&keys, &id).unwrap();
+        assert_eq!(got.len(), 3);
+        assert!(got.iter().all(|replicas| replicas.len() == 1));
+
+        // The identity guard applies to the batch too.
+        assert!(matches!(
+            m.batch_get_replica_list(&["k0".into()], &scope("ten-b")),
+            Err(ErrorCode::UnsafeReuse(_))
+        ));
+    }
+
+    #[test]
+    fn batch_put_start_rolls_back_on_failure() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 100);
+        let id = scope("ten-a");
+        // The second object (200B) can't fit a 100B segment → the batch fails and
+        // the first object's allocation is rolled back (no partial batch).
+        let items = vec![
+            ("a".to_string(), id.clone(), 64),
+            ("b".to_string(), id, 200),
+        ];
+        assert!(m
+            .batch_put_start(items, &ReplicateConfig::replicas(1))
+            .is_err());
+        assert_eq!(m.object_count(), 0);
+        assert_eq!(m.allocated(), 0);
     }
 }

--- a/crates/quillcache-transfer-engine/Cargo.toml
+++ b/crates/quillcache-transfer-engine/Cargo.toml
@@ -14,12 +14,27 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "rt"] }
 etcd-client = { version = "0.14", optional = true }
+# Real CUDA device segment (GPU HBM registered as a transfer-engine segment).
+# cudarc with dynamic-loading compiles without CUDA present; pinned to the 13.0
+# bindings to match the GPU image. See the `cuda` feature below.
+cudarc = { version = "0.19", optional = true, default-features = false, features = [
+    "driver",
+    "dynamic-loading",
+    "cuda-13000",
+] }
 
 [features]
 # RDMA / GPU transport backends (ibverbs / GPUDirect-RDMA / NVLink). Reserved
 # seams — implemented as Unsupported stubs until the hardware is wired.
 rdma = []
 nvlink = []
+# Real CUDA device segment: register GPU HBM as a transfer-engine segment and
+# serve it over the same one-sided (offset, length) wire as the host segment,
+# staging through cudaMemcpy (H2D/D2H). This is Mooncake's device-segment
+# registration; GPUDirect-RDMA / NVLink (the `nvlink` feature) is the zero-copy
+# network form that removes the host hop (reserved — needs a NIC / multi-GPU).
+# cudarc dynamic-loading => compiles with no CUDA toolkit; runs on a GPU box.
+cuda = ["dep:cudarc"]
 # etcd-backed metadata (Mooncake's etcd:// MetadataStoragePlugin) — the production
 # distributed metadata path. Off by default; needs a running etcd cluster (like
 # `rdma` needs a NIC). Pulls etcd-client (gRPC over tonic).

--- a/crates/quillcache-transfer-engine/src/device_segment.rs
+++ b/crates/quillcache-transfer-engine/src/device_segment.rs
@@ -1,0 +1,229 @@
+//! CUDA device segment — GPU HBM registered as a Transfer Engine segment.
+//!
+//! Mooncake registers memory *segments* (host OR device) and moves bytes
+//! one-sidedly by `(offset, length)`. This is the **device** form: the segment's
+//! bytes live in GPU HBM (`cudaMalloc`), and READ / WRITE stage through
+//! `cudaMemcpy` (D2H / H2D). It speaks the exact same wire as the host TCP
+//! segment ([`crate::transport::tcp`]), so an unmodified
+//! [`crate::transport::tcp::TcpTransport`] peer can READ & WRITE a GPU-resident
+//! segment with no changes above the [`crate::transport::Transport`] trait.
+//!
+//! The host hop (D2H to serve a read, H2D to apply a write) is exactly what
+//! GPUDirect-RDMA / NVLink (the reserved `nvlink` feature) removes — NIC / GPU ↔
+//! HBM with no staging. This `cuda` path is the real, single-GPU-verifiable core;
+//! `nvlink` is the zero-copy network optimization layered on top.
+//!
+//! Built only with `--features cuda` (cudarc with `dynamic-loading`, so it
+//! compiles without CUDA present and runs on a GPU box).
+
+use std::sync::{Arc, Mutex};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+// Same wire as transport/tcp.rs.
+const OP_READ: u8 = 0;
+const OP_WRITE: u8 = 1;
+const ST_OK: u8 = 0;
+const ST_ERR: u8 = 2;
+
+/// A GPU HBM byte arena registered as a transfer-engine segment. Capacity is
+/// fixed (HBM is precious); a logical length grows on WRITE up to capacity,
+/// mirroring the host segment's grow-on-write.
+pub struct DeviceSegment {
+    ctx: Arc<CudaContext>,
+    stream: Arc<CudaStream>,
+    arena: Mutex<Arena>,
+    capacity: usize,
+}
+
+struct Arena {
+    hbm: CudaSlice<u8>,
+    len: usize,
+}
+
+impl std::fmt::Debug for DeviceSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceSegment")
+            .field("ordinal", &self.ctx.ordinal())
+            .field("capacity", &self.capacity)
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl DeviceSegment {
+    /// Bind GPU `ordinal` and reserve `capacity` bytes of HBM for the segment.
+    pub fn new(ordinal: usize, capacity: usize) -> Result<Arc<Self>, String> {
+        let ctx = CudaContext::new(ordinal).map_err(|e| format!("CudaContext::new: {e:?}"))?;
+        let stream = ctx.default_stream();
+        let hbm = stream
+            .alloc_zeros::<u8>(capacity)
+            .map_err(|e| format!("alloc HBM arena: {e:?}"))?;
+        Ok(Arc::new(Self {
+            ctx,
+            stream,
+            arena: Mutex::new(Arena { hbm, len: 0 }),
+            capacity,
+        }))
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn len(&self) -> usize {
+        self.arena.lock().unwrap().len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Which CUDA device the segment's HBM lives on.
+    pub fn ordinal(&self) -> usize {
+        self.ctx.ordinal()
+    }
+
+    /// Register a buffer: H2D-copy it into the arena at the current end; returns
+    /// its offset — the handle a peer targets.
+    pub fn register(&self, data: &[u8]) -> Result<u64, String> {
+        let mut a = self.arena.lock().unwrap();
+        let offset = a.len;
+        self.write_locked(&mut a, offset, data)?;
+        Ok(offset as u64)
+    }
+
+    /// READ: D2H-copy `len` bytes from HBM at `offset`. Errors if out of bounds.
+    pub fn read(&self, offset: usize, len: usize) -> Result<Vec<u8>, String> {
+        let a = self.arena.lock().unwrap();
+        let end = offset.checked_add(len).ok_or("offset+len overflow")?;
+        if end > a.len {
+            return Err("read out of segment bounds".into());
+        }
+        let mut host = vec![0u8; len];
+        if len > 0 {
+            let view = a.hbm.slice(offset..end);
+            self.stream
+                .memcpy_dtoh(&view, &mut host)
+                .map_err(|e| format!("d2h: {e:?}"))?;
+            self.stream.synchronize().map_err(|e| format!("{e:?}"))?;
+        }
+        Ok(host)
+    }
+
+    /// WRITE: H2D-copy `data` into HBM at `offset`, growing the logical length up
+    /// to capacity. Errors if it would exceed capacity.
+    pub fn write(&self, offset: usize, data: &[u8]) -> Result<(), String> {
+        let mut a = self.arena.lock().unwrap();
+        self.write_locked(&mut a, offset, data)
+    }
+
+    fn write_locked(&self, a: &mut Arena, offset: usize, data: &[u8]) -> Result<(), String> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or("offset+len overflow")?;
+        if end > self.capacity {
+            return Err(format!(
+                "write exceeds HBM segment capacity ({end} > {})",
+                self.capacity
+            ));
+        }
+        if !data.is_empty() {
+            let mut view = a.hbm.slice_mut(offset..end);
+            self.stream
+                .memcpy_htod(data, &mut view)
+                .map_err(|e| format!("h2d: {e:?}"))?;
+            self.stream.synchronize().map_err(|e| format!("{e:?}"))?;
+        }
+        if end > a.len {
+            a.len = end;
+        }
+        Ok(())
+    }
+}
+
+/// Serve a GPU HBM [`DeviceSegment`] to peers over the same one-sided
+/// `(offset, length)` wire as the host TCP segment, so an unmodified
+/// [`crate::transport::tcp::TcpTransport`] peer READs / WRITEs GPU-resident
+/// bytes. The bytes stage through `cudaMemcpy` here (GPUDirect would remove the
+/// hop). The blocking copies run inline on the connection task — fine for the
+/// reference path; a production server would `spawn_blocking` them.
+pub async fn serve_device_segment(listener: TcpListener, segment: Arc<DeviceSegment>) {
+    loop {
+        let Ok((sock, _)) = listener.accept().await else {
+            return;
+        };
+        let segment = segment.clone();
+        tokio::spawn(async move {
+            let _ = handle_conn(sock, segment).await;
+        });
+    }
+}
+
+async fn handle_conn(mut sock: TcpStream, segment: Arc<DeviceSegment>) -> std::io::Result<()> {
+    loop {
+        let op = match sock.read_u8().await {
+            Ok(op) => op,
+            Err(_) => return Ok(()), // peer closed
+        };
+        let offset = sock.read_u64().await? as usize;
+        let len = sock.read_u64().await? as usize;
+        match op {
+            OP_READ => match segment.read(offset, len) {
+                Ok(bytes) => {
+                    sock.write_u8(ST_OK).await?;
+                    sock.write_u64(bytes.len() as u64).await?;
+                    sock.write_all(&bytes).await?;
+                }
+                Err(_) => sock.write_u8(ST_ERR).await?,
+            },
+            OP_WRITE => {
+                let mut buf = vec![0u8; len];
+                sock.read_exact(&mut buf).await?;
+                match segment.write(offset, &buf) {
+                    Ok(()) => sock.write_u8(ST_OK).await?,
+                    Err(_) => sock.write_u8(ST_ERR).await?,
+                }
+            }
+            _ => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::tcp::TcpTransport;
+    use crate::transport::Transport;
+    use bytes::Bytes;
+
+    // Needs a real NVIDIA GPU; compiles everywhere (dynamic-loading) but only run
+    // on a GPU box: `cargo test -p quillcache-transfer-engine --features cuda -- --ignored`.
+    #[tokio::test]
+    #[ignore = "requires an NVIDIA GPU"]
+    async fn tcp_peer_reads_writes_a_gpu_hbm_segment() {
+        // A GPU HBM segment served over the one-sided wire.
+        let seg = DeviceSegment::new(0, 1 << 20).expect("alloc HBM segment");
+        let off = seg.register(b"resident-in-HBM").expect("register"); // 15 bytes
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = listener.local_addr().unwrap().to_string();
+        tokio::spawn(serve_device_segment(listener, seg.clone()));
+
+        // An UNMODIFIED TCP transport peer reads the GPU-resident bytes back.
+        let tcp = TcpTransport;
+        let got = tcp.read_remote(&endpoint, off, 15).await.expect("read HBM");
+        assert_eq!(&got[..], b"resident-in-HBM");
+
+        // ...and writes new bytes straight into HBM, which read back identically.
+        tcp.write_remote(&endpoint, 100, Bytes::from_static(b"written-into-HBM"))
+            .await
+            .expect("write HBM");
+        let got2 = tcp
+            .read_remote(&endpoint, 100, 16)
+            .await
+            .expect("read HBM 2");
+        assert_eq!(&got2[..], b"written-into-HBM");
+    }
+}

--- a/crates/quillcache-transfer-engine/src/lib.rs
+++ b/crates/quillcache-transfer-engine/src/lib.rs
@@ -10,6 +10,8 @@
 //! | `Transport` + subclasses (`transport/*`) | [`transport::Transport`] + backends |
 //! | &nbsp;&nbsp;`TcpTransport` | [`transport::tcp::TcpTransport`] — **real** |
 //! | &nbsp;&nbsp;`RdmaTransport` (ibverbs) | [`transport::rdma::RdmaTransport`] — reserved |
+//! | &nbsp;&nbsp;`NvlinkTransport` / `transport/device` | [`transport::nvlink`] (zero-copy) — reserved |
+//! | GPU HBM segment (device `cudaMalloc` registration) | [`device_segment::DeviceSegment`] — **real** (`--features cuda`) |
 //! | `TransferMetadata` (`transfer_metadata.h`) | [`metadata`] (`SegmentDesc`, backend) |
 //! | `Topology` (`topology.h`) | [`topology::Topology`] |
 //!
@@ -25,6 +27,8 @@
 //! This is Phase 1 of the Mooncake-faithful restructure: the store
 //! (`quillcache-store`) is rebuilt on this engine in a later phase.
 
+#[cfg(feature = "cuda")]
+pub mod device_segment;
 pub mod engine;
 pub mod metadata;
 #[cfg(feature = "etcd")]
@@ -33,6 +37,8 @@ pub mod multi_transport;
 pub mod topology;
 pub mod transport;
 
+#[cfg(feature = "cuda")]
+pub use device_segment::{serve_device_segment, DeviceSegment};
 pub use engine::TransferEngine;
 pub use metadata::{BufferDesc, InMemoryMetadata, MetadataBackend, SegmentDesc};
 #[cfg(feature = "etcd")]

--- a/crates/quillcache-transfer-engine/src/transport/nvlink.rs
+++ b/crates/quillcache-transfer-engine/src/transport/nvlink.rs
@@ -2,10 +2,12 @@
 //! — the GPU-resident data path: NVLink for intra-node GPU↔GPU, GPUDirect-RDMA
 //! for HBM↔NIC zero-copy. **This is where "CUDA" lives in Mooncake's Transfer
 //! Engine** — moving KV bytes to / from / between GPU HBM without staging through
-//! host memory — not a separate quantize-on-offload tier. Reserved seam: needs an
-//! NVIDIA GPU (CUDA + NVLink / IBGDA), stubbed until hardware is wired; the real
-//! impl lands behind `--features nvlink` and nothing above the [`Transport`] trait
-//! changes.
+//! host memory — not a separate quantize-on-offload tier. The host-staged form of
+//! a GPU HBM segment is already **real** ([`crate::device_segment`],
+//! `--features cuda`, L4-verified): register HBM, serve it over the one-sided wire
+//! via `cudaMemcpy`. NVLink / GPUDirect is the *zero-copy* form that removes the
+//! host hop — a reserved seam (needs an NVIDIA GPU + NVLink / IBGDA) landing behind
+//! `--features nvlink`; nothing above the [`Transport`] trait changes.
 //!
 //! (`quillcache-cuda` is a *different* concern — the Dynamo-KVBM HBM tier with
 //! FP16→FP8 quantize-on-offload, an LMCache/KVBM-flavored idea Mooncake does not

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,19 @@
+# Modal deploy + verification scripts
+
+GPU / multi-process runs that verify the parts of QuillCache a laptop can't.
+Each is `modal run deploy/<script>.py` (needs the Modal CLI authed).
+
+| script | what it runs | verifies |
+| --- | --- | --- |
+| `modal_vllm.py` | a single vLLM engine on an L4 (`modal deploy`) | a real OpenAI-compatible engine for the gateway to route to |
+| `modal_vllm_introspect.py` | dumps vLLM 0.22.1's `KVConnectorBase_V1` source (CPU) | the exact connector API we implement against (no guessing) |
+| `modal_vllm_connector_check.py` | loads `QuillCacheV1Connector` via vLLM's factory (CPU) | 5/5 conformance — vLLM will load our connector |
+| `modal_vllm_connector.py` | vLLM + co-located store + the connector (1×L4) | offload → reuse: request-1 commits a prefix, request-2 loads it from the store |
+| `modal_vllm_pd.py` | 2 vLLM (GPU0 prefill / GPU1 decode) + store + `pd-proxy` (2×L4) | disaggregated P/D: one request through the proxy warms the store on GPU0, reuses it on GPU1 |
+| `modal_cuda_verify.py` | builds `quillcache-cuda` / transfer-engine `--features cuda` (1×L4) | real CUDA: device-tier H2D/D2H + the GPU HBM device segment over the one-sided wire |
+
+The Rust device tier + HBM segment (cudarc 0.19, `dynamic-loading`) compile with
+no CUDA toolkit, so CI compile-checks them; the GPU round-trip tests are
+`#[ignore]` and run here. The store, transfer engine, connector, master HA, and
+P/D are real and verified across laptop / Docker etcd / these Modal runs; only
+zero-copy RDMA/GPUDirect (needs a NIC / multi-GPU) stays reserved.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,7 +9,8 @@ Each is `modal run deploy/<script>.py` (needs the Modal CLI authed).
 | `modal_vllm_introspect.py` | dumps vLLM 0.22.1's `KVConnectorBase_V1` source (CPU) | the exact connector API we implement against (no guessing) |
 | `modal_vllm_connector_check.py` | loads `QuillCacheV1Connector` via vLLM's factory (CPU) | 5/5 conformance — vLLM will load our connector |
 | `modal_vllm_connector.py` | vLLM + co-located store + the connector (1×L4) | offload → reuse: request-1 commits a prefix, request-2 loads it from the store |
-| `modal_vllm_pd.py` | 2 vLLM (GPU0 prefill / GPU1 decode) + store + `pd-proxy` (2×L4) | disaggregated P/D: one request through the proxy warms the store on GPU0, reuses it on GPU1 |
+| `modal_vllm_pd.py` | 2 vLLM (GPU0 prefill / GPU1 decode, both `kv_both`) + store + `pd-proxy` (2×L4) | content-addressed P/D: one request through the proxy warms the store on GPU0, reuses it on GPU1 by prompt-prefix hash |
+| `modal_vllm_disagg.py` | 2 vLLM (GPU0 `kv_producer` / GPU1 `kv_consumer`) + store + `pd-proxy` router (2×L4) | **true vLLM-native P/D**: the proxy mints a `transfer_id`; producer offloads the request's KV under it (`do_remote_decode`), consumer pulls by id + skips prefill (`do_remote_prefill`); output matches a monolithic reference |
 | `modal_cuda_verify.py` | builds `quillcache-cuda` / transfer-engine `--features cuda` (1×L4) | real CUDA: device-tier H2D/D2H + the GPU HBM device segment over the one-sided wire |
 
 The Rust device tier + HBM segment (cudarc 0.19, `dynamic-loading`) compile with

--- a/deploy/modal_cuda_verify.py
+++ b/deploy/modal_cuda_verify.py
@@ -1,0 +1,120 @@
+"""Verify the REAL CUDA device tier (quillcache-cuda --features cuda) on a GPU.
+
+Builds the crate with cudarc 0.19 (dynamic-loading) on an L4 and runs the
+GPU-only tests for real:
+  - host_device_roundtrip : H2D -> D2H copy preserves the bytes (needs libcuda)
+  - quantize_kernel       : FP16 -> FP8 NVRTC kernel runs on the GPU (needs libnvrtc)
+
+    modal run deploy/modal_cuda_verify.py
+
+cudarc's dynamic-loading dlopen's `libcuda.so` / `libnvrtc.so`, but a GPU
+container ships `libcuda.so.1` (driver) and `libnvrtc.so.13` (the pip wheel), so
+the function symlinks unversioned names onto LD_LIBRARY_PATH before running.
+"""
+
+import modal
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config")
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .add_local_file("Cargo.toml", "/build/Cargo.toml", copy=True)
+    .add_local_file("Cargo.lock", "/build/Cargo.lock", copy=True)
+    .add_local_dir("crates", "/build/crates", copy=True, ignore=["**/target/**"])
+    .add_local_dir("src", "/build/src", copy=True, ignore=["**/target/**"])
+    # Pre-compile the test binaries so the GPU run is just execution.
+    .run_commands(
+        "cd /build && $HOME/.cargo/bin/cargo test -p quillcache-cuda --features cuda --no-run",
+        "cd /build && $HOME/.cargo/bin/cargo test -p quillcache-transfer-engine --features cuda --no-run",
+    )
+)
+app = modal.App("quillcache-cuda-verify")
+
+
+@app.function(gpu="L4", image=image, timeout=60 * 20)
+def verify():
+    import glob
+    import os
+    import subprocess
+
+    # Expose unversioned libcuda.so / libnvrtc.so where cudarc's dlopen looks.
+    linkdir = "/usr/local/lib/quillcache-cuda"
+    os.makedirs(linkdir, exist_ok=True)
+    found = {}
+    for soname, patterns in {
+        "libcuda.so": [
+            "/usr/lib/x86_64-linux-gnu/libcuda.so*",
+            "/usr/lib64/libcuda.so*",
+            "/usr/local/cuda/lib64/libcuda.so*",
+            "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+        ],
+    }.items():
+        cands = []
+        for p in patterns:
+            cands += glob.glob(p)
+        # Prefer the real versioned object (skip any unversioned symlink we might add).
+        cands = sorted(c for c in cands if os.path.basename(c) != soname)
+        if cands:
+            target = cands[-1]
+            link = os.path.join(linkdir, soname)
+            if not os.path.exists(link):
+                os.symlink(target, link)
+            found[soname] = target
+        else:
+            found[soname] = None
+
+    env = dict(os.environ)
+    env["LD_LIBRARY_PATH"] = linkdir + ":" + env.get("LD_LIBRARY_PATH", "")
+    env["PATH"] = os.path.expanduser("~/.cargo/bin") + ":" + env["PATH"]
+
+    # nvidia-smi for the record
+    smi = subprocess.run(["nvidia-smi", "--query-gpu=name,driver_version", "--format=csv,noheader"],
+                         capture_output=True, text=True)
+
+    # Driver-only GPU tests (H2D/D2H + the HBM device segment over the one-sided
+    # wire). The NVRTC quantize test needs libnvrtc (CUDA toolkit), absent here.
+    suites = [
+        ("device tier H2D/D2H", "quillcache-cuda", "host_device_roundtrip"),
+        ("transfer-engine HBM segment", "quillcache-transfer-engine",
+         "tcp_peer_reads_writes_a_gpu_hbm_segment"),
+    ]
+    results = []
+    for label, pkg, test in suites:
+        run = subprocess.run(
+            ["cargo", "test", "-p", pkg, "--features", "cuda", test,
+             "--", "--ignored", "--nocapture", "--test-threads=1"],
+            cwd="/build", env=env, capture_output=True, text=True,
+        )
+        results.append({
+            "label": label, "pkg": pkg,
+            "stdout": run.stdout[-1500:], "stderr": run.stderr[-1500:],
+            "returncode": run.returncode,
+        })
+    return {"gpu": smi.stdout.strip(), "resolved_libs": found, "suites": results}
+
+
+@app.local_entrypoint()
+def main():
+    res = verify.remote()
+    print("\n" + "=" * 78)
+    print("quillcache-cuda (cudarc 0.19, --features cuda) — real GPU verification")
+    print("=" * 78)
+    print("GPU:", res["gpu"])
+    print("resolved libs:", res["resolved_libs"])
+    all_ok = True
+    for s in res["suites"]:
+        ok = s["returncode"] == 0
+        all_ok = all_ok and ok
+        print(f"\n[{'PASS' if ok else 'FAIL'}] {s['label']}  (-p {s['pkg']})")
+        for line in s["stdout"].splitlines():
+            if "test result" in line or " ... " in line or line.startswith("running"):
+                print("   ", line.strip())
+        if not ok:
+            print("   --- stderr ---")
+            print(s["stderr"])
+    verdict = (
+        "PASS — real CUDA on the GPU: device-tier H2D/D2H + HBM device segment "
+        "served over the one-sided wire (cudarc 0.19 dynamic-loading)"
+        if all_ok else "see failures above"
+    )
+    print(f"\nVERDICT: {verdict}")

--- a/deploy/modal_vllm_connector.py
+++ b/deploy/modal_vllm_connector.py
@@ -1,0 +1,227 @@
+"""Stage B — the REAL connector end-to-end on a GPU (Modal L4).
+
+One container runs the whole faithful data path, all real:
+  - `quillcache transfer-node`  — a Transfer Engine RAM segment over TCP   (Rust)
+  - `quillcache store-master`   — the MasterService: two-phase Put, the     (Rust)
+                                  identity-guarded Get
+  - `vllm serve <model>`        — vLLM 0.22.1 with QuillCacheV1Connector      (GPU)
+                                  registered via --kv-transfer-config
+
+Prefix caching is turned OFF in vLLM, so the *only* way a repeated prompt can
+skip prefill is through the connector loading KV from the QuillCache store.
+We send the same long-prefix prompt twice and prove from the vLLM logs that:
+  request 1  -> connector SAVED the prefix   ("committed N-token prefix … to the store")
+  request 2  -> connector HIT + LOADED it    ("external cache HIT" / "loading N tokens … from the store")
+and that the store master reports the stored objects.
+
+    modal run deploy/modal_vllm_connector.py
+
+First run builds the Rust binary into the image (cached afterwards) and downloads
+the 0.5B model. GPU + a few minutes.
+"""
+
+import modal
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config", "libssl-dev")
+    # Rust toolchain, to build the real store binary from this repo.
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .pip_install("vllm", "huggingface_hub")
+    # Only the Rust build inputs (NOT the whole repo) so edits elsewhere can't
+    # race the build snapshot; then build just the binary.
+    .add_local_file("Cargo.toml", "/build/Cargo.toml", copy=True)
+    .add_local_file("Cargo.lock", "/build/Cargo.lock", copy=True)
+    .add_local_dir("crates", "/build/crates", copy=True, ignore=["**/target/**"])
+    .add_local_dir("src", "/build/src", copy=True, ignore=["**/target/**"])
+    .run_commands(
+        "cd /build && $HOME/.cargo/bin/cargo build --release --bin quillcache",
+        "cp /build/target/release/quillcache /usr/local/bin/quillcache",
+    )
+    # The connector + store client, importable by vLLM's worker/scheduler processes.
+    .add_local_file("bridge/quillcache_v1_connector.py", "/root/quillcache_v1_connector.py", copy=True)
+    .add_local_file("bridge/quillcache_store_client.py", "/root/quillcache_store_client.py", copy=True)
+)
+app = modal.App("quillcache-vllm-connector")
+
+
+@app.function(gpu="L4", image=image, timeout=60 * 60)
+def run_e2e():
+    import json
+    import os
+    import subprocess
+    import time
+    import urllib.request
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "/root"
+    env["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
+
+    procs = {}
+
+    def spawn(name, args, logpath):
+        f = open(logpath, "w")
+        procs[name] = (subprocess.Popen(args, stdout=f, stderr=subprocess.STDOUT, env=env), f)
+
+    def tail(path, n=60):
+        try:
+            return "\n".join(open(path, errors="replace").read().splitlines()[-n:])
+        except OSError:
+            return f"<no {path}>"
+
+    def wait_ready(url, timeout, name, proc=None):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if proc is not None and proc.poll() is not None:
+                raise RuntimeError(
+                    f"{name} exited early (code {proc.returncode}) before ready:\n{tail('/tmp/vllm.log')}"
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=2) as r:
+                    if r.status < 500:
+                        return
+            except Exception:
+                time.sleep(1.0)
+        raise TimeoutError(f"{name} not ready at {url} within {timeout}s")
+
+    def shutdown():
+        for _, (p, f) in procs.items():
+            try:
+                p.terminate()
+            except Exception:
+                pass
+            f.close()
+
+    try:
+        # 1) the storage node + the master (both Rust, CPU).
+        spawn("transfer-node", ["quillcache", "transfer-node", "--addr", "127.0.0.1:8100", "--segment", "seg-0"], "/tmp/node.log")
+        spawn("store-master", ["quillcache", "store-master", "--addr", "127.0.0.1:7777"], "/tmp/master.log")
+        wait_ready("http://127.0.0.1:7777/v1/state", 30, "store-master", procs["store-master"][0])
+
+        # 2) vLLM with the QuillCache connector. Prefix caching OFF so a repeated
+        #    prompt can only skip prefill via the connector.
+        kv_cfg = {
+            "kv_connector": "QuillCacheV1Connector",
+            "kv_connector_module_path": "quillcache_v1_connector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {
+                "master_url": "http://127.0.0.1:7777",
+                "segment_endpoints": {"seg-0": "127.0.0.1:8100"},
+                "tenant_id": "default",
+                "replica_num": 1,
+            },
+        }
+        spawn(
+            "vllm",
+            [
+                "vllm", "serve", MODEL,
+                "--port", "8000",
+                "--max-model-len", "4096",
+                "--gpu-memory-utilization", "0.6",
+                "--no-enable-prefix-caching",
+                "--disable-hybrid-kv-cache-manager",
+                "--kv-transfer-config", json.dumps(kv_cfg),
+            ],
+            "/tmp/vllm.log",
+        )
+        wait_ready("http://127.0.0.1:8000/health", 600, "vllm", procs["vllm"][0])
+
+        # 3) Two identical long-prefix requests. #1 populates the store, #2 must hit it.
+        shared_prefix = (
+            "You are a meticulous assistant. Follow these standing rules for every "
+            "answer. " + " ".join(
+                f"Rule {i}: always be precise, cite assumptions, and prefer concrete "
+                "examples over abstractions." for i in range(24)
+            )
+        )
+
+        def chat(tag):
+            body = json.dumps({
+                "model": MODEL,
+                "messages": [
+                    {"role": "system", "content": shared_prefix},
+                    {"role": "user", "content": "In one sentence, what is a KV cache?"},
+                ],
+                "max_tokens": 16,
+                "temperature": 0.0,
+            }).encode()
+            req = urllib.request.Request(
+                "http://127.0.0.1:8000/v1/chat/completions",
+                data=body, headers={"Content-Type": "application/json"}, method="POST",
+            )
+            t0 = time.time()
+            with urllib.request.urlopen(req, timeout=120) as r:
+                out = json.loads(r.read())
+            dt = (time.time() - t0) * 1000
+            usage = out.get("usage", {})
+            text = out["choices"][0]["message"]["content"]
+            print(f"[{tag}] {dt:.0f} ms  prompt_tokens={usage.get('prompt_tokens')}  -> {text!r}")
+            return dt
+
+        t1 = chat("request-1 (populate store)")
+        time.sleep(2.0)  # let async saves + manifest commit settle
+        t2 = chat("request-2 (should hit store)")
+        time.sleep(1.0)
+
+        # 4) Evidence: connector log lines + store state.
+        vllm_log = open("/tmp/vllm.log", errors="replace").read()
+        markers = [
+            "QuillCacheV1Connector role",
+            "committed",
+            "external cache HIT",
+            "loading",
+            "identity guard REFUSED",
+        ]
+        hits = {m: [l for l in vllm_log.splitlines() if m in l] for m in markers}
+        state = json.loads(urllib.request.urlopen("http://127.0.0.1:7777/v1/state").read())
+        result = {
+            "ok": True,
+            "ttft_ms": {"request_1": round(t1), "request_2": round(t2)},
+            "connector_log_evidence": {m: hits[m][:4] for m in markers},
+            "store_state": state,
+            "vllm_log_tail": "\n".join(vllm_log.splitlines()[-40:]),
+        }
+    except Exception as e:
+        result = {
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "vllm_log_tail": tail("/tmp/vllm.log"),
+            "master_log_tail": tail("/tmp/master.log", 20),
+            "node_log_tail": tail("/tmp/node.log", 20),
+        }
+    finally:
+        shutdown()
+    return result
+
+
+@app.local_entrypoint()
+def main():
+    import json
+
+    res = run_e2e.remote()
+    print("\n" + "=" * 80)
+    print("QuillCacheV1Connector — end-to-end on vLLM 0.22.1 + the real store (L4)")
+    print("=" * 80)
+    if not res.get("ok"):
+        print(f"\nFAILED: {res.get('error')}")
+        print("\n--- vllm log tail ---\n" + res.get("vllm_log_tail", ""))
+        print("\n--- master log tail ---\n" + res.get("master_log_tail", ""))
+        print("\n--- node log tail ---\n" + res.get("node_log_tail", ""))
+        return
+    print("\nlatency:", res["ttft_ms"])
+    print("\n--- connector log evidence (from inside vLLM's processes) ---")
+    for marker, lines in res["connector_log_evidence"].items():
+        print(f"\n[{marker}]  ({len(lines)} line(s))")
+        for l in lines:
+            print("   ", l.strip()[:160])
+    print("\n--- store master /v1/state ---")
+    print(json.dumps(res["store_state"], indent=2)[:1500])
+    save = res["connector_log_evidence"]["committed"]
+    load = res["connector_log_evidence"]["external cache HIT"]
+    verdict = "REAL end-to-end: store populated AND served via the connector" if (save and load) \
+        else "partial — see vllm_log_tail"
+    print(f"\nVERDICT: {verdict}")
+    if not (save and load):
+        print("\n--- vllm log tail ---\n" + res["vllm_log_tail"])

--- a/deploy/modal_vllm_connector.py
+++ b/deploy/modal_vllm_connector.py
@@ -168,10 +168,11 @@ def run_e2e():
         # 4) Evidence: connector log lines + store state.
         vllm_log = open("/tmp/vllm.log", errors="replace").read()
         markers = [
-            "QuillCacheV1Connector role",
-            "committed",
-            "external cache HIT",
-            "loading",
+            "QC match-check",
+            "QC committed",
+            "QC external cache HIT",
+            "QC loading",
+            "attn_metadata is None but load",
             "identity guard REFUSED",
         ]
         hits = {m: [l for l in vllm_log.splitlines() if m in l] for m in markers}
@@ -218,10 +219,10 @@ def main():
             print("   ", l.strip()[:160])
     print("\n--- store master /v1/state ---")
     print(json.dumps(res["store_state"], indent=2)[:1500])
-    save = res["connector_log_evidence"]["committed"]
-    load = res["connector_log_evidence"]["external cache HIT"]
-    verdict = "REAL end-to-end: store populated AND served via the connector" if (save and load) \
-        else "partial — see vllm_log_tail"
+    save = res["connector_log_evidence"]["QC committed"]
+    load = res["connector_log_evidence"]["QC loading"]
+    verdict = "REAL end-to-end: store populated AND reused via the connector" if (save and load) \
+        else "partial — see match-check trace + vllm_log_tail"
     print(f"\nVERDICT: {verdict}")
     if not (save and load):
         print("\n--- vllm log tail ---\n" + res["vllm_log_tail"])

--- a/deploy/modal_vllm_connector_check.py
+++ b/deploy/modal_vllm_connector_check.py
@@ -1,0 +1,129 @@
+"""Stage A — prove QuillCacheV1Connector conforms to the DEPLOYED vllm 0.22.1.
+
+Runs the exact code path `--kv-transfer-config` triggers: import the external
+module, resolve the class, run the factory's external-connector checks. CPU-only,
+no GPU, no model download, no store — just "will vllm 0.22.1 load this connector?"
+
+    modal run deploy/modal_vllm_connector_check.py
+"""
+
+import modal
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install("vllm")
+    # the connector + its store client, importable as top-level modules
+    .add_local_file("bridge/quillcache_v1_connector.py", "/root/quillcache_v1_connector.py", copy=True)
+    .add_local_file("bridge/quillcache_store_client.py", "/root/quillcache_store_client.py", copy=True)
+)
+app = modal.App("quillcache-vllm-connector-check")
+
+
+@app.function(image=image, timeout=600)
+def check():
+    import sys
+
+    sys.path.insert(0, "/root")
+    results = []
+
+    def step(name, fn):
+        try:
+            detail = fn()
+            results.append((name, True, detail))
+        except Exception as e:
+            import traceback
+
+            results.append((name, False, f"{type(e).__name__}: {e}\n{traceback.format_exc()}"))
+
+    # 1) The connector module imports under the real vllm 0.22.1 (every vllm
+    #    symbol the connector references must resolve in this version).
+    def s1():
+        import quillcache_v1_connector as m
+
+        return f"imported; class={m.QuillCacheV1Connector.__name__}"
+
+    step("import connector module under vllm 0.22.1", s1)
+
+    # 2) It is a CONCRETE subclass of the real base — no abstract method left out.
+    def s2():
+        import quillcache_v1_connector as m
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+
+        cls = m.QuillCacheV1Connector
+        assert issubclass(cls, KVConnectorBase_V1), "not a KVConnectorBase_V1 subclass"
+        missing = sorted(getattr(cls, "__abstractmethods__", frozenset()))
+        assert not missing, f"unimplemented abstract methods: {missing}"
+        return "concrete subclass; all abstract methods implemented"
+
+    step("concrete KVConnectorBase_V1 (no missing abstract methods)", s2)
+
+    # 3) The factory's external-connector contract: 3-arg ctor incl. kv_cache_config.
+    def s3():
+        import quillcache_v1_connector as m
+        from vllm.utils.func_utils import supports_kw
+
+        assert supports_kw(m.QuillCacheV1Connector, "kv_cache_config"), "ctor missing kv_cache_config"
+        return "constructor accepts kv_cache_config (external v1 contract)"
+
+    step("constructor signature accepted by the factory", s3)
+
+    # 4) The EXACT resolution path `--kv-transfer-config` uses: build a real
+    #    KVTransferConfig and ask the factory for the class by module path.
+    def s4():
+        import quillcache_v1_connector as m
+        from vllm.config.kv_transfer import KVTransferConfig
+        from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+        kt = KVTransferConfig(
+            kv_connector="QuillCacheV1Connector",
+            kv_connector_module_path="quillcache_v1_connector",
+            kv_role="kv_both",
+        )
+        resolved = KVConnectorFactory.get_connector_class(kt)
+        assert resolved is m.QuillCacheV1Connector, f"factory resolved {resolved}"
+        return "vllm factory resolves QuillCacheV1Connector via kv_connector_module_path"
+
+    step("vllm KVConnectorFactory resolves it (the --kv-transfer-config path)", s4)
+
+    # 5) The paged-KV slot-mapping math (pure torch, no GPU) produces the right shape.
+    def s5():
+        import quillcache_v1_connector as m
+
+        rm = m.ReqMeta.make_meta(
+            token_ids=list(range(40)),
+            block_ids=[0, 1, 2],
+            block_size=16,
+            is_store=True,
+            prefix_hash="deadbeef",
+        )
+        # align_to_block_size(40,16) = (39//16)*16 = 32 tokens covered.
+        assert rm.slot_mapping.numel() == 32, f"slot_mapping len={rm.slot_mapping.numel()}"
+        # block 0 -> slots 0..15, block 1 -> 16..31 (contiguous within block).
+        assert rm.slot_mapping[0].item() == 0, f"slot[0]={rm.slot_mapping[0].item()}"
+        assert rm.slot_mapping[16].item() == 16, f"slot[16]={rm.slot_mapping[16].item()}"
+        h, aligned = m._prefix_hash(list(range(40)), 16, [])
+        assert aligned == 32, f"aligned={aligned}"
+        assert isinstance(h, str) and len(h) >= 16, f"hash={h!r}"
+        return f"slot_mapping=32 tokens, prefix_hash ok ({h[:12]}… len={len(h)})"
+
+    step("paged-KV slot-mapping + prefix-hash math", s5)
+
+    return results
+
+
+@app.local_entrypoint()
+def main():
+    results = check.remote()
+    print("\n=== QuillCacheV1Connector vs vllm 0.22.1 — conformance ===")
+    ok = 0
+    for name, passed, detail in results:
+        mark = "PASS" if passed else "FAIL"
+        print(f"[{mark}] {name}")
+        if passed:
+            print(f"       {detail}")
+            ok += 1
+        else:
+            # show only the first 2 lines of the traceback inline
+            for line in str(detail).splitlines()[:6]:
+                print(f"       {line}")
+    print(f"\n{ok}/{len(results)} checks passed")

--- a/deploy/modal_vllm_disagg.py
+++ b/deploy/modal_vllm_disagg.py
@@ -1,0 +1,279 @@
+"""GPU-real TRUE mid-request P/D — vLLM-native disaggregation, end to end on GPUs.
+
+Unlike modal_vllm_pd.py (content-addressed reuse, both engines `kv_both`), this
+exercises vLLM's first-class disaggregation handshake with role-split engines:
+
+  - prefill : vLLM on GPU 0 (port 8000), QuillCacheV1Connector, kv_role=kv_producer
+  - decode  : vLLM on GPU 1 (port 8001), QuillCacheV1Connector, kv_role=kv_consumer
+  - store   : one quillcache store-master + transfer-node on localhost, shared
+  - proxy   : quillcache pd-proxy (the router) mints a transfer_id per request
+
+ONE request to the proxy drives the real handshake:
+  proxy → prefill (do_remote_decode, transfer_id T): the producer prefills and
+          offloads the request's KV to the store under `qc-pd/T` (no real decode);
+  proxy → decode  (do_remote_prefill, transfer_id T): the consumer pulls the KV
+          named by T, SKIPS prefill, and generates.
+
+The transfer_id — not the prompt content — names the KV, so this is true P/D for
+a UNIQUE prompt (no prefix-cache hit possible). We then run the same prompt as a
+monolithic request and assert the disagg output matches: proof the KV computed on
+GPU 0 and pulled onto GPU 1 is correct.
+
+    modal run deploy/modal_vllm_disagg.py
+"""
+
+import modal
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config", "libssl-dev")
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .pip_install("vllm", "huggingface_hub")
+    .add_local_file("Cargo.toml", "/build/Cargo.toml", copy=True)
+    .add_local_file("Cargo.lock", "/build/Cargo.lock", copy=True)
+    .add_local_dir("crates", "/build/crates", copy=True, ignore=["**/target/**"])
+    .add_local_dir("src", "/build/src", copy=True, ignore=["**/target/**"])
+    .run_commands(
+        "cd /build && $HOME/.cargo/bin/cargo build --release --bin quillcache",
+        "cp /build/target/release/quillcache /usr/local/bin/quillcache",
+    )
+    .add_local_file("bridge/quillcache_v1_connector.py", "/root/quillcache_v1_connector.py", copy=True)
+    .add_local_file("bridge/quillcache_store_client.py", "/root/quillcache_store_client.py", copy=True)
+)
+app = modal.App("quillcache-vllm-disagg")
+
+
+@app.function(gpu="L4:2", image=image, timeout=60 * 60)
+def run_disagg():
+    import json
+    import os
+    import re
+    import subprocess
+    import time
+    import urllib.request
+
+    procs = {}
+
+    def tail(path, n=60):
+        try:
+            return "\n".join(open(path, errors="replace").read().splitlines()[-n:])
+        except OSError:
+            return f"<no {path}>"
+
+    def spawn(name, args, logpath, extra_env=None):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = "/root"
+        env["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
+        if extra_env:
+            env.update(extra_env)
+        f = open(logpath, "w")
+        procs[name] = (subprocess.Popen(args, stdout=f, stderr=subprocess.STDOUT, env=env), f)
+
+    def wait_ready(url, timeout, name, proc=None):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if proc is not None and proc.poll() is not None:
+                raise RuntimeError(f"{name} exited early (code {proc.returncode})")
+            try:
+                with urllib.request.urlopen(url, timeout=2) as r:
+                    if r.status < 500:
+                        return
+            except Exception:
+                time.sleep(1.0)
+        raise TimeoutError(f"{name} not ready at {url} within {timeout}s")
+
+    def kv_cfg(role, engine_id):
+        return json.dumps({
+            "kv_connector": "QuillCacheV1Connector",
+            "kv_connector_module_path": "quillcache_v1_connector",
+            "kv_role": role,
+            "engine_id": engine_id,
+            "kv_connector_extra_config": {
+                "master_url": "http://127.0.0.1:7777",
+                "segment_endpoints": {"seg-0": "127.0.0.1:8100"},
+                "tenant_id": "default",
+                "replica_num": 1,
+            },
+        })
+
+    def serve(port, gpu_ordinal, logpath, role, engine_id):
+        spawn(
+            f"vllm-{port}",
+            [
+                "vllm", "serve", MODEL,
+                "--port", str(port),
+                "--max-model-len", "4096",
+                "--gpu-memory-utilization", "0.55",
+                "--no-enable-prefix-caching",
+                "--disable-hybrid-kv-cache-manager",
+                "--kv-transfer-config", kv_cfg(role, engine_id),
+            ],
+            logpath,
+            extra_env={"CUDA_VISIBLE_DEVICES": str(gpu_ordinal)},
+        )
+
+    # A UNIQUE prompt so no content/prefix cache could serve it — the only way
+    # decode can skip prefill is the transfer_id handshake.
+    PROMPT = (
+        "You are QuillCache's disaggregation test harness, run id 7af3c91e. "
+        "Considering the tradeoffs of KV-cache disaggregation across prefill and "
+        "decode instances, answer precisely and concretely: "
+        "In one sentence, what is a KV cache?"
+    )
+
+    def post(url, body, timeout=180):
+        req = urllib.request.Request(
+            url, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        t0 = time.time()
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            out = json.loads(r.read())
+        return (time.time() - t0) * 1000, out
+
+    def msg_body():
+        return {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": PROMPT}],
+            "max_tokens": 24,
+            "temperature": 0.0,
+        }
+
+    try:
+        # 1) shared store: one master + one transfer-node segment on localhost.
+        spawn("transfer-node", ["quillcache", "transfer-node", "--addr", "127.0.0.1:8100", "--segment", "seg-0"], "/tmp/node.log")
+        spawn("store-master", ["quillcache", "store-master", "--addr", "127.0.0.1:7777"], "/tmp/master.log")
+        wait_ready("http://127.0.0.1:7777/v1/state", 30, "store-master", procs["store-master"][0])
+
+        # 2) role-split engines: prefill=kv_producer (GPU0), decode=kv_consumer (GPU1).
+        serve(8000, 0, "/tmp/vllm_prefill.log", "kv_producer", "prefill-engine")
+        serve(8001, 1, "/tmp/vllm_decode.log", "kv_consumer", "decode-engine")
+        wait_ready("http://127.0.0.1:8000/health", 900, "vllm-prefill", procs["vllm-8000"][0])
+        wait_ready("http://127.0.0.1:8001/health", 900, "vllm-decode", procs["vllm-8001"][0])
+
+        # 3) the router (pd-proxy) fronts both engines.
+        spawn(
+            "pd-proxy",
+            ["quillcache", "pd-proxy", "--bind", "127.0.0.1:9000",
+             "--prefill", "http://127.0.0.1:8000", "--decode", "http://127.0.0.1:8001"],
+            "/tmp/proxy.log",
+        )
+        wait_ready("http://127.0.0.1:9000/v1/state", 30, "pd-proxy", procs["pd-proxy"][0])
+
+        # 4) ONE request THROUGH the proxy → the true disagg handshake.
+        t_disagg, disagg_out = post("http://127.0.0.1:9000/v1/chat/completions", msg_body())
+        disagg_text = disagg_out["choices"][0]["message"]["content"]
+        time.sleep(1.5)  # let producer commit + consumer load settle in the logs
+
+        # 5) monolithic reference: same prompt straight to the decode engine, NO
+        #    handshake (no kv_transfer_params) → normal prefill+decode on GPU 1.
+        t_ref, ref_out = post("http://127.0.0.1:8001/v1/chat/completions", msg_body())
+        ref_text = ref_out["choices"][0]["message"]["content"]
+
+        prefill_log = open("/tmp/vllm_prefill.log", errors="replace").read()
+        decode_log = open("/tmp/vllm_decode.log", errors="replace").read()
+
+        def grep(text, needle):
+            return [l for l in text.splitlines() if needle in l]
+
+        # Producer offloaded under qc-pd/<transfer_id>; consumer pulled by id + loaded it.
+        producer_committed = [l for l in grep(prefill_log, "QC committed") if "qc-pd/" in l]
+        consumer_claimed = grep(decode_log, "QC disagg consumer")
+        consumer_loaded = [l for l in grep(decode_log, "QC loading") if "qc-pd/" in l]
+
+        # Correlate the transfer_id across producer + consumer.
+        def first_id(lines, pat):
+            for l in lines:
+                m = re.search(pat, l)
+                if m:
+                    return m.group(1)
+            return None
+
+        producer_id = first_id(producer_committed, r"qc-pd/(\S+?)\)")
+        consumer_id = first_id(consumer_claimed, r"transfer_id=(\S+?)\s")
+
+        state = json.loads(urllib.request.urlopen("http://127.0.0.1:7777/v1/state").read())
+
+        result = {
+            "ok": True,
+            "disagg_ms": round(t_disagg),
+            "ref_ms": round(t_ref),
+            "disagg_text": disagg_text,
+            "ref_text": ref_text,
+            "outputs_match": disagg_text.strip() == ref_text.strip(),
+            "producer_committed": producer_committed[:3],
+            "consumer_claimed": consumer_claimed[:3],
+            "consumer_loaded": consumer_loaded[:3],
+            "producer_id": producer_id,
+            "consumer_id": consumer_id,
+            "transfer_id_correlated": bool(producer_id) and producer_id == consumer_id,
+            "store_state": state,
+            "proxy_log_tail": "\n".join(open("/tmp/proxy.log", errors="replace").read().splitlines()[-12:]),
+            "decode_log_tail": "\n".join(decode_log.splitlines()[-30:]),
+        }
+    except Exception as e:
+        result = {
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "prefill_log_tail": tail("/tmp/vllm_prefill.log"),
+            "decode_log_tail": tail("/tmp/vllm_decode.log"),
+            "master_log_tail": tail("/tmp/master.log", 15),
+            "proxy_log_tail": tail("/tmp/proxy.log", 15),
+        }
+    finally:
+        for _, (p, f) in procs.items():
+            try:
+                p.terminate()
+            except Exception:
+                pass
+            f.close()
+    return result
+
+
+@app.local_entrypoint()
+def main():
+    import json
+
+    res = run_disagg.remote()
+    print("\n" + "=" * 80)
+    print("QuillCache TRUE mid-request P/D — prefill=kv_producer(GPU0) → store → decode=kv_consumer(GPU1)")
+    print("=" * 80)
+    if not res.get("ok"):
+        print(f"\nFAILED: {res.get('error')}")
+        print("\n--- prefill log tail ---\n" + res.get("prefill_log_tail", ""))
+        print("\n--- decode log tail ---\n" + res.get("decode_log_tail", ""))
+        print("\n--- proxy log tail ---\n" + res.get("proxy_log_tail", ""))
+        print("\n--- master log tail ---\n" + res.get("master_log_tail", ""))
+        return
+
+    print(f"\ndisagg via proxy: {res['disagg_ms']}ms → {res['disagg_text']!r}")
+    print(f"monolithic ref:   {res['ref_ms']}ms → {res['ref_text']!r}")
+    print(f"\noutputs identical: {res['outputs_match']}  (proof the transferred KV is correct)")
+
+    print("\n[prefill GPU0 = kv_producer offloaded KV under qc-pd/<transfer_id>]")
+    for l in res["producer_committed"]:
+        print("   ", l.strip()[:150])
+    print("\n[decode GPU1 = kv_consumer claimed the prefix by transfer_id (skipped prefill)]")
+    for l in res["consumer_claimed"]:
+        print("   ", l.strip()[:150])
+    print("\n[decode GPU1 pulled the KV over the transfer engine]")
+    for l in res["consumer_loaded"]:
+        print("   ", l.strip()[:150])
+    print(f"\ntransfer_id: producer={res['producer_id']}  consumer={res['consumer_id']}  correlated={res['transfer_id_correlated']}")
+    print("\n--- store master /v1/state ---")
+    print(json.dumps(res["store_state"], indent=2)[:600])
+
+    real = (
+        bool(res["producer_committed"])
+        and bool(res["consumer_claimed"])
+        and bool(res["consumer_loaded"])
+        and res["transfer_id_correlated"]
+    )
+    print(
+        f"\nVERDICT: {'REAL vLLM-native P/D — router minted a transfer_id; producer(GPU0) offloaded KV under it; consumer(GPU1) pulled by id, skipped prefill, generated' + (' — and output matches the monolithic reference' if res['outputs_match'] else ' (output differs from reference — see texts)') if real else 'partial — see logs'}"
+    )
+    if not real:
+        print("\n--- proxy log tail ---\n" + res.get("proxy_log_tail", ""))
+        print("\n--- decode log tail ---\n" + res["decode_log_tail"])

--- a/deploy/modal_vllm_disagg_introspect.py
+++ b/deploy/modal_vllm_disagg_introspect.py
@@ -1,0 +1,77 @@
+"""Dump vLLM 0.22.1's native disaggregated-prefilling API (CPU, no GPU).
+
+For true mid-request P/D we need the ground-truth of how vLLM 0.22.1 wires a
+kv_producer (prefill) to a kv_consumer (decode): the KVTransferConfig (kv_role),
+the request-level `kv_transfer_params` handshake, and how a consumer connector's
+get_num_new_matched_tokens / update_state_after_alloc consume the producer's KV.
+
+    modal run deploy/modal_vllm_disagg_introspect.py
+"""
+
+import modal
+
+image = modal.Image.debian_slim(python_version="3.12").pip_install("vllm")
+app = modal.App("quillcache-vllm-disagg-introspect")
+
+
+@app.function(image=image, timeout=600)
+def dump():
+    import glob
+    import os
+    import re
+    import sysconfig
+
+    sp = sysconfig.get_paths()["purelib"]
+    root = os.path.join(sp, "vllm")
+    out = {}
+
+    # 1) The KVTransferConfig source (kv_role, connector, extra_config).
+    for f in glob.glob(os.path.join(root, "config/kv_transfer*.py")) + glob.glob(
+        os.path.join(root, "**/kv_transfer_config.py"), recursive=True
+    ):
+        out[f.replace(sp + "/", "")] = open(f, errors="replace").read()
+
+    # 2) Where `kv_transfer_params` is threaded through (the disagg handshake).
+    hits = {}
+    for f in glob.glob(os.path.join(root, "**/*.py"), recursive=True):
+        try:
+            text = open(f, errors="replace").read()
+        except OSError:
+            continue
+        for kw in ("kv_transfer_params", "do_remote_prefill", "do_remote_decode", "remote_engine_id"):
+            for i, line in enumerate(text.splitlines()):
+                if kw in line:
+                    hits.setdefault(kw, []).append(
+                        f"{f.replace(sp + '/', '')}:{i + 1}: {line.strip()[:140]}"
+                    )
+
+    # 3) Any shipped disagg proxy / example entrypoint inside the package.
+    proxy_files = [
+        f.replace(sp + "/", "")
+        for f in glob.glob(os.path.join(root, "**/*.py"), recursive=True)
+        if re.search(r"disagg|disaggregat", os.path.basename(f), re.I)
+    ]
+
+    return {
+        "config_sources": out,
+        "kv_transfer_params_hits": {k: v[:25] for k, v in hits.items()},
+        "disagg_files": proxy_files,
+    }
+
+
+@app.local_entrypoint()
+def main():
+    res = dump.remote()
+    for name, src in res["config_sources"].items():
+        print("=" * 90)
+        print(name)
+        print("=" * 90)
+        print(src[:6000])
+    print("\n\n##### kv_transfer_params / disagg handshake call sites #####")
+    for kw, lines in res["kv_transfer_params_hits"].items():
+        print(f"\n--- {kw} ({len(lines)} shown) ---")
+        for l in lines:
+            print(l)
+    print("\n\n##### files named *disagg* in the package #####")
+    for f in res["disagg_files"]:
+        print(f)

--- a/deploy/modal_vllm_introspect.py
+++ b/deploy/modal_vllm_introspect.py
@@ -1,0 +1,76 @@
+"""Dump the EXACT KV-connector API of the vLLM version deployed on Modal.
+
+The connector must subclass vLLM's real `KVConnectorBase_V1`, whose signatures
+are version-specific and (for vllm 0.22.1) postdate our knowledge. So instead of
+guessing, pull the ground-truth source from the same image the engines run:
+
+    modal run deploy/modal_vllm_introspect.py
+
+CPU-only, no GPU, no model download — it just reads the installed .py files
+(never imports torch/cuda), so it's cheap and independent of the live engines.
+"""
+
+import modal
+
+# Same vLLM as the serving image (unpinned -> latest, currently 0.22.1).
+image = modal.Image.debian_slim(python_version="3.12").pip_install("vllm")
+app = modal.App("quillcache-vllm-introspect")
+
+
+@app.function(image=image, timeout=600)
+def dump():
+    import glob
+    import os
+    import re
+    import sysconfig
+
+    sp = sysconfig.get_paths()["purelib"]
+    root = os.path.join(sp, "vllm")
+
+    # The whole kv_transfer subtree (base class + shipped connectors as references).
+    files = sorted(
+        glob.glob(os.path.join(root, "distributed/kv_transfer/**/*.py"), recursive=True)
+    )
+    # Anything else in the tree that defines a KVConnector class (in case the
+    # path moved in 0.22.1).
+    extra = []
+    for f in glob.glob(os.path.join(root, "**/*.py"), recursive=True):
+        if f in files:
+            continue
+        try:
+            head = open(f, "r", errors="replace").read(4000)
+        except OSError:
+            continue
+        if re.search(r"class \w*KVConnector", head):
+            extra.append(f)
+
+    version = "unknown"
+    try:
+        version = open(os.path.join(root, "version.py")).read()
+    except OSError:
+        pass
+
+    out = {"__version__": version}
+    for f in sorted(set(files + extra)):
+        try:
+            out[f.replace(sp + "/", "")] = open(f, "r", errors="replace").read()
+        except OSError as e:
+            out[f.replace(sp + "/", "")] = f"<unreadable: {e}>"
+    return out
+
+
+@app.local_entrypoint()
+def main():
+    res = dump.remote()
+    # version banner first
+    print("#### vllm/version.py ####")
+    print(res.pop("__version__", "?"))
+    # then every connector source file, base.py first
+    def sort_key(name):
+        return (0 if name.endswith("/v1/base.py") else 1, name)
+
+    for name in sorted(res, key=sort_key):
+        print("\n" + "=" * 100)
+        print(name)
+        print("=" * 100)
+        print(res[name])

--- a/deploy/modal_vllm_pd.py
+++ b/deploy/modal_vllm_pd.py
@@ -146,13 +146,19 @@ def run_pd():
         wait_ready("http://127.0.0.1:8000/health", 900, "vllm-prefill", procs["vllm-8000"][0])
         wait_ready("http://127.0.0.1:8001/health", 900, "vllm-decode", procs["vllm-8001"][0])
 
-        # 3) prefill the prompt on GPU 0 → its KV is published to the store.
-        t_prefill, out_p = chat(8000)
-        time.sleep(2.0)  # let the manifest commit settle
-        # 4) same prompt to the DECODE instance on GPU 1 → it loads prefill's KV
-        #    from the store instead of prefilling.
-        t_decode, out_d = chat(8001)
-        time.sleep(1.0)
+        # 3) the P/D proxy fronts both engines: ONE request to it orchestrates
+        #    prefill (GPU 0, warms the store) → decode (GPU 1, reuses from the store).
+        spawn(
+            "pd-proxy",
+            ["quillcache", "pd-proxy", "--bind", "127.0.0.1:9000",
+             "--prefill", "http://127.0.0.1:8000", "--decode", "http://127.0.0.1:8001"],
+            "/tmp/proxy.log",
+        )
+        wait_ready("http://127.0.0.1:9000/v1/state", 30, "pd-proxy", procs["pd-proxy"][0])
+
+        # 4) a single request THROUGH the proxy drives the whole P/D flow.
+        t_proxy, out_text = chat(9000)
+        time.sleep(1.5)  # let the manifest commit + decode load settle
 
         prefill_log = open("/tmp/vllm_prefill.log", errors="replace").read()
         decode_log = open("/tmp/vllm_decode.log", errors="replace").read()
@@ -167,13 +173,15 @@ def run_pd():
 
         result = {
             "ok": True,
-            "prefill_ms": round(t_prefill),
-            "decode_ms": round(t_decode),
-            "outputs_match": out_p == out_d,
+            "proxy_ms": round(t_proxy),
+            "output": out_text,
             "prefill_committed": prefill_committed[:3],
             "decode_manifest_hit": decode_hit[:3],
             "decode_loaded": decode_loaded[:3],
             "store_state": state,
+            "proxy_log_tail": "\n".join(
+                open("/tmp/proxy.log", errors="replace").read().splitlines()[-12:]
+            ),
             "decode_log_tail": "\n".join(decode_log.splitlines()[-30:]),
         }
     except Exception as e:
@@ -208,8 +216,7 @@ def main():
         print("\n--- decode log tail ---\n" + res.get("decode_log_tail", ""))
         print("\n--- master log tail ---\n" + res.get("master_log_tail", ""))
         return
-    print(f"\nlatency: prefill(GPU0)={res['prefill_ms']}ms  decode(GPU1)={res['decode_ms']}ms")
-    print(f"outputs identical: {res['outputs_match']}")
+    print(f"\none request THROUGH the P/D proxy: {res['proxy_ms']}ms → {res['output']!r}")
     print("\n[prefill GPU0 committed KV to the store]")
     for l in res["prefill_committed"]:
         print("   ", l.strip()[:150])
@@ -223,7 +230,8 @@ def main():
     print(json.dumps(res["store_state"], indent=2)[:600])
     cross = bool(res["prefill_committed"]) and bool(res["decode_manifest_hit"]) and bool(res["decode_loaded"])
     print(
-        f"\nVERDICT: {'REAL cross-instance P/D — GPU0 prefill KV reused by GPU1 decode via the store' if cross else 'partial — see decode_log_tail'}"
+        f"\nVERDICT: {'REAL end-to-end P/D THROUGH THE PROXY — one request → prefill(GPU0) warmed the store → decode(GPU1) reused it' if cross else 'partial — see logs'}"
     )
     if not cross:
+        print("\n--- proxy log tail ---\n" + res.get("proxy_log_tail", ""))
         print("\n--- decode log tail ---\n" + res["decode_log_tail"])

--- a/deploy/modal_vllm_pd.py
+++ b/deploy/modal_vllm_pd.py
@@ -1,0 +1,229 @@
+"""GPU-real disaggregated prefill/decode — Mooncake's P/D, end to end on GPUs.
+
+Two SEPARATE vLLM instances in one 2-GPU container, sharing one QuillCache store:
+  - prefill  : vLLM on GPU 0 (port 8000), QuillCacheV1Connector
+  - decode   : vLLM on GPU 1 (port 8001), QuillCacheV1Connector
+  - store    : one quillcache store-master + transfer-node on localhost, shared
+
+The flow is Mooncake's P/D: the prompt goes to the PREFILL instance, which
+computes the prefix KV and publishes it to the store; then the SAME prompt goes
+to the DECODE instance, which finds prefill's KV in the store and LOADS it over
+the transfer engine instead of prefilling — KV computed on GPU 0 is reused on
+GPU 1, across instances. Prefix caching is off on both so the only way decode
+can skip prefill is via the connector.
+
+    modal run deploy/modal_vllm_pd.py
+
+(One 2-GPU box avoids Modal cross-container networking; swap the localhost store
+for a shared remote store + put the two vLLMs on two nodes and nothing changes.)
+"""
+
+import modal
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config", "libssl-dev")
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .pip_install("vllm", "huggingface_hub")
+    .add_local_file("Cargo.toml", "/build/Cargo.toml", copy=True)
+    .add_local_file("Cargo.lock", "/build/Cargo.lock", copy=True)
+    .add_local_dir("crates", "/build/crates", copy=True, ignore=["**/target/**"])
+    .add_local_dir("src", "/build/src", copy=True, ignore=["**/target/**"])
+    .run_commands(
+        "cd /build && $HOME/.cargo/bin/cargo build --release --bin quillcache",
+        "cp /build/target/release/quillcache /usr/local/bin/quillcache",
+    )
+    .add_local_file("bridge/quillcache_v1_connector.py", "/root/quillcache_v1_connector.py", copy=True)
+    .add_local_file("bridge/quillcache_store_client.py", "/root/quillcache_store_client.py", copy=True)
+)
+app = modal.App("quillcache-vllm-pd")
+
+
+@app.function(gpu="L4:2", image=image, timeout=60 * 60)
+def run_pd():
+    import json
+    import os
+    import subprocess
+    import time
+    import urllib.request
+
+    procs = {}
+
+    def tail(path, n=60):
+        try:
+            return "\n".join(open(path, errors="replace").read().splitlines()[-n:])
+        except OSError:
+            return f"<no {path}>"
+
+    def spawn(name, args, logpath, extra_env=None):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = "/root"
+        env["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
+        if extra_env:
+            env.update(extra_env)
+        f = open(logpath, "w")
+        procs[name] = (subprocess.Popen(args, stdout=f, stderr=subprocess.STDOUT, env=env), f)
+
+    def wait_ready(url, timeout, name, proc=None):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if proc is not None and proc.poll() is not None:
+                raise RuntimeError(f"{name} exited early (code {proc.returncode})")
+            try:
+                with urllib.request.urlopen(url, timeout=2) as r:
+                    if r.status < 500:
+                        return
+            except Exception:
+                time.sleep(1.0)
+        raise TimeoutError(f"{name} not ready at {url} within {timeout}s")
+
+    def kv_cfg():
+        return json.dumps({
+            "kv_connector": "QuillCacheV1Connector",
+            "kv_connector_module_path": "quillcache_v1_connector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {
+                "master_url": "http://127.0.0.1:7777",
+                "segment_endpoints": {"seg-0": "127.0.0.1:8100"},
+                "tenant_id": "default",
+                "replica_num": 1,
+            },
+        })
+
+    def serve(port, gpu_ordinal, logpath):
+        spawn(
+            f"vllm-{port}",
+            [
+                "vllm", "serve", MODEL,
+                "--port", str(port),
+                "--max-model-len", "4096",
+                "--gpu-memory-utilization", "0.55",
+                "--no-enable-prefix-caching",
+                "--disable-hybrid-kv-cache-manager",
+                "--kv-transfer-config", kv_cfg(),
+            ],
+            logpath,
+            extra_env={"CUDA_VISIBLE_DEVICES": str(gpu_ordinal)},
+        )
+
+    def chat(port):
+        shared_prefix = (
+            "You are a meticulous assistant. Follow these standing rules for every "
+            "answer. " + " ".join(
+                f"Rule {i}: always be precise, cite assumptions, and prefer concrete "
+                "examples over abstractions." for i in range(24)
+            )
+        )
+        body = json.dumps({
+            "model": MODEL,
+            "messages": [
+                {"role": "system", "content": shared_prefix},
+                {"role": "user", "content": "In one sentence, what is a KV cache?"},
+            ],
+            "max_tokens": 16,
+            "temperature": 0.0,
+        }).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/chat/completions",
+            data=body, headers={"Content-Type": "application/json"}, method="POST",
+        )
+        t0 = time.time()
+        with urllib.request.urlopen(req, timeout=180) as r:
+            out = json.loads(r.read())
+        return (time.time() - t0) * 1000, out["choices"][0]["message"]["content"]
+
+    try:
+        # 1) shared store: one master + one transfer-node segment on localhost.
+        spawn("transfer-node", ["quillcache", "transfer-node", "--addr", "127.0.0.1:8100", "--segment", "seg-0"], "/tmp/node.log")
+        spawn("store-master", ["quillcache", "store-master", "--addr", "127.0.0.1:7777"], "/tmp/master.log")
+        wait_ready("http://127.0.0.1:7777/v1/state", 30, "store-master", procs["store-master"][0])
+
+        # 2) two vLLM instances: prefill on GPU 0, decode on GPU 1, same store.
+        serve(8000, 0, "/tmp/vllm_prefill.log")
+        serve(8001, 1, "/tmp/vllm_decode.log")
+        wait_ready("http://127.0.0.1:8000/health", 900, "vllm-prefill", procs["vllm-8000"][0])
+        wait_ready("http://127.0.0.1:8001/health", 900, "vllm-decode", procs["vllm-8001"][0])
+
+        # 3) prefill the prompt on GPU 0 → its KV is published to the store.
+        t_prefill, out_p = chat(8000)
+        time.sleep(2.0)  # let the manifest commit settle
+        # 4) same prompt to the DECODE instance on GPU 1 → it loads prefill's KV
+        #    from the store instead of prefilling.
+        t_decode, out_d = chat(8001)
+        time.sleep(1.0)
+
+        prefill_log = open("/tmp/vllm_prefill.log", errors="replace").read()
+        decode_log = open("/tmp/vllm_decode.log", errors="replace").read()
+
+        def grep(text, needle):
+            return [l for l in text.splitlines() if needle in l]
+
+        prefill_committed = grep(prefill_log, "QC committed")
+        decode_hit = [l for l in grep(decode_log, "QC match-check") if "manifest=True" in l]
+        decode_loaded = grep(decode_log, "QC loading")
+        state = json.loads(urllib.request.urlopen("http://127.0.0.1:7777/v1/state").read())
+
+        result = {
+            "ok": True,
+            "prefill_ms": round(t_prefill),
+            "decode_ms": round(t_decode),
+            "outputs_match": out_p == out_d,
+            "prefill_committed": prefill_committed[:3],
+            "decode_manifest_hit": decode_hit[:3],
+            "decode_loaded": decode_loaded[:3],
+            "store_state": state,
+            "decode_log_tail": "\n".join(decode_log.splitlines()[-30:]),
+        }
+    except Exception as e:
+        result = {
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "prefill_log_tail": tail("/tmp/vllm_prefill.log"),
+            "decode_log_tail": tail("/tmp/vllm_decode.log"),
+            "master_log_tail": tail("/tmp/master.log", 15),
+        }
+    finally:
+        for _, (p, f) in procs.items():
+            try:
+                p.terminate()
+            except Exception:
+                pass
+            f.close()
+    return result
+
+
+@app.local_entrypoint()
+def main():
+    import json
+
+    res = run_pd.remote()
+    print("\n" + "=" * 80)
+    print("QuillCache disaggregated P/D — prefill (GPU 0) → store → decode (GPU 1)")
+    print("=" * 80)
+    if not res.get("ok"):
+        print(f"\nFAILED: {res.get('error')}")
+        print("\n--- prefill log tail ---\n" + res.get("prefill_log_tail", ""))
+        print("\n--- decode log tail ---\n" + res.get("decode_log_tail", ""))
+        print("\n--- master log tail ---\n" + res.get("master_log_tail", ""))
+        return
+    print(f"\nlatency: prefill(GPU0)={res['prefill_ms']}ms  decode(GPU1)={res['decode_ms']}ms")
+    print(f"outputs identical: {res['outputs_match']}")
+    print("\n[prefill GPU0 committed KV to the store]")
+    for l in res["prefill_committed"]:
+        print("   ", l.strip()[:150])
+    print("\n[decode GPU1 found prefill's KV in the store]")
+    for l in res["decode_manifest_hit"]:
+        print("   ", l.strip()[:150])
+    print("\n[decode GPU1 loaded it over the transfer engine]")
+    for l in res["decode_loaded"]:
+        print("   ", l.strip()[:150])
+    print("\n--- store master /v1/state ---")
+    print(json.dumps(res["store_state"], indent=2)[:600])
+    cross = bool(res["prefill_committed"]) and bool(res["decode_manifest_hit"]) and bool(res["decode_loaded"])
+    print(
+        f"\nVERDICT: {'REAL cross-instance P/D — GPU0 prefill KV reused by GPU1 decode via the store' if cross else 'partial — see decode_log_tail'}"
+    )
+    if not cross:
+        print("\n--- decode log tail ---\n" + res["decode_log_tail"])

--- a/docs/real-engine-pool.md
+++ b/docs/real-engine-pool.md
@@ -12,7 +12,9 @@ The pieces (all in this repo):
 | `quillcache store-master` | the `MasterService` over HTTP — two-phase Put, identity-guarded Get, Mount (`src/store_master_http.rs`) |
 | `quillcache transfer-node` | a Transfer Engine storage node serving one named RAM segment over the `(segment, offset)` wire (`src/transfer_node.rs`) |
 | `bridge/quillcache_store_client.py` | stdlib client: the store master (HTTP) + the transfer wire (TCP) |
-| `bridge/vllm_quillcache_connector.py` | a vLLM KV-connector skeleton on the above |
+| `bridge/quillcache_v1_connector.py` | the **real** vLLM 0.22.1 `KVConnectorBase_V1` on the store (GPU-verified) |
+| `bridge/quillcache_store_demo.py` | a no-GPU demo of the store offload/load path |
+| `quillcache pd-proxy` | orchestrates prefill → store → decode across two engines (`src/pd_proxy.rs`) |
 
 The flow is Mooncake's: **put** = `put_start` (master allocates replica buffers)
 → WRITE the bytes to each `(segment, offset)` over the transfer engine →
@@ -32,8 +34,8 @@ cargo run -- transfer-node --addr 127.0.0.1:8100 --segment seg-0
 # 2) the store master — metadata, two-phase Put, the identity guard
 cargo run -- store-master --addr 127.0.0.1:7777
 
-# 3) the connector demo — offload a block, load it back through the store
-python3 bridge/vllm_quillcache_connector.py     # run from the bridge/ dir
+# 3) the store demo — offload a block, load it back through the store (no GPU)
+python3 bridge/quillcache_store_demo.py          # run from the bridge/ dir
 #   -> loaded back: b'fake-kv-bytes-over-the-faithful-store'
 curl -s http://127.0.0.1:7777/v1/state
 #   -> {"objects":1,"segments":1,"capacity":...,"allocated":37}
@@ -44,36 +46,37 @@ connector's `segment_endpoints` + `--replica-num 2`) and a Put replicates across
 distinct segments. A Get under a different `tenant_id` is refused with HTTP 403
 (the identity guard, over the wire).
 
-## On a GPU (Modal) — wire the connector to vLLM
+## On a GPU (Modal) — the connector is real and verified
 
-The connector's store logic (put_start → transfer WRITE → put_end; get_replica_list
-→ transfer READ; identity guard) is real and tested above. What needs a real
-GPU + a pinned vLLM version is the **KV-tensor (de)serialization** and the
-`KVConnectorBase_V1` **hook signatures** — documented TODOs in
-`bridge/vllm_quillcache_connector.py`:
+The vLLM `KVConnectorBase_V1` implementation (`bridge/quillcache_v1_connector.py`)
+is written against the deployed vLLM 0.22.1 API and **verified on a Modal L4**:
 
-1. Run `store-master` somewhere reachable, and a `transfer-node` co-located with
-   each vLLM worker (same box → `localhost`, no network hop for the warm path).
-2. Register `QuillCacheConnector` as the vLLM KV connector; wire its hooks:
-   - `save_kv_layer` → `offload(block_key, kv_bytes)` (quantize to FP8 to match
-     `quillcache-cuda`'s device tier);
-   - `start_load_kv` → `load(block_key)` (copy pool bytes into vLLM's paged-KV);
-   - `get_num_new_matched_tokens` → how many prefix tokens the store can serve, so
-     the scheduler skips recomputing that prefix.
-3. Measure prefix-cache **hit rate** + **TTFT** with the connector on vs off, under
-   a shared-prefix workload (`bench/run_trace.py`).
+- `deploy/modal_vllm_connector_check.py` — 5/5 conformance: vLLM's own
+  `KVConnectorFactory` loads the connector via `kv_connector_module_path`.
+- `deploy/modal_vllm_connector.py` — single-engine e2e: request-1 offloads a
+  496-token prefix to the store (`QC committed`), request-2 reuses it
+  (`QC loading`); prefix caching off, so the reuse can only come from the store.
+- `deploy/modal_vllm_pd.py` — disaggregated P/D on a 2-GPU box: one request
+  through `quillcache pd-proxy` warms the store on GPU 0 (prefill) and reuses it
+  on GPU 1 (decode). KV computed on one instance, reused by another, via the store.
+
+The connector keeps vLLM's paged-KV slot-mapping extract/inject verbatim (correct
+per attention backend) and swaps disk-safetensors for the identity-guarded store.
 
 ## Status — what's real vs what needs hardware
 
 | piece | status |
 | --- | --- |
-| `store-master` (MasterService over HTTP) | **real, tested** (`cargo test`) |
+| `store-master` (MasterService over HTTP; **HA**: snapshot recovery + heartbeat + etcd leader election) | **real, tested** — HA verified locally + vs Docker etcd |
 | `transfer-node` (Transfer Engine segment server) | **real, tested** (the engine's TCP round-trip) |
 | `quillcache_store_client.py` (master HTTP + transfer wire) | **real, tested** (the local e2e above) |
 | connector offload / load (two-phase Put, identity-guarded Get) | **real, tested** (the local e2e above) |
-| vLLM `KVConnectorBase_V1` hooks + KV-tensor (de)serialization | **skeleton** — wire to your vLLM + GPU |
-| RDMA / GPUDirect transfer (vs the TCP wire) | **reserved** — `--features rdma/nvlink`, needs a NIC/GPU |
+| vLLM `KVConnectorBase_V1` connector + KV-tensor (de)serialization | **real, L4-verified** (`deploy/modal_vllm_connector.py`) |
+| disaggregated P/D (prefill → store → decode via `pd-proxy`) | **real, 2×L4-verified** (`deploy/modal_vllm_pd.py`) |
+| multi-node (store on a separate node) | **code-ready** — `master_url` / `segment_endpoints` are arbitrary `host:port`, and the TCP byte path is identical to localhost; only Modal cross-container plumbing (tunnels) remains |
+| RDMA / GPUDirect transfer (vs the TCP wire) | **reserved** — `--features rdma/nvlink`, needs a NIC / multi-GPU |
 
-This mirrors the project's honesty rule: the store + the byte-moving transfer
-engine + the connector path are real and verified on a laptop; the GPU-resident
-tensor plumbing is a clearly-marked seam you complete on your own hardware.
+This mirrors the project's honesty rule: the store, the byte-moving transfer
+engine, the connector, master HA, and disaggregated P/D are real and verified
+(laptop / Docker etcd / Modal L4); zero-copy RDMA/GPUDirect is the clearly-marked
+seam that needs a NIC or multi-GPU.

--- a/docs/real-engine-pool.md
+++ b/docs/real-engine-pool.md
@@ -14,7 +14,7 @@ The pieces (all in this repo):
 | `bridge/quillcache_store_client.py` | stdlib client: the store master (HTTP) + the transfer wire (TCP) |
 | `bridge/quillcache_v1_connector.py` | the **real** vLLM 0.22.1 `KVConnectorBase_V1` on the store (GPU-verified) |
 | `bridge/quillcache_store_demo.py` | a no-GPU demo of the store offload/load path |
-| `quillcache pd-proxy` | orchestrates prefill → store → decode across two engines (`src/pd_proxy.rs`) |
+| `quillcache pd-proxy` | the disaggregation **router**: mints a `transfer_id` and drives prefill → store → decode across two engines via vLLM's `kv_transfer_params` handshake (`src/pd_proxy.rs`) |
 
 The flow is Mooncake's: **put** = `put_start` (master allocates replica buffers)
 → WRITE the bytes to each `(segment, offset)` over the transfer engine →
@@ -59,6 +59,13 @@ is written against the deployed vLLM 0.22.1 API and **verified on a Modal L4**:
 - `deploy/modal_vllm_pd.py` — disaggregated P/D on a 2-GPU box: one request
   through `quillcache pd-proxy` warms the store on GPU 0 (prefill) and reuses it
   on GPU 1 (decode). KV computed on one instance, reused by another, via the store.
+- `deploy/modal_vllm_disagg.py` — **true vLLM-native P/D**: prefill runs as
+  `kv_producer` (GPU 0), decode as `kv_consumer` (GPU 1), and `pd-proxy` is the
+  router that mints a `transfer_id` per request. The producer offloads the
+  request's KV under that id (`do_remote_decode`); the consumer pulls it by id and
+  skips prefill (`do_remote_prefill`). Verified with a *unique* prompt (no prefix
+  cache possible), and the disagg output matches a monolithic reference token for
+  token — proof the KV computed on GPU 0 is pulled onto GPU 1 correctly.
 
 The connector keeps vLLM's paged-KV slot-mapping extract/inject verbatim (correct
 per attention backend) and swaps disk-safetensors for the identity-guarded store.
@@ -72,11 +79,19 @@ per attention backend) and swaps disk-safetensors for the identity-guarded store
 | `quillcache_store_client.py` (master HTTP + transfer wire) | **real, tested** (the local e2e above) |
 | connector offload / load (two-phase Put, identity-guarded Get) | **real, tested** (the local e2e above) |
 | vLLM `KVConnectorBase_V1` connector + KV-tensor (de)serialization | **real, L4-verified** (`deploy/modal_vllm_connector.py`) |
-| disaggregated P/D (prefill → store → decode via `pd-proxy`) | **real, 2×L4-verified** (`deploy/modal_vllm_pd.py`) |
+| content-addressed P/D (prefill → store → decode via `pd-proxy`, `kv_both`) | **real, 2×L4-verified** (`deploy/modal_vllm_pd.py`) |
+| true vLLM-native P/D (`kv_producer`/`kv_consumer` + `transfer_id` handshake) | **real, 2×L4-verified** (`deploy/modal_vllm_disagg.py`) — output matches a monolithic reference token-for-token |
 | multi-node (store on a separate node) | **code-ready** — `master_url` / `segment_endpoints` are arbitrary `host:port`, and the TCP byte path is identical to localhost; only Modal cross-container plumbing (tunnels) remains |
 | RDMA / GPUDirect transfer (vs the TCP wire) | **reserved** — `--features rdma/nvlink`, needs a NIC / multi-GPU |
 
 This mirrors the project's honesty rule: the store, the byte-moving transfer
-engine, the connector, master HA, and disaggregated P/D are real and verified
-(laptop / Docker etcd / Modal L4); zero-copy RDMA/GPUDirect is the clearly-marked
-seam that needs a NIC or multi-GPU.
+engine, the connector, master HA, and both content-addressed and vLLM-native
+disaggregated P/D are real and verified (laptop / Docker etcd / Modal L4);
+zero-copy RDMA/GPUDirect is the clearly-marked seam that needs a NIC or multi-GPU.
+
+> A note on the numbers: in the 2×L4 demo the disagg path is *slower* than the
+> monolithic one (~1.6s vs ~0.2s) because the prompt is tiny — the proxy→store→
+> proxy round-trip and safetensors I/O dwarf the prefill it saves. Disaggregation
+> wins on long shared prefixes and on decoupling prefill/decode capacity, not on
+> short prompts; this run proves *correctness* of the vLLM-native mechanism, not a
+> latency win at this size.

--- a/examples/quillcache-modal-roundrobin.yaml
+++ b/examples/quillcache-modal-roundrobin.yaml
@@ -1,12 +1,9 @@
-# QuillCache gateway in front of a 2-vLLM fleet on Modal L4, using the
-# Dynamo-style KV-router cost function. Swap `policy:` to round-robin for the
-# cache-blind baseline. Warm both engines first (bench/run_trace.py --warmup-urls)
-# so the measured TTFT is steady-state, not Modal scale-to-zero cold start.
+# Cache-blind baseline: same 2-engine Modal fleet, round-robin routing, no
+# Conductor. Contrast against quillcache-modal.yaml (dynamo-cost + conductor) to
+# show what cache-affine routing buys on a shared-prefix workload.
 bind: 127.0.0.1:8080
-policy: dynamo-cost
-# Route via the Mooncake Conductor (PrefixCacheTable + the Dynamo cost), fed by
-# inferred placement — the P3 path. Set false to use the residency-snapshot router.
-conductor: true
+policy: round-robin
+conductor: false
 engines:
   - id: modal-vllm-a
     kind: Vllm

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cluster;
 mod gateway;
+mod pd;
 mod store_master_http;
 mod transfer_node;
 
@@ -56,6 +57,10 @@ enum Command {
         #[arg(long, default_value_t = 12)]
         requests: usize,
     },
+    /// Run the disaggregated prefill/decode demo: the control plane emits a
+    /// Disaggregated plan, then the freshly-prefilled KV moves from the prefill
+    /// node to the decode node over the transfer engine, identity-guarded.
+    Pd,
     /// Run the store's MasterService over HTTP (Mooncake's master service): the
     /// two-phase Put, identity-guarded Get, Mount, Remove, for out-of-process
     /// engine KV connectors. Object bytes still move via the transfer engine.
@@ -90,6 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Gateway { config } => run_from_config_path(config).await?,
         Command::Plan => print_plan(),
         Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
+        Command::Pd => pd::run_pd_demo().await?,
         Command::StoreMaster { addr, strategy } => {
             store_master_http::run_store_master(addr, strategy).await?
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cluster;
 mod gateway;
 mod pd;
+mod pd_proxy;
 mod store_master_http;
 mod transfer_node;
 
@@ -61,6 +62,20 @@ enum Command {
     /// Disaggregated plan, then the freshly-prefilled KV moves from the prefill
     /// node to the decode node over the transfer engine, identity-guarded.
     Pd,
+    /// Run the P/D proxy: an OpenAI-compatible front that orchestrates
+    /// prefill → store → decode across two engines sharing a QuillCache store
+    /// (puts the store on the request hot path). The prefill engine offloads the
+    /// prefix KV; the decode engine reuses it from the store.
+    PdProxy {
+        #[arg(long, default_value = "127.0.0.1:8080")]
+        bind: String,
+        /// Base URL of the prefill engine (its connector offloads KV).
+        #[arg(long)]
+        prefill: String,
+        /// Base URL of the decode engine (its connector loads KV).
+        #[arg(long)]
+        decode: String,
+    },
     /// Run the store's MasterService over HTTP (Mooncake's master service): the
     /// two-phase Put, identity-guarded Get, Mount, Remove, for out-of-process
     /// engine KV connectors. Object bytes still move via the transfer engine.
@@ -113,6 +128,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Plan => print_plan(),
         Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
         Command::Pd => pd::run_pd_demo().await?,
+        Command::PdProxy {
+            bind,
+            prefill,
+            decode,
+        } => pd_proxy::run_pd_proxy(bind, prefill, decode).await?,
         Command::StoreMaster {
             addr,
             strategy,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,23 @@ enum Command {
         addr: String,
         #[arg(long, default_value = "random")]
         strategy: String,
+        /// Snapshot file — recovered on startup if present, saved periodically
+        /// (HA: a restarted or newly-elected master rebuilds its state from it).
+        #[arg(long)]
+        snapshot: Option<String>,
+        /// Seconds between periodic snapshots (0 disables).
+        #[arg(long, default_value_t = 5)]
+        snapshot_interval: u64,
+        /// Seconds a segment may miss heartbeats before it's dead (0 = health off).
+        #[arg(long, default_value_t = 0)]
+        segment_ttl: u64,
+        /// Comma-separated etcd endpoints → multi-master leader election (HA mode;
+        /// needs `--features etcd`). Only the elected leader serves.
+        #[arg(long)]
+        etcd: Option<String>,
+        /// This master's id (the leader value in the election).
+        #[arg(long, default_value = "master-0")]
+        node_id: String,
     },
     /// Run a standalone Transfer Engine storage node serving one named RAM
     /// segment over the (segment, offset) wire — where a store client / engine
@@ -96,8 +113,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Plan => print_plan(),
         Command::Cluster { nodes, requests } => cluster::run_cluster(nodes, requests).await?,
         Command::Pd => pd::run_pd_demo().await?,
-        Command::StoreMaster { addr, strategy } => {
-            store_master_http::run_store_master(addr, strategy).await?
+        Command::StoreMaster {
+            addr,
+            strategy,
+            snapshot,
+            snapshot_interval,
+            segment_ttl,
+            etcd,
+            node_id,
+        } => {
+            store_master_http::run_store_master(store_master_http::StoreMasterOpts {
+                addr,
+                strategy,
+                snapshot,
+                snapshot_interval_secs: snapshot_interval,
+                segment_ttl,
+                etcd,
+                node_id,
+            })
+            .await?
         }
         Command::TransferNode { addr, segment } => {
             transfer_node::run_transfer_node(addr, segment).await?

--- a/src/pd.rs
+++ b/src/pd.rs
@@ -1,0 +1,172 @@
+//! Disaggregated prefill/decode demo — Mooncake's P/D data path, end to end and
+//! real (no GPU). The control plane decides the plan (which worker prefills,
+//! which decodes); then the freshly-prefilled KV physically moves from the
+//! prefill node to the decode node **over the Transfer Engine**, identity-guarded.
+//!
+//! This wires three real pieces together:
+//!   1. `ControlPlane::plan` → a `Disaggregated` `RequestPlan` (`prefill_worker`,
+//!      `decode_worker`, `RunPrefill` blocks) and its `KvHandoff`.
+//!   2. the prefill worker publishes the computed KV to the store
+//!      (`put_start` → WRITE over the transfer engine → `put_end`).
+//!   3. the decode worker resolves the replica (identity-guarded `get_replica_list`)
+//!      and READs it over the transfer engine before continuing generation.
+//!
+//! The bytes really cross loopback TCP between two transfer engines; swap
+//! `TcpTransport` for RDMA / the local engines for remote nodes and nothing above
+//! changes. On a GPU the KV would be the prefill engine's paged-KV (the connector
+//! seam); here it is a stand-in buffer so the *handoff* is exercised without a GPU.
+
+use quillcache_core::{
+    ControlPlane, EngineEndpoint, EngineKind, EngineRole, IdentityScope, KvBlockKey, RequestShape,
+    ServingMode, SloTarget,
+};
+use quillcache_store::{ErrorCode, RealClient, ReplicateConfig};
+use quillcache_transfer_engine::{InMemoryMetadata, MetadataBackend, TransferEngine};
+use std::sync::Arc;
+
+fn endpoint(id: &str, role: EngineRole) -> EngineEndpoint {
+    EngineEndpoint {
+        id: id.to_string(),
+        kind: EngineKind::Vllm,
+        role,
+        base_url: "http://127.0.0.1:0".to_string(),
+        model_id: "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
+        tokenizer_id: "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
+        tenant_id: "tenant-a".to_string(),
+        locality_domain: "local".to_string(),
+    }
+}
+
+fn identity_of(req: &RequestShape) -> IdentityScope {
+    IdentityScope {
+        model_id: req.model_id.clone(),
+        tokenizer_id: req.tokenizer_id.clone(),
+        adapter_id: req.adapter_id.clone(),
+        tenant_id: req.tenant_id.clone(),
+    }
+}
+
+pub async fn run_pd_demo() -> Result<(), Box<dyn std::error::Error>> {
+    println!("QuillCache P/D — disaggregated prefill→decode KV handoff (Mooncake data path)\n");
+
+    // 1) Control plane: one prefill-only worker + one decode-only worker. A cold
+    //    prefix block (not resident anywhere) forces a prefill the decode worker
+    //    cannot do itself → the planner disaggregates.
+    let control = ControlPlane::new(vec![
+        endpoint("prefill-a", EngineRole::Prefill),
+        endpoint("decode-a", EngineRole::Decode),
+    ]);
+    let request = RequestShape {
+        id: "req-pd-0".to_string(),
+        model_id: "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
+        tokenizer_id: "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
+        adapter_id: None,
+        tenant_id: "tenant-a".to_string(),
+        session_id: None,
+        blocks: vec![KvBlockKey::new(
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            "tenant-a",
+            "root",
+            "blk-cold",
+            0,
+            64,
+        )],
+        estimated_decode_tokens: 16,
+        slo: SloTarget::default(),
+    };
+
+    let plan = control.plan(&request)?;
+    let handoff = plan
+        .kv_handoff()
+        .ok_or("expected a disaggregated plan (got aggregated)")?;
+    assert_eq!(plan.mode, ServingMode::Disaggregated);
+
+    println!("  control-plane decision:");
+    println!(
+        "    request {} (tenant-a) → mode = {:?}",
+        request.id, plan.mode
+    );
+    println!(
+        "    prefill worker: {}   decode worker: {}",
+        handoff.prefill_worker_id, handoff.decode_worker_id
+    );
+    println!(
+        "    handoff: {} freshly-prefilled block(s) prefill computes → decode must receive\n",
+        handoff.blocks.len()
+    );
+
+    // 2) The transfer-engine reality: the prefill worker's node serves a segment
+    //    (where its computed KV lives); the decode worker's node reads from it.
+    let metadata: Arc<dyn MetadataBackend> = Arc::new(InMemoryMetadata::new());
+    let _prefill_node = TransferEngine::init("prefill-a", metadata.clone(), "127.0.0.1:0").await?;
+    let decode_engine = TransferEngine::init("decode-a", metadata.clone(), "127.0.0.1:0").await?;
+
+    // A client driving the data path; it reads/writes the prefill node's segment
+    // over the transfer engine (decode-a's engine is the one issuing the READ).
+    let mut client = RealClient::new("random", decode_engine);
+    client.mount("prefill-a", 1 << 20);
+
+    let id = identity_of(&request);
+    let key = format!("kv-handoff:{}", handoff.request_id);
+
+    // 2a) prefill-a computes the block's KV (stand-in bytes) and publishes it to
+    //     the pool: put_start (master allocates on prefill-a) → WRITE → put_end.
+    let kv = vec![0xA5u8; 4096];
+    client
+        .put(&key, id.clone(), &kv, &ReplicateConfig::replicas(1))
+        .await?;
+    println!("  data path (real bytes over the transfer engine):");
+    println!(
+        "    prefill-a computed {} B of KV and published it to the pool (put_start→WRITE→put_end)",
+        kv.len()
+    );
+
+    // 2b) decode-a resolves the replica (identity-guarded) and READs it back over
+    //     the transfer engine — the KV crosses from the prefill node to decode.
+    let received = client.get(&key, &id).await?;
+    let ok = received.len() == kv.len() && received[..] == kv[..];
+    println!(
+        "    decode-a resolved the replica (identity-guarded) and READ {} B over the engine → {}",
+        received.len(),
+        if ok {
+            "matches prefill output"
+        } else {
+            "MISMATCH (bug!)"
+        }
+    );
+
+    // 3) The identity guard: a different tenant cannot pull tenant-a's KV.
+    let refused = matches!(
+        client
+            .get(
+                &key,
+                &IdentityScope {
+                    tenant_id: "tenant-b".into(),
+                    ..id.clone()
+                },
+            )
+            .await,
+        Err(ErrorCode::UnsafeReuse(_))
+    );
+    println!(
+        "    identity guard: tenant-b's decode of tenant-a's KV was {}",
+        if refused {
+            "REFUSED (no cross-tenant leak)"
+        } else {
+            "SERVED (bug!)"
+        }
+    );
+    println!(
+        "\n  master: {} object(s) across {} segment(s)",
+        client.master().object_count(),
+        client.master().segment_count()
+    );
+
+    if ok && refused {
+        println!("\n  P/D handoff complete: control-plane plan → real prefill→decode KV transfer.");
+        Ok(())
+    } else {
+        Err("P/D handoff verification failed".into())
+    }
+}

--- a/src/pd_proxy.rs
+++ b/src/pd_proxy.rs
@@ -1,0 +1,176 @@
+//! P/D proxy — the running service that joins the pieces: it puts the QuillCache
+//! store on the request hot path by orchestrating a disaggregated prefill→decode
+//! flow across two engines that share one store.
+//!
+//! For each `POST /v1/chat/completions`:
+//!   1. send the prompt to the **prefill** engine (with `max_tokens=1`) — its
+//!      QuillCache KV connector computes the prefix KV and offloads it to the
+//!      shared store;
+//!   2. send the original request to the **decode** engine — its connector finds
+//!      that prefix in the store and loads it instead of re-prefilling, then
+//!      generates; the decode response is returned to the caller.
+//!
+//! So the bytes really cross the store between two engines on the hot path
+//! (gateway/proxy + store + connector as one service), rather than each piece
+//! standing alone. True mid-request token-level P/D (vLLM's kv_producer/consumer
+//! handshake) is the next step on top of this orchestration.
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde_json::Value;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+#[derive(Clone)]
+struct ProxyState {
+    client: reqwest::Client,
+    prefill_url: String,
+    decode_url: String,
+}
+
+/// Orchestrate prefill (warm the store) → decode (reuse from the store).
+async fn chat(
+    State(st): State<Arc<ProxyState>>,
+    Json(body): Json<Value>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // 1) Warm: prefill the prompt with max_tokens=1 so the prefill engine just
+    //    computes + offloads the prefix KV to the shared store.
+    let mut warm = body.clone();
+    if let Some(obj) = warm.as_object_mut() {
+        obj.insert("max_tokens".into(), Value::from(1));
+        obj.insert("stream".into(), Value::from(false));
+    }
+    st.client
+        .post(format!("{}/v1/chat/completions", st.prefill_url))
+        .json(&warm)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("prefill engine: {e}")))?;
+
+    // 2) Generate: the decode engine finds the prefix KV in the store (its
+    //    connector loads it instead of re-prefilling) and generates.
+    let resp = st
+        .client
+        .post(format!("{}/v1/chat/completions", st.decode_url))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("decode engine: {e}")))?;
+
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::OK);
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    Ok((
+        status,
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (
+                header::HeaderName::from_static("x-quillcache-pd"),
+                "prefill→store→decode",
+            ),
+        ],
+        text,
+    ))
+}
+
+async fn state(State(st): State<Arc<ProxyState>>) -> Json<Value> {
+    Json(serde_json::json!({
+        "mode": "pd-proxy",
+        "flow": "prefill → store → decode",
+        "prefill": st.prefill_url,
+        "decode": st.decode_url,
+    }))
+}
+
+fn router(st: Arc<ProxyState>) -> Router {
+    Router::new()
+        .route("/v1/chat/completions", post(chat))
+        .route("/v1/state", get(state))
+        .with_state(st)
+}
+
+pub async fn run_pd_proxy(
+    bind: String,
+    prefill_url: String,
+    decode_url: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let st = Arc::new(ProxyState {
+        client: reqwest::Client::new(),
+        prefill_url: prefill_url.trim_end_matches('/').to_string(),
+        decode_url: decode_url.trim_end_matches('/').to_string(),
+    });
+    let socket: SocketAddr = bind.parse()?;
+    let listener = TcpListener::bind(socket).await?;
+    println!("QuillCache P/D proxy on http://{socket}  (prefill → store → decode)");
+    println!("  prefill: {}   decode: {}", st.prefill_url, st.decode_url);
+    axum::serve(listener, router(st)).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State as AxState;
+    use std::sync::Mutex;
+
+    type Seen = Arc<Mutex<Vec<i64>>>;
+
+    // A mock engine that records the max_tokens it received and echoes its name.
+    async fn mock_engine(
+        AxState((name, seen)): AxState<(String, Seen)>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mt = body.get("max_tokens").and_then(|v| v.as_i64()).unwrap_or(-1);
+        seen.lock().unwrap().push(mt);
+        Json(serde_json::json!({"engine": name, "saw_max_tokens": mt}))
+    }
+
+    async fn spawn_mock(name: &str) -> (String, Seen) {
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_engine))
+            .with_state((name.to_string(), seen.clone()));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{addr}"), seen)
+    }
+
+    #[tokio::test]
+    async fn proxy_warms_prefill_then_returns_decode() {
+        let (prefill_url, prefill_seen) = spawn_mock("prefill").await;
+        let (decode_url, decode_seen) = spawn_mock("decode").await;
+
+        let st = Arc::new(ProxyState {
+            client: reqwest::Client::new(),
+            prefill_url: prefill_url.clone(),
+            decode_url: decode_url.clone(),
+        });
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router(st)).await.unwrap() });
+
+        let http = reqwest::Client::new();
+        let out: Value = http
+            .post(format!("http://{addr}/v1/chat/completions"))
+            .json(&serde_json::json!({"model":"m","messages":[],"max_tokens":16}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        // The caller gets the DECODE engine's response.
+        assert_eq!(out["engine"], "decode");
+        // Prefill was warmed with max_tokens=1; decode saw the original 16.
+        assert_eq!(prefill_seen.lock().unwrap().as_slice(), &[1]);
+        assert_eq!(decode_seen.lock().unwrap().as_slice(), &[16]);
+    }
+}

--- a/src/pd_proxy.rs
+++ b/src/pd_proxy.rs
@@ -1,19 +1,26 @@
-//! P/D proxy — the running service that joins the pieces: it puts the QuillCache
-//! store on the request hot path by orchestrating a disaggregated prefill→decode
-//! flow across two engines that share one store.
+//! P/D proxy / router — the running service that joins the pieces: it puts the
+//! QuillCache store on the request hot path by orchestrating a true mid-request
+//! disaggregated prefill→decode flow across two engines that share one store.
 //!
-//! For each `POST /v1/chat/completions`:
-//!   1. send the prompt to the **prefill** engine (with `max_tokens=1`) — its
-//!      QuillCache KV connector computes the prefix KV and offloads it to the
-//!      shared store;
-//!   2. send the original request to the **decode** engine — its connector finds
-//!      that prefix in the store and loads it instead of re-prefilling, then
-//!      generates; the decode response is returned to the caller.
+//! This is the **router** in vLLM's disaggregation handshake. For each
+//! `POST /v1/chat/completions` it mints a unique `transfer_id` and threads it
+//! through vLLM's request-level `kv_transfer_params`:
+//!   1. send the prompt to the **prefill** engine (the `kv_producer`) tagged
+//!      `do_remote_decode` + `transfer_id`. Its QuillCache connector offloads the
+//!      request's KV to the shared store under `qc-pd/{transfer_id}` and does no
+//!      real decoding (`max_tokens=1` as a belt-and-suspenders cap);
+//!   2. send the original request to the **decode** engine (the `kv_consumer`)
+//!      tagged `do_remote_prefill` + the same `transfer_id`. Its connector pulls
+//!      the KV named by that id, skips prefill, and generates; that response is
+//!      returned to the caller.
 //!
-//! So the bytes really cross the store between two engines on the hot path
-//! (gateway/proxy + store + connector as one service), rather than each piece
-//! standing alone. True mid-request token-level P/D (vLLM's kv_producer/consumer
-//! handshake) is the next step on top of this orchestration.
+//! The `transfer_id` — not the prompt content — names the KV, so this works for
+//! unique/uncacheable prompts (true P/D), and degrades gracefully: against plain
+//! `kv_both` engines the `kv_transfer_params` are simply ignored and the
+//! connectors fall back to content-addressed prefix reuse.
+//!
+//! One-shot `qc-pd/{transfer_id}` entries are reclaimed by the store's eviction
+//! (they're unpinned); explicit post-decode removal is a follow-up.
 
 use axum::extract::State;
 use axum::http::{header, StatusCode};
@@ -22,7 +29,9 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::Value;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 
 #[derive(Clone)]
@@ -30,33 +39,67 @@ struct ProxyState {
     client: reqwest::Client,
     prefill_url: String,
     decode_url: String,
+    // Per-process base (startup nanos) + monotonic counter → unique transfer_ids
+    // that don't collide across requests or across proxy restarts.
+    id_base: u64,
+    next_id: Arc<AtomicU64>,
 }
 
-/// Orchestrate prefill (warm the store) → decode (reuse from the store).
+impl ProxyState {
+    /// A unique handshake id naming this request's KV in the shared store.
+    fn mint_transfer_id(&self) -> String {
+        let n = self.next_id.fetch_add(1, Ordering::Relaxed);
+        format!("pd-{:x}-{}", self.id_base, n)
+    }
+}
+
+/// Set `kv_transfer_params` on a JSON request body (creating it if absent).
+fn set_kv_transfer_params(body: &mut Value, params: Value) {
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("kv_transfer_params".into(), params);
+    }
+}
+
+/// Orchestrate prefill (producer offloads KV) → decode (consumer pulls + generates).
 async fn chat(
     State(st): State<Arc<ProxyState>>,
     Json(body): Json<Value>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    // 1) Warm: prefill the prompt with max_tokens=1 so the prefill engine just
-    //    computes + offloads the prefix KV to the shared store.
-    let mut warm = body.clone();
-    if let Some(obj) = warm.as_object_mut() {
+    let transfer_id = st.mint_transfer_id();
+
+    // 1) Prefill (kv_producer): tag the request `do_remote_decode` so the engine
+    //    only prefills and its connector offloads the KV under this transfer_id.
+    //    max_tokens=1 caps any decode the engine would otherwise do.
+    let mut prefill = body.clone();
+    if let Some(obj) = prefill.as_object_mut() {
         obj.insert("max_tokens".into(), Value::from(1));
         obj.insert("stream".into(), Value::from(false));
     }
+    set_kv_transfer_params(
+        &mut prefill,
+        serde_json::json!({ "do_remote_decode": true, "transfer_id": transfer_id }),
+    );
     st.client
         .post(format!("{}/v1/chat/completions", st.prefill_url))
-        .json(&warm)
+        .json(&prefill)
         .send()
         .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("prefill engine: {e}")))?
+        .error_for_status()
         .map_err(|e| (StatusCode::BAD_GATEWAY, format!("prefill engine: {e}")))?;
 
-    // 2) Generate: the decode engine finds the prefix KV in the store (its
-    //    connector loads it instead of re-prefilling) and generates.
+    // 2) Decode (kv_consumer): tag the original request `do_remote_prefill` with
+    //    the SAME transfer_id so the engine pulls the producer's KV and skips
+    //    prefill, then generates. Awaiting (1) first guarantees the KV is committed.
+    let mut decode = body.clone();
+    set_kv_transfer_params(
+        &mut decode,
+        serde_json::json!({ "do_remote_prefill": true, "transfer_id": transfer_id }),
+    );
     let resp = st
         .client
         .post(format!("{}/v1/chat/completions", st.decode_url))
-        .json(&body)
+        .json(&decode)
         .send()
         .await
         .map_err(|e| (StatusCode::BAD_GATEWAY, format!("decode engine: {e}")))?;
@@ -82,7 +125,7 @@ async fn chat(
 async fn state(State(st): State<Arc<ProxyState>>) -> Json<Value> {
     Json(serde_json::json!({
         "mode": "pd-proxy",
-        "flow": "prefill → store → decode",
+        "flow": "prefill(do_remote_decode) → store[qc-pd/{transfer_id}] → decode(do_remote_prefill)",
         "prefill": st.prefill_url,
         "decode": st.decode_url,
     }))
@@ -100,10 +143,16 @@ pub async fn run_pd_proxy(
     prefill_url: String,
     decode_url: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let id_base = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
     let st = Arc::new(ProxyState {
         client: reqwest::Client::new(),
         prefill_url: prefill_url.trim_end_matches('/').to_string(),
         decode_url: decode_url.trim_end_matches('/').to_string(),
+        id_base,
+        next_id: Arc::new(AtomicU64::new(0)),
     });
     let socket: SocketAddr = bind.parse()?;
     let listener = TcpListener::bind(socket).await?;
@@ -119,16 +168,15 @@ mod tests {
     use axum::extract::State as AxState;
     use std::sync::Mutex;
 
-    type Seen = Arc<Mutex<Vec<i64>>>;
+    type Seen = Arc<Mutex<Vec<Value>>>;
 
-    // A mock engine that records the max_tokens it received and echoes its name.
+    // A mock engine that records each request body it received and echoes its name.
     async fn mock_engine(
         AxState((name, seen)): AxState<(String, Seen)>,
         Json(body): Json<Value>,
     ) -> Json<Value> {
-        let mt = body.get("max_tokens").and_then(|v| v.as_i64()).unwrap_or(-1);
-        seen.lock().unwrap().push(mt);
-        Json(serde_json::json!({"engine": name, "saw_max_tokens": mt}))
+        seen.lock().unwrap().push(body.clone());
+        Json(serde_json::json!({"engine": name}))
     }
 
     async fn spawn_mock(name: &str) -> (String, Seen) {
@@ -151,6 +199,8 @@ mod tests {
             client: reqwest::Client::new(),
             prefill_url: prefill_url.clone(),
             decode_url: decode_url.clone(),
+            id_base: 0xabc,
+            next_id: Arc::new(AtomicU64::new(0)),
         });
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -169,8 +219,33 @@ mod tests {
 
         // The caller gets the DECODE engine's response.
         assert_eq!(out["engine"], "decode");
-        // Prefill was warmed with max_tokens=1; decode saw the original 16.
-        assert_eq!(prefill_seen.lock().unwrap().as_slice(), &[1]);
-        assert_eq!(decode_seen.lock().unwrap().as_slice(), &[16]);
+
+        let prefill = prefill_seen.lock().unwrap();
+        let decode = decode_seen.lock().unwrap();
+        assert_eq!(prefill.len(), 1);
+        assert_eq!(decode.len(), 1);
+        let p = &prefill[0];
+        let d = &decode[0];
+
+        // Prefill (producer): do_remote_decode + max_tokens capped to 1.
+        assert_eq!(
+            p["kv_transfer_params"]["do_remote_decode"],
+            Value::from(true)
+        );
+        assert_eq!(p["max_tokens"], Value::from(1));
+        // Decode (consumer): do_remote_prefill + the caller's original max_tokens.
+        assert_eq!(
+            d["kv_transfer_params"]["do_remote_prefill"],
+            Value::from(true)
+        );
+        assert_eq!(d["max_tokens"], Value::from(16));
+        // Both carry the SAME router-minted transfer_id (the handshake correlation).
+        let pid = p["kv_transfer_params"]["transfer_id"].as_str().unwrap();
+        let did = d["kv_transfer_params"]["transfer_id"].as_str().unwrap();
+        assert_eq!(pid, did);
+        assert!(
+            pid.starts_with("pd-"),
+            "transfer_id should be router-minted: {pid}"
+        );
     }
 }

--- a/src/store_master_http.rs
+++ b/src/store_master_http.rs
@@ -23,6 +23,7 @@ use quillcache_store::{AllocatedBuffer, ErrorCode, MasterService, Replica, Repli
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::net::TcpListener;
 
 type Shared = Arc<Mutex<MasterService>>;
@@ -82,12 +83,19 @@ struct GetResp {
     replicas: Vec<Replica>,
 }
 
+#[derive(Deserialize)]
+struct SegmentReq {
+    segment: String,
+}
+
 #[derive(Serialize)]
 struct StateResp {
     objects: usize,
     segments: usize,
     capacity: u64,
     allocated: u64,
+    /// Segments whose node has missed heartbeats past the TTL (failure detection).
+    dead_segments: Vec<String>,
 }
 
 async fn mount(State(master): State<Shared>, Json(req): Json<MountReq>) -> Json<bool> {
@@ -155,6 +163,19 @@ async fn remove(
     Ok(Json(true))
 }
 
+/// Record a liveness heartbeat from a segment's node (Mooncake's client heartbeats).
+async fn heartbeat(
+    State(master): State<Shared>,
+    Json(req): Json<SegmentReq>,
+) -> Result<Json<bool>, (StatusCode, String)> {
+    master
+        .lock()
+        .unwrap()
+        .heartbeat(&req.segment)
+        .map_err(http_err)?;
+    Ok(Json(true))
+}
+
 async fn state(State(master): State<Shared>) -> Json<StateResp> {
     let master = master.lock().unwrap();
     Json(StateResp {
@@ -162,6 +183,7 @@ async fn state(State(master): State<Shared>) -> Json<StateResp> {
         segments: master.segment_count(),
         capacity: master.capacity(),
         allocated: master.allocated(),
+        dead_segments: master.dead_segments(),
     })
 }
 
@@ -173,21 +195,119 @@ fn router(shared: Shared) -> Router {
         .route("/v1/put_revoke", post(put_revoke))
         .route("/v1/get_replica_list", post(get_replica_list))
         .route("/v1/remove", post(remove))
+        .route("/v1/heartbeat", post(heartbeat))
         .route("/v1/state", get(state))
         .with_state(shared)
 }
 
-pub async fn run_store_master(
-    addr: String,
-    strategy: String,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let shared: Shared = Arc::new(Mutex::new(MasterService::new(&strategy)));
-    let socket: SocketAddr = addr.parse()?;
+/// Options for the HA-capable store master.
+pub struct StoreMasterOpts {
+    pub addr: String,
+    pub strategy: String,
+    /// Snapshot file: recovered on startup if present, saved periodically.
+    pub snapshot: Option<String>,
+    /// Seconds between periodic snapshots (0 = only on demand / never).
+    pub snapshot_interval_secs: u64,
+    /// Seconds a segment may miss heartbeats before it's dead (0 = health off).
+    pub segment_ttl: u64,
+    /// Comma-separated etcd endpoints for leader election (HA mode). Requires the
+    /// `etcd` build feature; without it a given value is ignored with a warning.
+    pub etcd: Option<String>,
+    /// This master's id (the leader value in the election).
+    pub node_id: String,
+}
+
+pub async fn run_store_master(opts: StoreMasterOpts) -> Result<(), Box<dyn std::error::Error>> {
+    // 1) HA: if etcd endpoints are configured, campaign for leadership and only
+    //    the winner serves (standbys block here until the leader's lease lapses).
+    #[cfg(feature = "etcd")]
+    let _leadership = match &opts.etcd {
+        Some(endpoints) => {
+            let eps: Vec<String> = endpoints
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            println!(
+                "store-master '{}' joining leader election on etcd {eps:?} …",
+                opts.node_id
+            );
+            let mut election = quillcache_store::MasterElection::join(
+                eps,
+                "quillcache/store-master/leader",
+                opts.node_id.clone(),
+                10,
+            )
+            .await?;
+            let leadership = election.campaign().await?; // blocks until we are leader
+            println!(
+                "store-master '{}' is now the LEADER — serving",
+                opts.node_id
+            );
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(3)).await;
+                    if election.keep_alive().await.is_err() {
+                        break;
+                    }
+                }
+            });
+            Some(leadership)
+        }
+        None => None,
+    };
+    #[cfg(not(feature = "etcd"))]
+    if opts.etcd.is_some() {
+        eprintln!("--etcd given but built without `--features etcd`; running as a single master");
+    }
+
+    // 2) Recover from the snapshot if present, else start fresh.
+    let mut master = match &opts.snapshot {
+        Some(path) if std::path::Path::new(path).exists() => {
+            println!("recovering master state from snapshot {path}");
+            MasterService::load_snapshot(path)?
+        }
+        _ => MasterService::new(&opts.strategy),
+    };
+    if opts.segment_ttl > 0 {
+        master.set_segment_ttl(opts.segment_ttl);
+    }
+    let shared: Shared = Arc::new(Mutex::new(master));
+
+    // 3) Drive the logical clock on wall time so leases + segment health advance.
+    {
+        let s = shared.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(1));
+            loop {
+                tick.tick().await;
+                s.lock().unwrap().tick();
+            }
+        });
+    }
+
+    // 4) Periodic crash-safe snapshot of the in-memory metadata.
+    if let (Some(path), true) = (opts.snapshot.clone(), opts.snapshot_interval_secs > 0) {
+        let s = shared.clone();
+        let interval = opts.snapshot_interval_secs;
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(interval));
+            loop {
+                tick.tick().await;
+                if let Err(e) = s.lock().unwrap().save_snapshot(&path) {
+                    eprintln!("snapshot save failed: {e}");
+                }
+            }
+        });
+    }
+
+    let socket: SocketAddr = opts.addr.parse()?;
     let listener = TcpListener::bind(socket).await?;
-    println!("QuillCache store MasterService on http://{socket} (strategy: {strategy})");
     println!(
-        "  POST /v1/{{mount,put_start,put_end,put_revoke,get_replica_list,remove}} · GET /v1/state"
+        "QuillCache store MasterService '{}' on http://{socket} (strategy: {}, snapshot: {:?}, segment_ttl: {}s)",
+        opts.node_id, opts.strategy, opts.snapshot, opts.segment_ttl
     );
+    println!("  POST /v1/{{mount,put_start,put_end,put_revoke,get_replica_list,remove,heartbeat}} · GET /v1/state");
     axum::serve(listener, router(shared)).await?;
     Ok(())
 }

--- a/src/store_master_http.rs
+++ b/src/store_master_http.rs
@@ -98,6 +98,43 @@ struct StateResp {
     dead_segments: Vec<String>,
 }
 
+// ---- batch APIs (Mooncake's BatchPut / BatchGet) ----
+
+#[derive(Deserialize)]
+struct BatchPutItem {
+    key: String,
+    identity: IdentityScope,
+    size: u64,
+}
+
+#[derive(Deserialize)]
+struct BatchPutStartReq {
+    items: Vec<BatchPutItem>,
+    #[serde(default)]
+    replica_num: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BatchPutStartResp {
+    buffers: Vec<Vec<AllocatedBuffer>>,
+}
+
+#[derive(Deserialize)]
+struct BatchKeysReq {
+    keys: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct BatchGetReq {
+    keys: Vec<String>,
+    identity: IdentityScope,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BatchGetResp {
+    replicas: Vec<Vec<Replica>>,
+}
+
 async fn mount(State(master): State<Shared>, Json(req): Json<MountReq>) -> Json<bool> {
     master.lock().unwrap().mount_segment(req.name, req.capacity);
     Json(true)
@@ -176,6 +213,51 @@ async fn heartbeat(
     Ok(Json(true))
 }
 
+async fn batch_put_start(
+    State(master): State<Shared>,
+    Json(req): Json<BatchPutStartReq>,
+) -> Result<Json<BatchPutStartResp>, (StatusCode, String)> {
+    let config = req
+        .replica_num
+        .map(ReplicateConfig::replicas)
+        .unwrap_or_default();
+    let items = req
+        .items
+        .into_iter()
+        .map(|i| (i.key, i.identity, i.size))
+        .collect();
+    let buffers = master
+        .lock()
+        .unwrap()
+        .batch_put_start(items, &config)
+        .map_err(http_err)?;
+    Ok(Json(BatchPutStartResp { buffers }))
+}
+
+async fn batch_put_end(
+    State(master): State<Shared>,
+    Json(req): Json<BatchKeysReq>,
+) -> Result<Json<bool>, (StatusCode, String)> {
+    master
+        .lock()
+        .unwrap()
+        .batch_put_end(&req.keys)
+        .map_err(http_err)?;
+    Ok(Json(true))
+}
+
+async fn batch_get_replica_list(
+    State(master): State<Shared>,
+    Json(req): Json<BatchGetReq>,
+) -> Result<Json<BatchGetResp>, (StatusCode, String)> {
+    let replicas = master
+        .lock()
+        .unwrap()
+        .batch_get_replica_list(&req.keys, &req.identity)
+        .map_err(http_err)?;
+    Ok(Json(BatchGetResp { replicas }))
+}
+
 async fn state(State(master): State<Shared>) -> Json<StateResp> {
     let master = master.lock().unwrap();
     Json(StateResp {
@@ -194,6 +276,9 @@ fn router(shared: Shared) -> Router {
         .route("/v1/put_end", post(put_end))
         .route("/v1/put_revoke", post(put_revoke))
         .route("/v1/get_replica_list", post(get_replica_list))
+        .route("/v1/batch_put_start", post(batch_put_start))
+        .route("/v1/batch_put_end", post(batch_put_end))
+        .route("/v1/batch_get_replica_list", post(batch_get_replica_list))
         .route("/v1/remove", post(remove))
         .route("/v1/heartbeat", post(heartbeat))
         .route("/v1/state", get(state))
@@ -369,5 +454,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(refused.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn batch_put_then_batch_get_over_http() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shared: Shared = Arc::new(Mutex::new(MasterService::new("random")));
+        tokio::spawn(async move { axum::serve(listener, router(shared)).await.unwrap() });
+        let base = format!("http://{addr}");
+        let http = reqwest::Client::new();
+        let id = serde_json::json!({"model_id":"m","tokenizer_id":"t","adapter_id":null,"tenant_id":"ten-a"});
+
+        http.post(format!("{base}/v1/mount"))
+            .json(&serde_json::json!({"name":"seg-0","capacity":65536}))
+            .send()
+            .await
+            .unwrap();
+
+        // Batch-allocate three keys in one call.
+        let started = http
+            .post(format!("{base}/v1/batch_put_start"))
+            .json(&serde_json::json!({
+                "items": [
+                    {"key":"a","identity":id,"size":64},
+                    {"key":"b","identity":id,"size":64},
+                    {"key":"c","identity":id,"size":64},
+                ],
+                "replica_num": 1
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert!(started.status().is_success());
+        let body: BatchPutStartResp = started.json().await.unwrap();
+        assert_eq!(body.buffers.len(), 3);
+
+        http.post(format!("{base}/v1/batch_put_end"))
+            .json(&serde_json::json!({"keys":["a","b","c"]}))
+            .send()
+            .await
+            .unwrap();
+
+        let got = http
+            .post(format!("{base}/v1/batch_get_replica_list"))
+            .json(&serde_json::json!({"keys":["a","b","c"],"identity":id}))
+            .send()
+            .await
+            .unwrap();
+        assert!(got.status().is_success());
+        let resp: BatchGetResp = got.json().await.unwrap();
+        assert_eq!(resp.replicas.len(), 3);
+        assert!(resp.replicas.iter().all(|r| r.len() == 1));
     }
 }

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -4,9 +4,40 @@ import starlight from "@astrojs/starlight";
 
 // QuillCache docs site — Astro + Starlight, Claude-themed.
 // Deployed to GitHub Pages at https://feichai0017.github.io/quillcache/
+const SITE_BASE = "/quillcache";
+
+// Astro/Starlight base-prefixes the *sidebar* but NOT root-absolute links written
+// in markdown/MDX prose (`[x](/storage-study/)`), so those 404 under a project
+// base. This rehype plugin rewrites every root-absolute internal <a href> to
+// include the base, once, centrally — so prose links can stay base-agnostic.
+function rehypeBaseUrl() {
+  const walk = (node) => {
+    if (
+      node.tagName === "a" &&
+      node.properties &&
+      typeof node.properties.href === "string"
+    ) {
+      const href = node.properties.href;
+      if (
+        href.startsWith("/") &&
+        !href.startsWith("//") &&
+        !href.startsWith(`${SITE_BASE}/`) &&
+        href !== SITE_BASE
+      ) {
+        node.properties.href = SITE_BASE + href;
+      }
+    }
+    if (Array.isArray(node.children)) node.children.forEach(walk);
+  };
+  return (tree) => walk(tree);
+}
+
 export default defineConfig({
   site: "https://feichai0017.github.io",
-  base: "/quillcache",
+  base: SITE_BASE,
+  markdown: {
+    rehypePlugins: [rehypeBaseUrl],
+  },
   integrations: [
     starlight({
       title: "QuillCache",

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -3,26 +3,28 @@ title: QuillCache
 description: A Mooncake/Dynamo-style distributed KV cache pool and control plane for LLM serving, in Rust — with identity-governed safe reuse and a crash-consistent persistent tier.
 template: splash
 hero:
-  tagline: A Mooncake/Dynamo-style distributed KV cache pool and control plane for LLM serving — in Rust, with identity-governed safe reuse and a crash-consistent persistent tier.
+  title: The KV cache as a resource.
+  tagline: "A faithful Rust port of Moonshot's Mooncake store with a Dynamo-style cache-aware gateway in front — plus two properties the production data planes leave implicit: identity-governed safe reuse and a crash-consistent persistent tier."
   actions:
-    - text: Read the docs
-      link: /overview/
-      icon: right-arrow
+    - text: Read the docs →
+      link: /quillcache/overview/
       variant: primary
-    - text: View on GitHub
+    - text: View on GitHub ↗
       link: https://github.com/feichai0017/quillcache
-      icon: external
       variant: minimal
 ---
 
 import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 import ArchDiagram from "../../components/ArchDiagram.astro";
 
+export const withBase = (p) =>
+  `${import.meta.env.BASE_URL.replace(/\/$/, "")}${p}`;
+
 <div class="qc-pills">
   <span class="qc-pill">faithful Mooncake-store port</span>
   <span class="qc-pill">transfer engine · (segment, offset)</span>
-  <span class="qc-pill">TCP / RDMA reserved</span>
   <span class="qc-pill">two-phase Put · MasterService</span>
+  <span class="qc-pill">vLLM-native disaggregated P/D</span>
   <span class="qc-pill">identity-safe reuse</span>
   <span class="qc-pill">crash-consistent DiskTier</span>
   <span class="qc-pill">persistent ART index</span>
@@ -41,19 +43,19 @@ measure. It does **not** run models — the CUDA tier moves and quantizes KV *by
 
 ## Headline results
 
-Real code, no simulation — every number is measured against in-tree baselines.
-60 tests pass; `fmt` + `clippy` clean.
+Real code, no simulation — every number is measured against in-tree baselines or
+verified on GPUs. 79 tests pass; `fmt` + `clippy` clean.
 
 <div class="qc-statgrid">
+  <div class="qc-stat">
+    <div class="n">2×L4</div>
+    <div class="k">True vLLM-native P/D</div>
+    <div class="d">Prefill runs as <code>kv_producer</code>, decode as <code>kv_consumer</code>; the router mints a <code>transfer_id</code>, the consumer pulls the KV by id and skips prefill. Output matches a monolithic run token-for-token.</div>
+  </div>
   <div class="qc-stat">
     <div class="n">9.96 µs</div>
     <div class="k">ART prefix-scan (p50)</div>
     <div class="d">Holt (persistent ART) residency index vs RocksDB/LSM 16.8 µs and an O(N) flat map (494 µs). Recovery 2.6 ms.</div>
-  </div>
-  <div class="qc-stat">
-    <div class="n">1× vs 10.6×</div>
-    <div class="k">Write amplification</div>
-    <div class="d">ART writes each record once; LSM rewrites through compaction. Measured from RocksDB's own stats, not assumed.</div>
   </div>
   <div class="qc-stat">
     <div class="n">0 leaks</div>
@@ -66,9 +68,9 @@ Real code, no simulation — every number is measured against in-tree baselines.
     <div class="d">Object-first atomic publish + WAL: complete blocks recover, half-written / corrupted blocks dropped, no dangling pointers (Mooncake's pool is volatile).</div>
   </div>
   <div class="qc-stat">
-    <div class="n">real KV bytes</div>
-    <div class="k">HBM / DRAM / SSD tiers</div>
-    <div class="d"><code>StoreDataPlane</code> over <code>LocalKvStore</code> holds actual KV blocks and moves them across tiers — wired online and measured.</div>
+    <div class="n">1× vs 10.6×</div>
+    <div class="k">Write amplification</div>
+    <div class="d">ART writes each record once; LSM rewrites through compaction. Measured from RocksDB's own stats, not assumed.</div>
   </div>
   <div class="qc-stat">
     <div class="n">(segment, offset)</div>
@@ -90,32 +92,32 @@ live, and decides routing and reuse.
 <CardGrid>
   <LinkCard
     title="Overview"
-    href="/overview/"
-    description="What it is, what's wired online vs a tested unit vs reserved."
+    href={withBase("/overview/")}
+    description="What it is, what's wired online vs GPU-verified vs reserved."
   />
   <LinkCard
     title="Architecture"
-    href="/architecture/"
+    href={withBase("/architecture/")}
     description="Gateway, control plane, the store, the transfer engine — how a request flows."
   />
   <LinkCard
     title="ART vs LSM storage study"
-    href="/storage-study/"
+    href={withBase("/storage-study/")}
     description="Which storage engine fits a residency index — prefix-scan, write-amp, recovery."
   />
   <LinkCard
     title="Identity-safe reuse"
-    href="/identity-safe-reuse/"
+    href={withBase("/identity-safe-reuse/")}
     description="Why content-hash caches leak, and the guard that refuses it — in memory, on disk, and at the master."
   />
   <LinkCard
     title="Crash-consistent tier"
-    href="/crash-consistency/"
+    href={withBase("/crash-consistency/")}
     description="Object-first atomic publish + WAL recovery, proven by test."
   />
   <LinkCard
     title="Mooncake / Dynamo mapping"
-    href="/reference-mapping/"
+    href={withBase("/reference-mapping/")}
     description="Every reference-design component, mapped to a crate."
   />
 </CardGrid>

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -33,17 +33,22 @@ how far each piece is integrated:
 - **✅ wired online & measured** — the gateway, control plane, Dynamo-cost
   routing, persistent residency index, `StoreDataPlane` moving real bytes across
   HBM/DRAM/SSD, live SLO goodput, and the ART-vs-LSM storage study.
-- **▣ tested unit (not yet on the live gateway path)** — the faithful store: a
-  `Client` Put→Get over the transfer engine (real TCP), the `MasterService`
-  two-phase Put + lease eviction, the identity guard, and `DiskTier` crash
-  recovery. All covered by tests (and the `cluster` demo); wiring them into the
-  live gateway needs an engine KV-connector for the engine⟷store byte handoff.
-- **⊙ reserved / needs hardware** — `RdmaTransport` (behind the `rdma` feature),
-  the etcd metadata backend, and the CUDA device tier (build `quillcache-cuda`
-  with `--features cuda` on a GPU box). All real interfaces, stubbed so the
-  default build is hardware-free.
+- **◑ GPU-verified on Modal (the engine ⟷ store path)** — a real vLLM 0.22.1
+  `KVConnectorBase_V1` (`bridge/quillcache_v1_connector.py`) offloads a prompt's KV
+  to the store and **reuses** it on a later request (L4); **disaggregated
+  prefill/decode** runs across two engines sharing one store via `quillcache
+  pd-proxy` — both content-addressed reuse *and* true vLLM-native P/D
+  (`kv_producer`/`kv_consumer` with a `transfer_id` handshake, output matching a
+  monolithic run token-for-token) on 2×L4. This exercises the faithful store
+  (`Client` two-phase Put, `MasterService` + identity guard, transfer engine) and
+  master **HA** (etcd leader election, verified vs Docker etcd) end to end.
+- **⊙ reserved / needs hardware** — `RdmaTransport` / GPUDirect zero-copy (behind
+  the `rdma` / `nvlink` features): real interfaces, stubbed so the default build
+  stays hardware-free. (The CUDA device tier is also GPU-verified —
+  `quillcache-cuda --features cuda` on an L4 — but stays out of the default
+  workspace.)
 
-`cargo test` — 60 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
+`cargo test` — 79 tests pass; `cargo fmt --check` and `cargo clippy` are clean.
 
 ## Differentiation
 

--- a/web/src/content/docs/quickstart.md
+++ b/web/src/content/docs/quickstart.md
@@ -12,7 +12,7 @@ C++ toolchain.
 git clone https://github.com/feichai0017/quillcache
 cd quillcache
 cargo build
-cargo test          # 60 tests
+cargo test          # 79 tests
 ```
 
 ## The cluster demo — the Mooncake-faithful store

--- a/web/src/styles/claude.css
+++ b/web/src/styles/claude.css
@@ -1,12 +1,18 @@
-/* Claude-style theme for Starlight — warm paper, coral accent, serif display. */
+/* QuillCache — Claude.ai-style theme for Starlight.
+   Warm ivory paper, clay/coral accent, Fraunces serif display, Inter UI.
+   Mirrors Anthropic's calm, editorial aesthetic in both light and dark. */
 
 :root {
   --sl-font: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --sl-font-mono: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
   --qc-serif: "Fraunces", Georgia, "Times New Roman", serif;
-  --qc-radius: 14px;
-  --qc-coral: #d97757;
-  --qc-coral-ink: #c2410c;
+  --qc-radius: 16px;
+  --qc-radius-sm: 10px;
+  /* Claude clay / coral — the signature accent */
+  --qc-clay: #d97757;
+  --qc-clay-deep: #bd5d3a;
+  --qc-clay-soft: #e9a487;
+  --sl-nav-height: 4rem;
 }
 
 /* ---- Dark theme (Claude warm charcoal) — Starlight's default :root ---- */
@@ -14,60 +20,105 @@
   --sl-color-accent-low: #43210f;
   --sl-color-accent: #d97757;
   --sl-color-accent-high: #f2c9b8;
-  --sl-color-white: #f6f4ee;
-  --sl-color-gray-1: #e9e5dc;
-  --sl-color-gray-2: #cdc8bc;
-  --sl-color-gray-3: #9d978a;
-  --sl-color-gray-4: #6f6a5f;
-  --sl-color-gray-5: #48453f;
-  --sl-color-gray-6: #312f2b;
-  --sl-color-gray-7: #26241f;
-  --sl-color-black: #1c1b19;
-  --sl-color-bg: #1c1b19;
-  --sl-color-bg-nav: #1c1b19;
-  --sl-color-bg-sidebar: #211f1c;
-  --sl-color-bg-inline-code: #2b2925;
-  --sl-color-hairline: #34322d;
+  --sl-color-white: #f7f5ef;
+  --sl-color-gray-1: #ece8df;
+  --sl-color-gray-2: #cfcabd;
+  --sl-color-gray-3: #a09a8c;
+  --sl-color-gray-4: #716c61;
+  --sl-color-gray-5: #494640;
+  --sl-color-gray-6: #302e2a;
+  --sl-color-gray-7: #262420;
+  --sl-color-black: #1b1a17;
+  --sl-color-bg: #1b1a17;
+  --sl-color-bg-nav: rgba(27, 26, 23, 0.82);
+  --sl-color-bg-sidebar: #201e1b;
+  --sl-color-bg-inline-code: #2c2a25;
+  --sl-color-hairline: #36332d;
   --sl-color-hairline-light: #2b2925;
-  --sl-color-text-accent: #e8a187;
+  --sl-color-text-accent: #ecaa8f;
+  --qc-hero-glow: radial-gradient(60% 80% at 50% 0%, rgba(217, 119, 87, 0.12), transparent 70%);
+  --qc-card-bg: #211f1b;
+  --qc-card-bg-hover: #262320;
 }
 
-/* ---- Light theme (Claude cream) ---- */
+/* ---- Light theme (Claude ivory) ---- */
 :root[data-theme="light"] {
-  --sl-color-accent-low: #f6e2d8;
-  --sl-color-accent: #c2410c;
+  --sl-color-accent-low: #f7e3d8;
+  --sl-color-accent: #bd5d3a;
   --sl-color-accent-high: #7c2d12;
-  --sl-color-white: #1f1e1c;
-  --sl-color-gray-1: #2b2a26;
-  --sl-color-gray-2: #44423b;
-  --sl-color-gray-3: #6b6960;
-  --sl-color-gray-4: #918d81;
-  --sl-color-gray-5: #c3bdaf;
-  --sl-color-gray-6: #e4e0d4;
-  --sl-color-gray-7: #f1eee5;
+  --sl-color-white: #211f1b;
+  --sl-color-gray-1: #2d2b25;
+  --sl-color-gray-2: #46433b;
+  --sl-color-gray-3: #6d6a5f;
+  --sl-color-gray-4: #938e81;
+  --sl-color-gray-5: #c4beb0;
+  --sl-color-gray-6: #e6e1d5;
+  --sl-color-gray-7: #f1ede3;
   --sl-color-black: #faf9f5;
   --sl-color-bg: #faf9f5;
-  --sl-color-bg-nav: #faf9f5;
-  --sl-color-bg-sidebar: #f2f0e8;
-  --sl-color-bg-inline-code: #ece8dd;
-  --sl-color-hairline: #e4e0d4;
-  --sl-color-hairline-light: #ece8de;
-  --sl-color-text-accent: #c2410c;
+  --sl-color-bg-nav: rgba(250, 249, 245, 0.82);
+  --sl-color-bg-sidebar: #f3f1e9;
+  --sl-color-bg-inline-code: #ece7da;
+  --sl-color-hairline: #e3ddcf;
+  --sl-color-hairline-light: #ece7db;
+  --sl-color-text-accent: #bd5d3a;
+  --qc-hero-glow: radial-gradient(60% 80% at 50% 0%, rgba(189, 93, 58, 0.08), transparent 70%);
+  --qc-card-bg: #fffefb;
+  --qc-card-bg-hover: #fdfcf7;
 }
 
-/* ---- Serif display, Claude-style ---- */
-.site-title,
-.sl-markdown-content h1,
-.sl-markdown-content h2,
-.hero h1,
-.hero .tagline {
+/* ---- Type rhythm ---- */
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.sl-markdown-content {
+  line-height: 1.65;
+}
+.site-title {
   font-family: var(--qc-serif);
-  letter-spacing: -0.012em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* Serif display, Claude-style */
+.sl-markdown-content :is(h1, h2),
+.hero h1,
+.qc-hero-title {
+  font-family: var(--qc-serif);
+  letter-spacing: -0.018em;
   font-weight: 500;
 }
 .sl-markdown-content h1 {
   font-weight: 500;
-  font-size: 2.1rem;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  line-height: 1.1;
+}
+.sl-markdown-content h2 {
+  font-size: 1.55rem;
+  margin-top: 2.6rem;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--sl-color-hairline);
+}
+.sl-markdown-content h3 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* Translucent, blurred top nav — the Claude.ai header feel */
+.header {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+/* Links: warm clay, subtle underline */
+.sl-markdown-content a:not(:where(.qc-btn, .sl-link-card, .card *)) {
+  text-decoration-color: color-mix(in srgb, var(--sl-color-text-accent) 40%, transparent);
+  text-underline-offset: 0.18em;
+}
+.sl-markdown-content a:hover {
+  text-decoration-color: var(--sl-color-text-accent);
 }
 
 /* ---- Soften the UI ---- */
@@ -83,89 +134,174 @@ starlight-card {
 .sl-markdown-content :is(th, td) {
   border-color: var(--sl-color-hairline);
 }
+.sl-markdown-content :not(pre) > code {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 6px;
+  padding: 0.12em 0.38em;
+  font-size: 0.88em;
+}
 
-/* ---- Hero (landing) ---- */
+/* ======================================================================
+   Landing (splash)
+   ====================================================================== */
+
+/* Warm glow behind the hero */
+.sl-markdown-content {
+  position: relative;
+}
+
+/* Hero — Starlight splash hero, Claude-styled. A warm glow sits behind it. */
 .hero {
-  padding-block: 1.5rem 0.5rem;
+  position: relative;
+  padding-block: 1.5rem 2rem;
+  text-align: center;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -6rem -25% auto -25%;
+  height: 30rem;
+  background: var(--qc-hero-glow);
+  pointer-events: none;
+  z-index: -1;
+}
+.hero > .stack,
+.hero .copy {
+  align-items: center;
 }
 .hero h1 {
-  font-size: clamp(2.6rem, 6vw, 4rem);
-  line-height: 1.04;
+  font-family: var(--qc-serif);
+  font-weight: 500;
+  font-size: clamp(2.6rem, 6.5vw, 4.3rem);
+  line-height: 1.03;
+  letter-spacing: -0.02em;
+  color: var(--sl-color-white);
+  max-width: 18ch;
 }
 .hero .tagline {
-  font-family: var(--sl-font);
-  font-size: 1.15rem;
+  font-size: clamp(1.04rem, 2vw, 1.2rem);
+  line-height: 1.6;
   color: var(--sl-color-gray-2);
-  max-width: 44ch;
+  max-width: 52ch;
 }
-/* Primary CTA in coral */
-.hero .actions a[data-variant="primary"] {
-  background: var(--qc-coral);
-  border-color: var(--qc-coral);
-  color: #1c1b19;
-}
-.hero .actions a[data-variant="primary"]:hover {
-  background: #e2876a;
-  border-color: #e2876a;
+.hero .actions {
+  gap: 0.7rem;
+  margin-top: 0.5rem;
 }
 
-/* ---- Landing helpers ---- */
-.qc-statgrid {
-  display: grid;
-  gap: 0.9rem;
-  grid-template-columns: repeat(3, 1fr);
-  margin: 1.5rem 0;
+/* Buttons — pill-shaped, clay primary (Starlight sl-link-button) */
+.hero .actions a.sl-link-button {
+  border-radius: 999px;
+  font-weight: 550;
+  padding: 0.72rem 1.4rem;
+  transition: transform 0.08s ease, background 0.15s ease, border-color 0.15s ease;
 }
-@media (max-width: 56rem) {
-  .qc-statgrid {
-    grid-template-columns: 1fr;
-  }
+.hero .actions a.sl-link-button:active {
+  transform: translateY(1px);
 }
-.qc-stat {
+.hero .actions a.sl-link-button.primary {
+  background: var(--qc-clay);
+  border-color: var(--qc-clay);
+  color: #1b1a17;
+}
+.hero .actions a.sl-link-button.primary:hover {
+  background: var(--qc-clay-soft);
+  border-color: var(--qc-clay-soft);
+}
+.hero .actions a.sl-link-button.minimal {
   border: 1px solid var(--sl-color-hairline);
-  border-radius: var(--qc-radius);
-  background: var(--sl-color-bg-sidebar);
-  padding: 1rem 1.1rem;
+  color: var(--sl-color-white);
 }
-.qc-stat .n {
-  font-family: var(--sl-font-mono);
-  font-size: 1.6rem;
-  font-weight: 600;
-  color: var(--sl-color-text-accent);
-  letter-spacing: -0.02em;
+.hero .actions a.sl-link-button.minimal:hover {
+  border-color: var(--sl-color-gray-3);
+  background: color-mix(in srgb, var(--sl-color-gray-6) 45%, transparent);
 }
-.qc-stat .k {
-  font-weight: 600;
-  margin: 0.35rem 0 0.15rem;
-}
-.qc-stat .d {
-  font-size: 0.9rem;
-  color: var(--sl-color-gray-3);
-  line-height: 1.5;
-}
+
+/* Tech pills */
 .qc-pills {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
-  margin: 1.2rem 0;
+  justify-content: center;
+  max-width: 52rem;
+  margin: 1.8rem auto 2.5rem;
 }
 .qc-pill {
   font-family: var(--sl-font-mono);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: var(--sl-color-gray-2);
   border: 1px solid var(--sl-color-hairline);
-  border-radius: 8px;
-  padding: 0.3rem 0.55rem;
-  background: var(--sl-color-bg-sidebar);
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+  background: var(--qc-card-bg);
 }
+
+/* Stat grid */
+.qc-statgrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  margin: 1.5rem 0;
+}
+.qc-stat {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--qc-radius);
+  background: var(--qc-card-bg);
+  padding: 1.2rem 1.25rem;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+.qc-stat:hover {
+  border-color: color-mix(in srgb, var(--qc-clay) 45%, var(--sl-color-hairline));
+  background: var(--qc-card-bg-hover);
+  transform: translateY(-2px);
+}
+.qc-stat .n {
+  font-family: var(--qc-serif);
+  font-size: 1.7rem;
+  font-weight: 500;
+  color: var(--sl-color-text-accent);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+.qc-stat .k {
+  font-weight: 600;
+  margin: 0.5rem 0 0.3rem;
+  color: var(--sl-color-white);
+}
+.qc-stat .d {
+  font-size: 0.9rem;
+  color: var(--sl-color-gray-3);
+  line-height: 1.55;
+}
+.qc-stat code {
+  font-size: 0.85em;
+}
+
+/* Architecture diagram frame */
 .qc-diagram {
   border: 1px solid var(--sl-color-hairline);
   border-radius: var(--qc-radius);
-  background: var(--sl-color-bg-sidebar);
-  padding: 0.6rem;
-  margin: 1.2rem 0;
+  background: var(--qc-card-bg);
+  padding: 1rem;
+  margin: 1.4rem 0;
 }
 .qc-diagram svg {
   width: 100%;
   height: auto;
+}
+
+/* Explore link cards a touch warmer on hover */
+.sl-link-card {
+  background: var(--qc-card-bg) !important;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.sl-link-card:hover {
+  background: var(--qc-card-bg-hover) !important;
+  border-color: color-mix(in srgb, var(--qc-clay) 40%, var(--sl-color-hairline)) !important;
+}
+
+@media (max-width: 50rem) {
+  .qc-hero {
+    padding-block: 1.5rem 0.5rem;
+  }
 }


### PR DESCRIPTION
This branch takes QuillCache from a store-with-a-control-plane to a system that **really sits on the inference hot path**, aligns the internals module-for-module with Mooncake, and ships a working docs site. All of it is verified — laptop tests, Docker etcd, and Modal L4 / 2×L4 GPU runs.

## Headline — engine ⟷ store on the hot path (GPU-verified)
- **Real vLLM 0.22.1 `KVConnectorBase_V1`** (`bridge/quillcache_v1_connector.py`): offload a prompt's KV to the store, reuse it on a later request — identity-guarded, paged-KV layout kept verbatim. Verified on L4.
- **Disaggregated prefill/decode** via `quillcache pd-proxy` across two engines sharing one store (2×L4):
  - *content-addressed* reuse (`modal_vllm_pd.py`), and
  - **true vLLM-native P/D** (`modal_vllm_disagg.py`): prefill=`kv_producer`, decode=`kv_consumer`, the proxy mints a `transfer_id` and threads vLLM's `do_remote_decode`/`do_remote_prefill` handshake; the consumer pulls the producer's KV *by id* and skips prefill. Output matches a monolithic run **token-for-token**.

## Mooncake-aligned store internals
- **Master HA**: snapshot recovery + heartbeat failure detection + etcd leader election / lease failover (verified vs Docker etcd), wired into the `store-master` binary.
- **Batch Put/Get** APIs (Mooncake BatchPut/BatchGet) over HTTP + Python client.
- **Overload admission / early rejection** in the control plane (Mooncake overload scheduling).
- **O(1) size-binned buffer allocator** (Mooncake's allocator design).
- Completed the Mooncake component mapping; tidied bridge naming + data-plane docs.

## CUDA tier
- Real device tier + Transfer Engine HBM segment (`cudarc` `dynamic-loading`, so the default build needs no CUDA toolkit; GPU round-trip verified on L4).

## Docs site (`web/`) — fixes the "docs won't open" bug + Claude.ai restyle
- **Base-path fix**: a rehype plugin base-prefixes root-absolute links in prose; the landing now uses Starlight's native hero (gap-free) with base-correct actions + `BASE_URL` LinkCards. Every internal link previously 404'd on GitHub Pages; all now carry `/quillcache`.
- **Claude.ai-style redesign**: warm ivory/charcoal palette, clay accent, Fraunces serif + Inter, pill buttons, refined stat cards. Verified in a local build + preview (light + dark).
- Content refresh: 79 tests; true-P/D headline; de-staled the overview status.

## Verification
`cargo test` — 79 pass; `cargo fmt --check` + `cargo clippy` clean. Connector/P/D/CUDA on Modal L4 & 2×L4. Docs build clean (10 pages), all links base-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vLLM connector for distributed KV offload and reuse across requests.
  * Introduced disaggregated prefill/decode with transfer ID-based KV handoff.
  * Added etcd-backed master election for high-availability store deployment.
  * Implemented GPU HBM device segments for CUDA-backed transfers.
  * Added batch APIs for multi-key operations.
  * Introduced master snapshot/recovery for crash durability.

* **Documentation**
  * Updated deployment guides with Modal verification scripts.
  * Clarified feature status and hardware requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->