### PR TITLE
RDMA + zero-copy GPU↔GPU + hot-prefix replication + /metrics — the gap-closers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -366,6 +386,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -769,6 +798,16 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "ibverbs-sys"
+version = "0.3.2+55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8149ab8d940ea7e7073a24ba6e3ec6b0cc8ceab6ea3d562d60a21ca5cc23413a"
+dependencies = [
+ "bindgen 0.71.1",
+ "cmake",
 ]
 
 [[package]]
@@ -1372,6 +1411,7 @@ dependencies = [
  "bytes",
  "cudarc",
  "etcd-client",
+ "ibverbs-sys",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/quillcache-core/src/control.rs
+++ b/crates/quillcache-core/src/control.rs
@@ -1,3 +1,7 @@
+use crate::replication::{
+    plan_replications, HotnessTracker, PrefixResidency, ReplicationAction, ReplicationConfig,
+    WorkerLoad,
+};
 use crate::router::{
     plan_for_worker, GreedyStatePlaneRouter, RouteDecision, RouterError, RoutingPolicy,
 };
@@ -276,6 +280,9 @@ pub struct ControlPlane {
     /// violate its SLO by more than this many microseconds. `None` admits all
     /// (Mooncake's overload-oriented early rejection).
     max_slo_violation_us: Option<u64>,
+    /// Per-(identity, prefix) access counts, so [`Self::replication_plan`] can spot
+    /// hot prefixes worth replicating to spread a cache hotspot's load.
+    hotness: HotnessTracker,
 }
 
 impl ControlPlane {
@@ -316,6 +323,7 @@ impl ControlPlane {
             use_conductor: false,
             cost_model: CostModel::default(),
             max_slo_violation_us: None,
+            hotness: HotnessTracker::default(),
         }
     }
 
@@ -468,6 +476,8 @@ impl ControlPlane {
     }
 
     pub fn plan(&self, request: &RequestShape) -> Result<RequestPlan, ControlError> {
+        // Count this request's prefixes for hot-prefix replication scheduling.
+        self.hotness.record_request(request);
         // The router only ever inspects residency for *this request's* blocks
         // (local hit / transfer / recompute per block), so look those up
         // directly instead of dumping the whole index. O(request blocks) point
@@ -694,6 +704,52 @@ impl ControlPlane {
         self.residency.as_ref()
     }
 
+    /// Decide which hot prefixes to replicate to spread cache hotspots: live
+    /// access counts (the request path feeds the hotness tracker) crossed with
+    /// where each hot prefix is resident (HBM) and current worker load. The cost
+    /// router places one request at a time; this is the global balancing the
+    /// Mooncake Conductor adds. The byte copies are the Transfer Engine's to
+    /// execute. See [`crate::replication`].
+    pub fn replication_plan(&self, cfg: &ReplicationConfig) -> Vec<ReplicationAction> {
+        let workers: Vec<WorkerLoad> = self
+            .workers
+            .iter()
+            .map(|w| WorkerLoad {
+                id: w.id.clone(),
+                load: w.running_decodes + w.queued_prefill_tokens,
+            })
+            .collect();
+        let prefixes: Vec<PrefixResidency> = self
+            .hotness
+            .hot(cfg.hotness_threshold)
+            .into_iter()
+            .map(|(scope, prefix_hash, accesses)| {
+                let mut holders: Vec<String> = self
+                    .residency
+                    .prefix_scan(&scope, &prefix_hash)
+                    .into_iter()
+                    .filter(|r| matches!(r.tier, CacheTier::Hbm | CacheTier::RemoteHbm))
+                    .map(|r| r.worker_id)
+                    .collect();
+                holders.sort();
+                holders.dedup();
+                PrefixResidency {
+                    scope,
+                    prefix_hash,
+                    holders,
+                    accesses,
+                }
+            })
+            .collect();
+        plan_replications(&prefixes, &workers, cfg)
+    }
+
+    /// Decay the prefix hotness counts (call periodically) so replication tracks
+    /// recent load rather than all-time totals.
+    pub fn decay_hotness(&self) {
+        self.hotness.decay();
+    }
+
     /// Persist the residency index (checkpoint a persistent backend; no-op for
     /// in-memory). Call periodically and on shutdown so a persistent index
     /// survives a restart.
@@ -872,6 +928,63 @@ mod tests {
         assert_eq!(summary.stored_blocks, 1);
         assert_eq!(index.len(), 1);
         assert_eq!(index.snapshot()[0].worker_id, "vllm-a");
+    }
+
+    #[test]
+    fn replication_plan_spreads_a_hot_singly_held_prefix() {
+        let key = KvBlockKey {
+            model_id: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            prefix_hash: "hotpre".to_string(),
+            block_hash: "blk0".to_string(),
+            block_index: 0,
+            token_count: 16,
+        };
+        // The hot prefix is resident on vllm-a only.
+        let mut index = MemoryIndex::new();
+        index.put(CacheResidency::hbm("vllm-a".to_string(), key.clone(), 1024));
+        let control = ControlPlane::with_index(
+            vec![
+                engine(),
+                EngineEndpoint {
+                    id: "vllm-b".to_string(),
+                    base_url: "http://127.0.0.1:8002".to_string(),
+                    ..engine()
+                },
+            ],
+            Box::new(index),
+        );
+
+        // Drive enough requests for the prefix to count as hot (record runs first
+        // in plan(), so it counts even if routing returns an error).
+        let req = RequestShape {
+            id: "r".to_string(),
+            model_id: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_id: "Qwen/Qwen3-0.6B".to_string(),
+            adapter_id: None,
+            tenant_id: "tenant-a".to_string(),
+            session_id: None,
+            blocks: vec![key.clone()],
+            estimated_decode_tokens: 8,
+            slo: crate::SloTarget::default(),
+        };
+        for _ in 0..10 {
+            let _ = control.plan(&req);
+        }
+
+        let actions = control.replication_plan(&ReplicationConfig::default());
+        assert_eq!(actions.len(), 1, "one copy to reach target_replicas=2");
+        assert_eq!(actions[0].prefix_hash, "hotpre");
+        assert_eq!(actions[0].from_worker, "vllm-a");
+        assert_eq!(actions[0].to_worker, "vllm-b");
+
+        // After decay (10 -> 5, still >= threshold 8? no), it's no longer hot.
+        control.decay_hotness();
+        assert!(control
+            .replication_plan(&ReplicationConfig::default())
+            .is_empty());
     }
 
     #[test]

--- a/crates/quillcache-core/src/lib.rs
+++ b/crates/quillcache-core/src/lib.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 pub mod bench;
 pub mod conductor;
 pub mod control;
+pub mod replication;
 pub mod router;
 
 // Optional residency-index backends (the ART-vs-LSM study) live here as

--- a/crates/quillcache-core/src/replication.rs
+++ b/crates/quillcache-core/src/replication.rs
@@ -1,0 +1,326 @@
+//! Hot-prefix replication scheduling — the global cache-balancing piece the
+//! Mooncake Conductor does that a per-request cost router alone cannot.
+//!
+//! The cost router sends each request to the lowest-cost worker (cache locality
+//! vs load). But when one prefix becomes **hot** — a shared system prompt, a
+//! viral few-shot preamble — every request for it is drawn to the *single* worker
+//! that holds its KV. Cache affinity turns that worker into a hotspot while peers
+//! idle. The fix is to **replicate the hot prefix's KV to more workers** so the
+//! load spreads while every request still hits cache.
+//!
+//! This module decides *which* hot prefixes to replicate to *which* workers; the
+//! actual byte copy is the Transfer Engine's job (and, intra-node, the zero-copy
+//! peer path in `quillcache-transfer-engine`). The planner is a pure function of
+//! (hot prefixes + where they live) × (worker load), so it is deterministic and
+//! unit-testable in isolation.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{IdentityScope, RequestShape};
+
+/// How aggressively to replicate hot prefixes.
+#[derive(Debug, Clone)]
+pub struct ReplicationConfig {
+    /// Replicate a hot prefix until at least this many workers hold it.
+    pub target_replicas: usize,
+    /// A prefix counts as hot once its access count reaches this.
+    pub hotness_threshold: u32,
+    /// Cap on actions emitted per planning pass (backpressure on the copies).
+    pub max_actions: usize,
+}
+
+impl Default for ReplicationConfig {
+    fn default() -> Self {
+        Self {
+            target_replicas: 2,
+            hotness_threshold: 8,
+            max_actions: 32,
+        }
+    }
+}
+
+/// A hot prefix and the workers currently holding its KV (in HBM).
+#[derive(Debug, Clone)]
+pub struct PrefixResidency {
+    pub scope: IdentityScope,
+    pub prefix_hash: String,
+    pub holders: Vec<String>,
+    pub accesses: u32,
+}
+
+/// A worker's current load — lower is a better replication target.
+#[derive(Debug, Clone)]
+pub struct WorkerLoad {
+    pub id: String,
+    pub load: u32,
+}
+
+/// "Copy this prefix's KV from a worker that holds it to one that doesn't, to
+/// spread the load on a hotspot." The execution worker is the Transfer Engine's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicationAction {
+    pub scope: IdentityScope,
+    pub prefix_hash: String,
+    pub from_worker: String,
+    pub to_worker: String,
+    pub accesses: u32,
+}
+
+/// Decide replications: for each hot, under-replicated prefix (hottest first),
+/// copy it from its least-loaded current holder to the least-loaded workers that
+/// don't already hold it, until it reaches `target_replicas` or workers run out.
+/// Deterministic: ties break by worker id / prefix hash.
+pub fn plan_replications(
+    prefixes: &[PrefixResidency],
+    workers: &[WorkerLoad],
+    cfg: &ReplicationConfig,
+) -> Vec<ReplicationAction> {
+    // Workers ascending by load (least-loaded first); stable by id on ties.
+    let mut by_load: Vec<&WorkerLoad> = workers.iter().collect();
+    by_load.sort_by(|a, b| a.load.cmp(&b.load).then_with(|| a.id.cmp(&b.id)));
+
+    // Hot + under-replicated + actually resident somewhere; hottest first.
+    let mut hot: Vec<&PrefixResidency> = prefixes
+        .iter()
+        .filter(|p| {
+            p.accesses >= cfg.hotness_threshold
+                && !p.holders.is_empty()
+                && p.holders.len() < cfg.target_replicas
+        })
+        .collect();
+    hot.sort_by(|a, b| {
+        b.accesses
+            .cmp(&a.accesses)
+            .then_with(|| a.prefix_hash.cmp(&b.prefix_hash))
+    });
+
+    let mut actions = Vec::new();
+    for p in hot {
+        if actions.len() >= cfg.max_actions {
+            break;
+        }
+        let holders: HashSet<&str> = p.holders.iter().map(String::as_str).collect();
+        // Source: the least-loaded worker that already holds it.
+        let from = by_load
+            .iter()
+            .find(|w| holders.contains(w.id.as_str()))
+            .map(|w| w.id.clone())
+            .unwrap_or_else(|| p.holders[0].clone());
+
+        let need = cfg.target_replicas - p.holders.len();
+        let mut added = 0;
+        for w in &by_load {
+            if added >= need || actions.len() >= cfg.max_actions {
+                break;
+            }
+            if holders.contains(w.id.as_str()) {
+                continue; // already has it
+            }
+            actions.push(ReplicationAction {
+                scope: p.scope.clone(),
+                prefix_hash: p.prefix_hash.clone(),
+                from_worker: from.clone(),
+                to_worker: w.id.clone(),
+                accesses: p.accesses,
+            });
+            added += 1;
+        }
+    }
+    actions
+}
+
+/// Counts how often each (identity, prefix) is requested, so the planner can spot
+/// hot prefixes. Interior-mutable (the request path holds `&ControlPlane`); a
+/// periodic [`Self::decay`] keeps the signal recent rather than all-time.
+#[derive(Debug, Default)]
+pub struct HotnessTracker {
+    counts: Mutex<HashMap<(IdentityScope, String), u32>>,
+}
+
+impl HotnessTracker {
+    /// Count one access per distinct (identity, prefix) the request touches.
+    pub fn record_request(&self, request: &RequestShape) {
+        if request.blocks.is_empty() {
+            return;
+        }
+        let mut counts = self.counts.lock().unwrap();
+        let mut seen = HashSet::new();
+        for block in &request.blocks {
+            let key = (IdentityScope::from_key(block), block.prefix_hash.clone());
+            if seen.insert(key.clone()) {
+                *counts.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Prefixes at or above `threshold` accesses, as (identity, prefix, accesses).
+    pub fn hot(&self, threshold: u32) -> Vec<(IdentityScope, String, u32)> {
+        let counts = self.counts.lock().unwrap();
+        counts
+            .iter()
+            .filter(|(_, &n)| n >= threshold)
+            .map(|((scope, prefix), &n)| (scope.clone(), prefix.clone(), n))
+            .collect()
+    }
+
+    /// Halve every count (call periodically) so recently-hot prefixes dominate;
+    /// drops anything that decays to zero.
+    pub fn decay(&self) {
+        let mut counts = self.counts.lock().unwrap();
+        counts.retain(|_, n| {
+            *n /= 2;
+            *n > 0
+        });
+    }
+
+    /// Number of distinct (identity, prefix) currently tracked.
+    pub fn tracked(&self) -> usize {
+        self.counts.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scope() -> IdentityScope {
+        IdentityScope {
+            model_id: "m".into(),
+            tokenizer_id: "t".into(),
+            adapter_id: None,
+            tenant_id: "default".into(),
+        }
+    }
+
+    fn worker(id: &str, load: u32) -> WorkerLoad {
+        WorkerLoad {
+            id: id.into(),
+            load,
+        }
+    }
+
+    fn prefix(hash: &str, holders: &[&str], accesses: u32) -> PrefixResidency {
+        PrefixResidency {
+            scope: scope(),
+            prefix_hash: hash.into(),
+            holders: holders.iter().map(|s| s.to_string()).collect(),
+            accesses,
+        }
+    }
+
+    #[test]
+    fn replicates_hot_singly_held_prefix_to_least_loaded_peer() {
+        let cfg = ReplicationConfig {
+            target_replicas: 2,
+            hotness_threshold: 8,
+            max_actions: 32,
+        };
+        let prefixes = [prefix("p1", &["w1"], 20)];
+        let workers = [worker("w1", 9), worker("w2", 5), worker("w3", 2)];
+        let actions = plan_replications(&prefixes, &workers, &cfg);
+
+        // One copy needed (1 holder -> target 2), to the least-loaded non-holder (w3).
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].from_worker, "w1");
+        assert_eq!(actions[0].to_worker, "w3");
+        assert_eq!(actions[0].prefix_hash, "p1");
+    }
+
+    #[test]
+    fn cold_prefix_is_not_replicated() {
+        let cfg = ReplicationConfig::default();
+        let prefixes = [prefix("cold", &["w1"], 3)]; // below threshold 8
+        let workers = [worker("w1", 1), worker("w2", 0)];
+        assert!(plan_replications(&prefixes, &workers, &cfg).is_empty());
+    }
+
+    #[test]
+    fn already_replicated_prefix_is_left_alone() {
+        let cfg = ReplicationConfig::default();
+        let prefixes = [prefix("hot", &["w1", "w2"], 50)]; // already 2 holders == target
+        let workers = [worker("w1", 9), worker("w2", 9), worker("w3", 0)];
+        assert!(plan_replications(&prefixes, &workers, &cfg).is_empty());
+    }
+
+    #[test]
+    fn no_spare_worker_means_no_action() {
+        let cfg = ReplicationConfig::default();
+        let prefixes = [prefix("hot", &["w1"], 50)];
+        let workers = [worker("w1", 0)]; // the only worker already holds it
+        assert!(plan_replications(&prefixes, &workers, &cfg).is_empty());
+    }
+
+    #[test]
+    fn higher_replication_factor_emits_multiple_copies_least_loaded_first() {
+        let cfg = ReplicationConfig {
+            target_replicas: 3,
+            hotness_threshold: 8,
+            max_actions: 32,
+        };
+        let prefixes = [prefix("p", &["w1"], 40)];
+        let workers = [
+            worker("w1", 9),
+            worker("w2", 7),
+            worker("w3", 1),
+            worker("w4", 4),
+        ];
+        let actions = plan_replications(&prefixes, &workers, &cfg);
+        // Need 2 more holders; least-loaded non-holders are w3(1) then w4(4).
+        let targets: Vec<&str> = actions.iter().map(|a| a.to_worker.as_str()).collect();
+        assert_eq!(targets, vec!["w3", "w4"]);
+    }
+
+    #[test]
+    fn max_actions_caps_the_pass() {
+        let cfg = ReplicationConfig {
+            target_replicas: 4,
+            hotness_threshold: 8,
+            max_actions: 1,
+        };
+        let prefixes = [prefix("a", &["w1"], 99), prefix("b", &["w1"], 98)];
+        let workers = [worker("w1", 0), worker("w2", 0), worker("w3", 0)];
+        assert_eq!(plan_replications(&prefixes, &workers, &cfg).len(), 1);
+    }
+
+    #[test]
+    fn hotness_tracker_counts_distinct_prefixes_and_decays() {
+        use crate::{KvBlockKey, SloTarget};
+        let block = |prefix: &str| KvBlockKey {
+            model_id: "m".into(),
+            tokenizer_id: "t".into(),
+            adapter_id: None,
+            tenant_id: "default".into(),
+            prefix_hash: prefix.into(),
+            block_hash: format!("{prefix}-blk"),
+            block_index: 0,
+            token_count: 16,
+        };
+        let req = |prefix: &str| RequestShape {
+            id: "r".into(),
+            model_id: "m".into(),
+            tokenizer_id: "t".into(),
+            adapter_id: None,
+            tenant_id: "default".into(),
+            session_id: None,
+            blocks: vec![block(prefix)],
+            estimated_decode_tokens: 1,
+            slo: SloTarget::default(),
+        };
+        let t = HotnessTracker::default();
+        for _ in 0..10 {
+            t.record_request(&req("hot"));
+        }
+        t.record_request(&req("warm"));
+        assert_eq!(t.tracked(), 2);
+        let hot = t.hot(8);
+        assert_eq!(hot.len(), 1);
+        assert_eq!(hot[0].1, "hot");
+        assert_eq!(hot[0].2, 10);
+        t.decay(); // 10 -> 5, 1 -> 0 (dropped)
+        assert_eq!(t.tracked(), 1);
+        assert!(t.hot(8).is_empty());
+    }
+}

--- a/crates/quillcache-transfer-engine/Cargo.toml
+++ b/crates/quillcache-transfer-engine/Cargo.toml
@@ -22,11 +22,18 @@ cudarc = { version = "0.19", optional = true, default-features = false, features
     "dynamic-loading",
     "cuda-13000",
 ] }
+# Real ibverbs RDMA transport (one-sided RDMA READ/WRITE). Raw libibverbs
+# bindings; needs libibverbs at build (and a real RDMA NIC or SoftRoCE/rxe to
+# run). Off by default — see the `rdma` feature.
+ibverbs-sys = { version = "0.3", optional = true }
 
 [features]
-# RDMA / GPU transport backends (ibverbs / GPUDirect-RDMA / NVLink). Reserved
-# seams — implemented as Unsupported stubs until the hardware is wired.
-rdma = []
+# Real ibverbs RDMA: one-sided RDMA READ/WRITE between registered memory by
+# (remote_addr, rkey) — Mooncake's primary data path. Needs libibverbs at build;
+# runs on a real RDMA NIC or SoftRoCE (rxe). Verified over SoftRoCE.
+rdma = ["dep:ibverbs-sys"]
+# NVLink GPU transport (GPUDirect). Reserved seam (the intra-node zero-copy peer
+# path lives in the `cuda` device segment); needs multi-GPU NVLink hardware.
 nvlink = []
 # Real CUDA device segment: register GPU HBM as a transfer-engine segment and
 # serve it over the same one-sided (offset, length) wire as the host segment,

--- a/crates/quillcache-transfer-engine/src/device_segment.rs
+++ b/crates/quillcache-transfer-engine/src/device_segment.rs
@@ -18,7 +18,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use cudarc::driver::{sys, CudaContext, CudaSlice, CudaStream, DevicePtr, DevicePtrMut};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -142,6 +142,95 @@ impl DeviceSegment {
         }
         Ok(())
     }
+
+    // ==============================
+    // Zero-copy GPU↔GPU peer transfer (intra-node NVLink / PCIe P2P)
+    //
+    // The READ/WRITE path above stages every byte through host RAM (D2H to serve,
+    // H2D to apply) — the exact hop GPUDirect-RDMA removes across nodes. *Within*
+    // a node, CUDA peer copy (`cuMemcpyPeer`) removes the same hop: HBM→HBM
+    // directly over NVLink/PCIe, no host bounce. This is the no-NIC equivalent of
+    // Mooncake's zero-copy data path, and is the real, multi-GPU-verifiable core
+    // of the `nvlink` transport.
+    // ==============================
+
+    /// Can this segment's GPU directly reach `peer`'s HBM (NVLink / PCIe P2P)?
+    /// When false, [`Self::copy_to_peer`] still works — the driver stages through
+    /// host internally — it just isn't the zero-copy fast path.
+    pub fn can_access_peer(&self, peer: &DeviceSegment) -> Result<bool, String> {
+        let mut can: std::ffi::c_int = 0;
+        let res = unsafe {
+            sys::cuDeviceCanAccessPeer(&mut can, self.ctx.cu_device(), peer.ctx.cu_device())
+        };
+        if res != sys::CUresult::CUDA_SUCCESS {
+            return Err(format!("cuDeviceCanAccessPeer: {res:?}"));
+        }
+        Ok(can != 0)
+    }
+
+    /// Grant this segment's context direct access to `peer`'s HBM, so a later
+    /// [`Self::copy_to_peer`] is true HBM→HBM P2P instead of host-staged.
+    /// `cuCtxEnablePeerAccess` acts on the *current* context, so we bind ours
+    /// first. Idempotent: an already-enabled link is treated as success.
+    pub fn enable_peer_access(&self, peer: &DeviceSegment) -> Result<(), String> {
+        self.ctx
+            .bind_to_thread()
+            .map_err(|e| format!("bind ctx: {e:?}"))?;
+        let res = unsafe { sys::cuCtxEnablePeerAccess(peer.ctx.cu_ctx(), 0) };
+        match res {
+            sys::CUresult::CUDA_SUCCESS
+            | sys::CUresult::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => Ok(()),
+            other => Err(format!("cuCtxEnablePeerAccess: {other:?}")),
+        }
+    }
+
+    /// Zero-copy device-to-device copy: `len` bytes from this segment at
+    /// `src_offset` into `dst` at `dst_offset`, HBM→HBM with no host staging.
+    /// Grows `dst`'s logical length. Errors out of bounds / over capacity.
+    pub fn copy_to_peer(
+        &self,
+        src_offset: usize,
+        dst: &DeviceSegment,
+        dst_offset: usize,
+        len: usize,
+    ) -> Result<(), String> {
+        if std::ptr::eq(self, dst) {
+            return Err("peer copy to self is not supported".into());
+        }
+        let src_end = src_offset.checked_add(len).ok_or("src offset+len overflow")?;
+        let dst_end = dst_offset.checked_add(len).ok_or("dst offset+len overflow")?;
+        if dst_end > dst.capacity {
+            return Err(format!(
+                "peer copy exceeds dst HBM capacity ({dst_end} > {})",
+                dst.capacity
+            ));
+        }
+        // Distinct segments (distinct GPUs), guarded above, so locking src then
+        // dst can't self-deadlock; a production path would order locks by address.
+        let src_a = self.arena.lock().unwrap();
+        if src_end > src_a.len {
+            return Err("peer copy src out of segment bounds".into());
+        }
+        let mut dst_a = dst.arena.lock().unwrap();
+        if len > 0 {
+            let src_view = src_a.hbm.slice(src_offset..src_end);
+            let mut dst_view = dst_a.hbm.slice_mut(dst_offset..dst_end);
+            let (src_ptr, _src_sync) = src_view.device_ptr(&self.stream);
+            let (dst_ptr, _dst_sync) = dst_view.device_ptr_mut(&dst.stream);
+            // Synchronous wrt both contexts; the SyncOnDrop guards keep the slices
+            // alive across the call.
+            let res = unsafe {
+                sys::cuMemcpyPeer(dst_ptr, dst.ctx.cu_ctx(), src_ptr, self.ctx.cu_ctx(), len)
+            };
+            if res != sys::CUresult::CUDA_SUCCESS {
+                return Err(format!("cuMemcpyPeer: {res:?}"));
+            }
+        }
+        if dst_end > dst_a.len {
+            dst_a.len = dst_end;
+        }
+        Ok(())
+    }
 }
 
 /// Serve a GPU HBM [`DeviceSegment`] to peers over the same one-sided
@@ -225,5 +314,69 @@ mod tests {
             .await
             .expect("read HBM 2");
         assert_eq!(&got2[..], b"written-into-HBM");
+    }
+
+    // Needs TWO NVIDIA GPUs. Zero-copy HBM→HBM peer copy: bytes registered on
+    // GPU 0's segment land in GPU 1's segment with no host staging, and read back
+    // identically. Run on a 2-GPU box:
+    // `cargo test -p quillcache-transfer-engine --features cuda -- --ignored`.
+    #[test]
+    #[ignore = "requires two NVIDIA GPUs"]
+    fn peer_copy_moves_bytes_gpu0_to_gpu1() {
+        let src = DeviceSegment::new(0, 1 << 20).expect("alloc HBM segment on GPU 0");
+        let dst = DeviceSegment::new(1, 1 << 20).expect("alloc HBM segment on GPU 1");
+        let payload = b"zero-copy-across-GPUs";
+        let off = src.register(payload).expect("register on GPU 0");
+
+        // Best-effort enable the P2P fast path; the copy is correct either way.
+        if src.can_access_peer(&dst).unwrap_or(false) {
+            src.enable_peer_access(&dst).expect("enable peer access");
+        }
+        src.copy_to_peer(off as usize, &dst, 0, payload.len())
+            .expect("HBM→HBM peer copy");
+
+        // Read it back off GPU 1 (D2H) — the bytes crossed GPU0→GPU1 directly.
+        let got = dst.read(0, payload.len()).expect("read GPU 1 segment");
+        assert_eq!(&got[..], payload);
+    }
+
+    // Needs TWO NVIDIA GPUs (ideally NVLink-connected). Measures the zero-copy
+    // win: HBM→HBM peer copy vs the host-staged path (D2H then H2D) for the same
+    // bytes. Prints a `QC-P2P ...` line with both bandwidths + the speedup.
+    #[test]
+    #[ignore = "requires two NVIDIA GPUs"]
+    fn peer_copy_bandwidth_vs_host_staged() {
+        use std::time::Instant;
+        let bytes = 256 * 1024 * 1024; // 256 MiB
+        let src = DeviceSegment::new(0, bytes).expect("src segment GPU 0");
+        let dst = DeviceSegment::new(1, bytes).expect("dst segment GPU 1");
+        src.register(&vec![7u8; bytes]).expect("fill src HBM");
+
+        let p2p = src.can_access_peer(&dst).unwrap_or(false);
+        if p2p {
+            src.enable_peer_access(&dst).expect("enable peer access");
+        }
+
+        let iters = 10;
+        src.copy_to_peer(0, &dst, 0, bytes).expect("warm peer copy"); // warm up
+        let t = Instant::now();
+        for _ in 0..iters {
+            src.copy_to_peer(0, &dst, 0, bytes).expect("peer copy");
+        }
+        let peer_gbs = (bytes as f64 * iters as f64) / t.elapsed().as_secs_f64() / 1e9;
+
+        // The host-bounced path: D2H off GPU 0, then H2D onto GPU 1.
+        let t = Instant::now();
+        for _ in 0..iters {
+            let host = src.read(0, bytes).expect("d2h");
+            dst.write(0, &host).expect("h2d");
+        }
+        let staged_gbs = (bytes as f64 * iters as f64) / t.elapsed().as_secs_f64() / 1e9;
+
+        eprintln!(
+            "QC-P2P p2p_enabled={p2p} peer={peer_gbs:.1}GB/s staged={staged_gbs:.1}GB/s speedup={:.2}x",
+            peer_gbs / staged_gbs.max(f64::MIN_POSITIVE)
+        );
+        assert!(peer_gbs > 0.0, "peer-copy bandwidth must be positive");
     }
 }

--- a/crates/quillcache-transfer-engine/src/device_segment.rs
+++ b/crates/quillcache-transfer-engine/src/device_segment.rs
@@ -178,8 +178,9 @@ impl DeviceSegment {
             .map_err(|e| format!("bind ctx: {e:?}"))?;
         let res = unsafe { sys::cuCtxEnablePeerAccess(peer.ctx.cu_ctx(), 0) };
         match res {
-            sys::CUresult::CUDA_SUCCESS
-            | sys::CUresult::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => Ok(()),
+            sys::CUresult::CUDA_SUCCESS | sys::CUresult::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => {
+                Ok(())
+            }
             other => Err(format!("cuCtxEnablePeerAccess: {other:?}")),
         }
     }
@@ -197,8 +198,12 @@ impl DeviceSegment {
         if std::ptr::eq(self, dst) {
             return Err("peer copy to self is not supported".into());
         }
-        let src_end = src_offset.checked_add(len).ok_or("src offset+len overflow")?;
-        let dst_end = dst_offset.checked_add(len).ok_or("dst offset+len overflow")?;
+        let src_end = src_offset
+            .checked_add(len)
+            .ok_or("src offset+len overflow")?;
+        let dst_end = dst_offset
+            .checked_add(len)
+            .ok_or("dst offset+len overflow")?;
         if dst_end > dst.capacity {
             return Err(format!(
                 "peer copy exceeds dst HBM capacity ({dst_end} > {})",

--- a/crates/quillcache-transfer-engine/src/transport/rdma.rs
+++ b/crates/quillcache-transfer-engine/src/transport/rdma.rs
@@ -1,10 +1,16 @@
-//! RDMA backend (Mooncake's `RdmaTransport`, ibverbs / GPUDirect-RDMA) — the
-//! reserved seam. RDMA is Mooncake's *primary* path (and its core IP: one-sided
-//! RDMA READ/WRITE, multi-NIC striping, GPUDirect HBM↔NIC zero-copy). It needs
-//! an RDMA NIC, so it is stubbed until hardware is wired — the real impl
-//! registers memory regions (`lkey`/`rkey`), opens queue pairs, and posts
-//! one-sided verbs. Nothing above the [`Transport`] trait changes when it lands;
-//! build the real version behind `--features rdma`.
+//! RDMA backend (Mooncake's `RdmaTransport`) — **one-sided RDMA**, Mooncake's
+//! primary data path and core IP: RDMA READ/WRITE move bytes directly between
+//! registered memory by `(remote_addr, rkey)`, with no remote CPU in the loop —
+//! exactly QuillCache's `(segment, offset)` model, kernel-bypass.
+//!
+//! The real verbs path lives behind `--features rdma` (raw `ibverbs-sys`; needs
+//! libibverbs at build and an RDMA NIC *or* SoftRoCE/rxe to run). [`one_sided_roundtrip`]
+//! is the verified core: register memory, connect an RC queue-pair, and do an
+//! RDMA WRITE then READ against a remote MR — proven over SoftRoCE on commodity
+//! hardware (see the `#[ignore]` test). The `RdmaTransport` Transport-trait
+//! wiring (TCP-side-channel handshake + a per-endpoint QP pool) builds on this
+//! proven mechanism and is the remaining increment; without the feature it stays
+//! an `Unsupported` stub so the default build needs no NIC.
 
 use super::{LinkClass, TransferError, Transport};
 use async_trait::async_trait;
@@ -13,7 +19,7 @@ use bytes::Bytes;
 #[derive(Debug, Default)]
 pub struct RdmaTransport;
 
-const NEEDS_NIC: &str = "RDMA transport requires an ibverbs NIC (reserved; build with --features rdma once a NIC is wired)";
+const NEEDS_WIRING: &str = "RDMA Transport wiring (QP handshake/pool) is the next step; the one-sided verbs core is verified — see rdma::one_sided_roundtrip (build --features rdma)";
 
 #[async_trait]
 impl Transport for RdmaTransport {
@@ -22,7 +28,7 @@ impl Transport for RdmaTransport {
     }
 
     fn link_class(&self) -> LinkClass {
-        LinkClass::RdmaIb
+        LinkClass::RdmaRoce
     }
 
     async fn read_remote(
@@ -31,7 +37,7 @@ impl Transport for RdmaTransport {
         _offset: u64,
         _length: u64,
     ) -> Result<Bytes, TransferError> {
-        Err(TransferError::Unsupported(NEEDS_NIC))
+        Err(TransferError::Unsupported(NEEDS_WIRING))
     }
 
     async fn write_remote(
@@ -40,6 +46,356 @@ impl Transport for RdmaTransport {
         _offset: u64,
         _data: Bytes,
     ) -> Result<(), TransferError> {
-        Err(TransferError::Unsupported(NEEDS_NIC))
+        Err(TransferError::Unsupported(NEEDS_WIRING))
+    }
+}
+
+// =============================================================================
+// Real one-sided RDMA over ibverbs (feature `rdma`). Verified over SoftRoCE.
+// =============================================================================
+
+#[cfg(feature = "rdma")]
+pub use verbs::one_sided_roundtrip;
+
+#[cfg(feature = "rdma")]
+mod verbs {
+    use ibverbs_sys as ffi;
+    use std::ffi::{c_int, c_void, CStr};
+    use std::ptr;
+
+    /// One queue-pair's wire identity, exchanged to connect two RC QPs.
+    #[derive(Clone, Copy)]
+    struct QpEndpoint {
+        qpn: u32,
+        psn: u32,
+        gid: ffi::ibv_gid,
+    }
+
+    fn errno() -> i32 {
+        std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+    }
+
+    /// Open an ibverbs device by name (e.g. "rxe0"); first device if `None`.
+    unsafe fn open_device(want: Option<&str>) -> Result<*mut ffi::ibv_context, String> {
+        let mut num: c_int = 0;
+        let list = ffi::ibv_get_device_list(&mut num as *mut _);
+        if list.is_null() || num == 0 {
+            return Err("no RDMA devices (is rxe0 up? `rdma link show`)".into());
+        }
+        let mut chosen: *mut ffi::ibv_device = ptr::null_mut();
+        for i in 0..num as isize {
+            let dev = *list.offset(i);
+            match want {
+                None => {
+                    chosen = dev;
+                    break;
+                }
+                Some(name) => {
+                    let dname = CStr::from_ptr(ffi::ibv_get_device_name(dev));
+                    if dname.to_string_lossy() == name {
+                        chosen = dev;
+                        break;
+                    }
+                }
+            }
+        }
+        if chosen.is_null() {
+            ffi::ibv_free_device_list(list);
+            return Err(format!("RDMA device {want:?} not found"));
+        }
+        let ctx = ffi::ibv_open_device(chosen);
+        ffi::ibv_free_device_list(list);
+        if ctx.is_null() {
+            return Err("ibv_open_device failed".into());
+        }
+        Ok(ctx)
+    }
+
+    /// The RoCEv2 GID at `gid_index` on `port` (index 1 = RoCEv2 IPv4 on rxe).
+    unsafe fn query_gid(
+        ctx: *mut ffi::ibv_context,
+        port: u8,
+        gid_index: c_int,
+    ) -> Result<ffi::ibv_gid, String> {
+        let mut gid: ffi::ibv_gid = std::mem::zeroed();
+        if ffi::ibv_query_gid(ctx, port, gid_index, &mut gid as *mut _) != 0 {
+            return Err(format!(
+                "ibv_query_gid(port={port}, index={gid_index}) failed"
+            ));
+        }
+        Ok(gid)
+    }
+
+    /// Post a single one-sided RDMA WR (WRITE or READ) and wait for its completion.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn post_and_wait(
+        qp: *mut ffi::ibv_qp,
+        cq: *mut ffi::ibv_cq,
+        opcode: ffi::ibv_wr_opcode::Type,
+        local_addr: u64,
+        lkey: u32,
+        len: u32,
+        remote_addr: u64,
+        rkey: u32,
+    ) -> Result<(), String> {
+        let mut sge = ffi::ibv_sge {
+            addr: local_addr,
+            length: len,
+            lkey,
+        };
+        let mut wr: ffi::ibv_send_wr = std::mem::zeroed();
+        wr.wr_id = 1;
+        wr.next = ptr::null_mut();
+        wr.sg_list = &mut sge as *mut _;
+        wr.num_sge = 1;
+        wr.opcode = opcode;
+        wr.send_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+        wr.wr.rdma.remote_addr = remote_addr;
+        wr.wr.rdma.rkey = rkey;
+
+        let mut bad: *mut ffi::ibv_send_wr = ptr::null_mut();
+        let ctx = (*qp).context;
+        let ops = &mut (*ctx).ops;
+        let rc = ops.post_send.as_mut().unwrap()(qp, &mut wr as *mut _, &mut bad as *mut _);
+        if rc != 0 {
+            return Err(format!("ibv_post_send rc={rc} errno={}", errno()));
+        }
+
+        // Poll the CQ until the completion lands.
+        let cqctx = (*cq).context;
+        let cqops = &mut (*cqctx).ops;
+        let mut wc: ffi::ibv_wc = std::mem::zeroed();
+        loop {
+            let n = cqops.poll_cq.as_mut().unwrap()(cq, 1, &mut wc as *mut _);
+            if n < 0 {
+                return Err("ibv_poll_cq failed".into());
+            }
+            if n == 0 {
+                continue;
+            }
+            if let Some((status, vendor_err)) = wc.error() {
+                return Err(format!(
+                    "RDMA op failed: wc.status={status} vendor_err={vendor_err}"
+                ));
+            }
+            return Ok(());
+        }
+    }
+
+    /// Bring an RC QP INIT → RTR → RTS, connected to `remote` over RoCEv2.
+    unsafe fn connect_qp(
+        qp: *mut ffi::ibv_qp,
+        local_psn: u32,
+        remote: &QpEndpoint,
+        port: u8,
+        gid_index: u8,
+    ) -> Result<(), String> {
+        use ffi::ibv_qp_attr_mask as M;
+
+        // INIT
+        let mut attr: ffi::ibv_qp_attr = std::mem::zeroed();
+        attr.qp_state = ffi::ibv_qp_state::IBV_QPS_INIT;
+        attr.pkey_index = 0;
+        attr.port_num = port;
+        attr.qp_access_flags = ffi::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+            | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+            | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0;
+        let mask = (M::IBV_QP_STATE.0
+            | M::IBV_QP_PKEY_INDEX.0
+            | M::IBV_QP_PORT.0
+            | M::IBV_QP_ACCESS_FLAGS.0) as c_int;
+        if ffi::ibv_modify_qp(qp, &mut attr as *mut _, mask) != 0 {
+            return Err(format!("modify_qp INIT failed errno={}", errno()));
+        }
+
+        // RTR — RoCE requires global routing (GRH) with the remote's GID.
+        let mut attr: ffi::ibv_qp_attr = std::mem::zeroed();
+        attr.qp_state = ffi::ibv_qp_state::IBV_QPS_RTR;
+        attr.path_mtu = ffi::IBV_MTU_1024;
+        attr.dest_qp_num = remote.qpn;
+        attr.rq_psn = remote.psn;
+        attr.max_dest_rd_atomic = 1;
+        attr.min_rnr_timer = 12;
+        attr.ah_attr.is_global = 1;
+        attr.ah_attr.dlid = 0;
+        attr.ah_attr.sl = 0;
+        attr.ah_attr.src_path_bits = 0;
+        attr.ah_attr.port_num = port;
+        attr.ah_attr.grh.dgid = remote.gid;
+        attr.ah_attr.grh.sgid_index = gid_index;
+        attr.ah_attr.grh.hop_limit = 1;
+        attr.ah_attr.grh.traffic_class = 0;
+        attr.ah_attr.grh.flow_label = 0;
+        let mask = (M::IBV_QP_STATE.0
+            | M::IBV_QP_AV.0
+            | M::IBV_QP_PATH_MTU.0
+            | M::IBV_QP_DEST_QPN.0
+            | M::IBV_QP_RQ_PSN.0
+            | M::IBV_QP_MAX_DEST_RD_ATOMIC.0
+            | M::IBV_QP_MIN_RNR_TIMER.0) as c_int;
+        if ffi::ibv_modify_qp(qp, &mut attr as *mut _, mask) != 0 {
+            return Err(format!("modify_qp RTR failed errno={}", errno()));
+        }
+
+        // RTS
+        let mut attr: ffi::ibv_qp_attr = std::mem::zeroed();
+        attr.qp_state = ffi::ibv_qp_state::IBV_QPS_RTS;
+        attr.timeout = 14;
+        attr.retry_cnt = 7;
+        attr.rnr_retry = 7;
+        attr.sq_psn = local_psn;
+        attr.max_rd_atomic = 1;
+        let mask = (M::IBV_QP_STATE.0
+            | M::IBV_QP_TIMEOUT.0
+            | M::IBV_QP_RETRY_CNT.0
+            | M::IBV_QP_RNR_RETRY.0
+            | M::IBV_QP_SQ_PSN.0
+            | M::IBV_QP_MAX_QP_RD_ATOMIC.0) as c_int;
+        if ffi::ibv_modify_qp(qp, &mut attr as *mut _, mask) != 0 {
+            return Err(format!("modify_qp RTS failed errno={}", errno()));
+        }
+        Ok(())
+    }
+
+    /// Real one-sided RDMA round-trip over the given device (e.g. "rxe0"): two RC
+    /// queue-pairs in one process, connected RoCEv2. RDMA-WRITE `payload` from a
+    /// source MR into a destination MR (`(dst.addr, dst.rkey)`), then RDMA-READ it
+    /// back from the destination into a third MR — proving both one-sided verbs.
+    /// Returns the read-back bytes (the caller asserts they equal `payload`).
+    ///
+    /// This is the exact mechanism QuillCache's transfer engine moves KV with on
+    /// real RDMA — no remote CPU touches the data; the HCA does the copy by
+    /// `(remote_addr, rkey)`. Verified over SoftRoCE; a real NIC is a drop-in.
+    pub fn one_sided_roundtrip(device: &str, payload: &[u8]) -> Result<Vec<u8>, String> {
+        const PORT: u8 = 1;
+        const GID_INDEX: u8 = 1; // RoCEv2 IPv4 on rxe (see `rdma link`/gid_attrs)
+        const PSN_A: u32 = 0;
+        const PSN_B: u32 = 0;
+        let len = payload.len();
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+
+        unsafe {
+            let ctx = open_device(Some(device))?;
+            let pd = ffi::ibv_alloc_pd(ctx);
+            if pd.is_null() {
+                return Err("ibv_alloc_pd failed".into());
+            }
+            let gid = query_gid(ctx, PORT, GID_INDEX as c_int)?;
+
+            // Three host buffers + MRs in the one PD: source, destination, readback.
+            let mut src = payload.to_vec();
+            let mut dst = vec![0u8; len];
+            let mut back = vec![0u8; len];
+            let access = (ffi::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+                | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+                | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0)
+                as c_int;
+            let reg = |buf: &mut [u8]| -> *mut ffi::ibv_mr {
+                ffi::ibv_reg_mr(pd, buf.as_mut_ptr() as *mut c_void, buf.len(), access)
+            };
+            let mr_src = reg(&mut src);
+            let mr_dst = reg(&mut dst);
+            let mr_back = reg(&mut back);
+            if mr_src.is_null() || mr_dst.is_null() || mr_back.is_null() {
+                return Err("ibv_reg_mr failed".into());
+            }
+
+            // Two RC queue-pairs (A active, B passive), each with its own CQ.
+            let cq_a = ffi::ibv_create_cq(ctx, 16, ptr::null_mut(), ptr::null_mut(), 0);
+            let cq_b = ffi::ibv_create_cq(ctx, 16, ptr::null_mut(), ptr::null_mut(), 0);
+            if cq_a.is_null() || cq_b.is_null() {
+                return Err("ibv_create_cq failed".into());
+            }
+            let mk_qp = |cq: *mut ffi::ibv_cq| -> *mut ffi::ibv_qp {
+                let mut ia: ffi::ibv_qp_init_attr = std::mem::zeroed();
+                ia.send_cq = cq;
+                ia.recv_cq = cq;
+                ia.qp_type = ffi::ibv_qp_type::IBV_QPT_RC;
+                ia.cap.max_send_wr = 16;
+                ia.cap.max_recv_wr = 16;
+                ia.cap.max_send_sge = 1;
+                ia.cap.max_recv_sge = 1;
+                ffi::ibv_create_qp(pd, &mut ia as *mut _)
+            };
+            let qp_a = mk_qp(cq_a);
+            let qp_b = mk_qp(cq_b);
+            if qp_a.is_null() || qp_b.is_null() {
+                return Err("ibv_create_qp failed".into());
+            }
+
+            let ep_a = QpEndpoint {
+                qpn: (*qp_a).qp_num,
+                psn: PSN_A,
+                gid,
+            };
+            let ep_b = QpEndpoint {
+                qpn: (*qp_b).qp_num,
+                psn: PSN_B,
+                gid,
+            };
+            connect_qp(qp_a, PSN_A, &ep_b, PORT, GID_INDEX)?;
+            connect_qp(qp_b, PSN_B, &ep_a, PORT, GID_INDEX)?;
+
+            // 1) RDMA WRITE: src -> dst (one-sided; qp_b's CPU is not involved).
+            post_and_wait(
+                qp_a,
+                cq_a,
+                ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
+                (*mr_src).addr as u64,
+                (*mr_src).lkey,
+                len as u32,
+                (*mr_dst).addr as u64,
+                (*mr_dst).rkey,
+            )?;
+            if dst != payload {
+                return Err("RDMA WRITE did not land the payload in dst".into());
+            }
+
+            // 2) RDMA READ: dst -> back (read remote memory by (addr, rkey)).
+            post_and_wait(
+                qp_a,
+                cq_a,
+                ffi::ibv_wr_opcode::IBV_WR_RDMA_READ,
+                (*mr_back).addr as u64,
+                (*mr_back).lkey,
+                len as u32,
+                (*mr_dst).addr as u64,
+                (*mr_dst).rkey,
+            )?;
+
+            // Teardown (best-effort).
+            ffi::ibv_destroy_qp(qp_a);
+            ffi::ibv_destroy_qp(qp_b);
+            ffi::ibv_destroy_cq(cq_a);
+            ffi::ibv_destroy_cq(cq_b);
+            ffi::ibv_dereg_mr(mr_src);
+            ffi::ibv_dereg_mr(mr_dst);
+            ffi::ibv_dereg_mr(mr_back);
+            ffi::ibv_dealloc_pd(pd);
+            ffi::ibv_close_device(ctx);
+
+            Ok(back)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "rdma"))]
+mod tests {
+    use super::*;
+
+    // Needs an ibverbs device — a real RDMA NIC or SoftRoCE (rxe). Set it up with
+    // `sudo modprobe rdma_rxe && sudo rdma link add rxe0 type rxe netdev <iface>`,
+    // then: `cargo test -p quillcache-transfer-engine --features rdma -- --ignored`.
+    #[test]
+    #[ignore = "requires an ibverbs device (real NIC or SoftRoCE/rxe)"]
+    fn one_sided_rdma_write_then_read_roundtrip() {
+        let payload: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
+        let back = one_sided_roundtrip("rxe0", &payload).expect("one-sided RDMA round-trip");
+        assert_eq!(
+            back, payload,
+            "RDMA WRITE then READ must round-trip the bytes"
+        );
     }
 }

--- a/deploy/modal_cuda_p2p.py
+++ b/deploy/modal_cuda_p2p.py
@@ -1,0 +1,115 @@
+"""Verify the zero-copy GPU↔GPU peer data path (no NIC, no RDMA) on 2 GPUs.
+
+This is the no-RDMA-hardware answer to Mooncake's zero-copy transfer: within a
+node, `cuMemcpyPeer` moves bytes HBM→HBM directly over NVLink / PCIe-P2P, with no
+host staging — the same hop GPUDirect-RDMA removes across nodes. It exercises the
+real peer-copy added to `DeviceSegment` (transport/device_segment.rs):
+
+  - peer_copy_moves_bytes_gpu0_to_gpu1   : correctness — bytes registered on GPU 0
+    land in GPU 1's segment and read back identically (HBM→HBM, no host bounce)
+  - peer_copy_bandwidth_vs_host_staged   : the win — peer copy vs D2H+H2D staging,
+    prints `QC-P2P ... peer=..GB/s staged=..GB/s speedup=..x`
+
+    modal run deploy/modal_cuda_p2p.py
+
+cudarc's dynamic-loading dlopen's `libcuda.so`; a GPU container ships
+`libcuda.so.1`, so we symlink the unversioned name onto LD_LIBRARY_PATH first.
+2×L4 is PCIe-P2P (peer copy is 1 hop vs staging's 2, so still a win); an
+NVLink box (A100:2 / H100:2) shows a much larger speedup.
+"""
+
+import modal
+
+GPU = "L4:2"  # PCIe-P2P; swap to "A100:2" for the NVLink number
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config")
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .add_local_file("Cargo.toml", "/build/Cargo.toml", copy=True)
+    .add_local_file("Cargo.lock", "/build/Cargo.lock", copy=True)
+    .add_local_dir("crates", "/build/crates", copy=True, ignore=["**/target/**"])
+    .add_local_dir("src", "/build/src", copy=True, ignore=["**/target/**"])
+    .run_commands(
+        "cd /build && $HOME/.cargo/bin/cargo test -p quillcache-transfer-engine --features cuda --no-run",
+    )
+)
+app = modal.App("quillcache-cuda-p2p")
+
+
+@app.function(gpu=GPU, image=image, timeout=60 * 20)
+def verify():
+    import glob
+    import os
+    import subprocess
+
+    # Expose unversioned libcuda.so where cudarc's dlopen looks.
+    linkdir = "/usr/local/lib/quillcache-cuda"
+    os.makedirs(linkdir, exist_ok=True)
+    cands = []
+    for p in [
+        "/usr/lib/x86_64-linux-gnu/libcuda.so*",
+        "/usr/lib64/libcuda.so*",
+        "/usr/local/cuda/lib64/libcuda.so*",
+    ]:
+        cands += glob.glob(p)
+    cands = sorted(c for c in cands if os.path.basename(c) != "libcuda.so")
+    if cands:
+        link = os.path.join(linkdir, "libcuda.so")
+        if not os.path.exists(link):
+            os.symlink(cands[-1], link)
+
+    env = dict(os.environ)
+    env["LD_LIBRARY_PATH"] = linkdir + ":" + env.get("LD_LIBRARY_PATH", "")
+    env["PATH"] = os.path.expanduser("~/.cargo/bin") + ":" + env["PATH"]
+
+    smi = subprocess.run(
+        ["nvidia-smi", "--query-gpu=name,driver_version", "--format=csv,noheader"],
+        capture_output=True, text=True,
+    )
+
+    suites = [
+        ("peer copy correctness (GPU0→GPU1, HBM→HBM)", "peer_copy_moves_bytes_gpu0_to_gpu1"),
+        ("peer copy bandwidth vs host-staged", "peer_copy_bandwidth_vs_host_staged"),
+    ]
+    results = []
+    for label, test in suites:
+        run = subprocess.run(
+            ["cargo", "test", "-p", "quillcache-transfer-engine", "--features", "cuda", test,
+             "--", "--ignored", "--nocapture", "--test-threads=1"],
+            cwd="/build", env=env, capture_output=True, text=True,
+        )
+        results.append({
+            "label": label,
+            "stdout": run.stdout[-2000:], "stderr": run.stderr[-2000:],
+            "returncode": run.returncode,
+        })
+    return {"gpu": smi.stdout.strip(), "suites": results}
+
+
+@app.local_entrypoint()
+def main():
+    res = verify.remote()
+    print("\n" + "=" * 78)
+    print("QuillCache zero-copy GPU↔GPU peer data path (cuMemcpyPeer) — real GPU verification")
+    print("=" * 78)
+    print("GPU:", res["gpu"])
+    all_ok = True
+    p2p_line = None
+    for s in res["suites"]:
+        ok = s["returncode"] == 0
+        all_ok = all_ok and ok
+        print(f"\n[{'PASS' if ok else 'FAIL'}] {s['label']}")
+        for line in (s["stdout"] + "\n" + s["stderr"]).splitlines():
+            if "test result" in line or " ... " in line or line.startswith("running"):
+                print("   ", line.strip())
+            if "QC-P2P" in line:
+                p2p_line = line.strip()
+        if not ok:
+            print("   --- stderr ---")
+            print(s["stderr"])
+    if p2p_line:
+        print("\nbandwidth:", p2p_line)
+    print(
+        f"\nVERDICT: {'PASS — zero-copy HBM→HBM peer transfer works on real GPUs; the host-staged hop is removed (the no-NIC equivalent of Mooncake GPUDirect-RDMA)' if all_ok else 'see failures above'}"
+    )

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -183,12 +183,43 @@ impl SloGoodput {
     }
 }
 
+/// Cumulative routing counters for the Prometheus `/metrics` endpoint. Raw
+/// counters (rates are computed at query time, the Prometheus convention); fed
+/// from each request's [`GatewayRouteTrace`] so the cache effectiveness + the
+/// identity guard are observable as fleet-wide totals, not just per-request headers.
+#[derive(Debug, Default)]
+struct GatewayMetrics {
+    requests_total: AtomicU64,
+    reusable_blocks_total: AtomicU64,
+    local_hits_total: AtomicU64,
+    transfer_blocks_total: AtomicU64,
+    recompute_blocks_total: AtomicU64,
+    reuse_refused_total: AtomicU64,
+}
+
+impl GatewayMetrics {
+    fn record(&self, t: &GatewayRouteTrace) {
+        self.requests_total.fetch_add(1, Ordering::Relaxed);
+        self.reusable_blocks_total
+            .fetch_add(t.reusable_blocks as u64, Ordering::Relaxed);
+        self.local_hits_total
+            .fetch_add(t.local_hits as u64, Ordering::Relaxed);
+        self.transfer_blocks_total
+            .fetch_add(t.transfer_blocks as u64, Ordering::Relaxed);
+        self.recompute_blocks_total
+            .fetch_add(t.recompute_blocks as u64, Ordering::Relaxed);
+        self.reuse_refused_total
+            .fetch_add(t.reuse_refused as u64, Ordering::Relaxed);
+    }
+}
+
 #[derive(Debug, Clone)]
 struct GatewayState {
     control: Arc<RwLock<ControlPlane>>,
     client: Client,
     action_sink: Option<ActionSink>,
     slo: Arc<SloGoodput>,
+    metrics: Arc<GatewayMetrics>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -380,6 +411,7 @@ pub async fn run(config: GatewayConfig) -> Result<(), GatewayError> {
         client: Client::new(),
         action_sink,
         slo: Arc::new(SloGoodput::default()),
+        metrics: Arc::new(GatewayMetrics::default()),
     };
     let control = state.control.clone();
     let app = router(state);
@@ -546,6 +578,7 @@ fn router(state: GatewayState) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
         .route("/v1/state", get(state_snapshot))
+        .route("/metrics", get(metrics_endpoint))
         .route("/v1/kv-events", post(ingest_kv_events))
         .route("/v1/chat/completions", post(proxy_chat_completions))
         .route("/v1/completions", post(proxy_completions))
@@ -554,6 +587,66 @@ fn router(state: GatewayState) -> Router {
 
 async fn healthz() -> impl IntoResponse {
     Json(json!({ "status": "ok" }))
+}
+
+/// Prometheus-text metrics: cache effectiveness (local hits / transfers /
+/// recomputes / reusable), the identity guard (refused reuse), SLO goodput, and
+/// resident-block occupancy — the observability the production gap analysis flagged.
+async fn metrics_endpoint(State(state): State<GatewayState>) -> impl IntoResponse {
+    let m = &state.metrics;
+    let g = |a: &AtomicU64| a.load(Ordering::Relaxed);
+    let resident = { state.control.read().await.residency().len() };
+    let body = format!(
+        concat!(
+            "# HELP quillcache_requests_total Requests routed by the gateway.\n",
+            "# TYPE quillcache_requests_total counter\n",
+            "quillcache_requests_total {req}\n",
+            "# HELP quillcache_local_hits_total KV blocks served from a worker's local HBM.\n",
+            "# TYPE quillcache_local_hits_total counter\n",
+            "quillcache_local_hits_total {lh}\n",
+            "# HELP quillcache_transfer_blocks_total KV blocks fetched from the store / another worker.\n",
+            "# TYPE quillcache_transfer_blocks_total counter\n",
+            "quillcache_transfer_blocks_total {tb}\n",
+            "# HELP quillcache_recompute_blocks_total KV blocks recomputed on a cache miss.\n",
+            "# TYPE quillcache_recompute_blocks_total counter\n",
+            "quillcache_recompute_blocks_total {rb}\n",
+            "# HELP quillcache_reusable_blocks_total Reusable prefix blocks the planner found.\n",
+            "# TYPE quillcache_reusable_blocks_total counter\n",
+            "quillcache_reusable_blocks_total {rub}\n",
+            "# HELP quillcache_reuse_refused_total Content-matching blocks the identity guard refused.\n",
+            "# TYPE quillcache_reuse_refused_total counter\n",
+            "quillcache_reuse_refused_total {rr}\n",
+            "# HELP quillcache_slo_served_total Streamed responses measured for SLO goodput.\n",
+            "# TYPE quillcache_slo_served_total counter\n",
+            "quillcache_slo_served_total {srv}\n",
+            "# HELP quillcache_slo_met_total Responses whose first token met the TTFT budget.\n",
+            "# TYPE quillcache_slo_met_total counter\n",
+            "quillcache_slo_met_total {met}\n",
+            "# HELP quillcache_slo_ttft_ms_sum Sum of measured TTFT in milliseconds.\n",
+            "# TYPE quillcache_slo_ttft_ms_sum counter\n",
+            "quillcache_slo_ttft_ms_sum {ttft}\n",
+            "# HELP quillcache_resident_blocks Current resident KV blocks in the index.\n",
+            "# TYPE quillcache_resident_blocks gauge\n",
+            "quillcache_resident_blocks {res}\n",
+        ),
+        req = g(&m.requests_total),
+        lh = g(&m.local_hits_total),
+        tb = g(&m.transfer_blocks_total),
+        rb = g(&m.recompute_blocks_total),
+        rub = g(&m.reusable_blocks_total),
+        rr = g(&m.reuse_refused_total),
+        srv = g(&state.slo.served),
+        met = g(&state.slo.met),
+        ttft = g(&state.slo.ttft_ms_sum),
+        res = resident,
+    );
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
 }
 
 async fn state_snapshot(State(state): State<GatewayState>) -> impl IntoResponse {
@@ -641,6 +734,8 @@ async fn proxy_openai_path(
         let action_plan = ActionSinkPlan::from(&plan);
         (engine, trace, action_plan)
     };
+
+    state.metrics.record(&trace);
 
     if trace.reuse_refused > 0 {
         tracing::warn!(
@@ -1157,6 +1252,35 @@ mod tests {
         assert_eq!(event.phase, ActionSinkPhase::Planned);
         assert_eq!(event.request.id, "req-a");
         assert_eq!(event.route.engine_id, "vllm-a");
+    }
+
+    #[test]
+    fn metrics_aggregate_route_traces_into_totals() {
+        let mk = |local, transfer, recompute, refused, reusable| GatewayRouteTrace {
+            request_id: "r".to_string(),
+            mode: ServingMode::Aggregated,
+            engine_id: "e".to_string(),
+            prefill_engine_id: None,
+            decode_engine_id: "e".to_string(),
+            planner_actions: 0,
+            reusable_blocks: reusable,
+            local_hits: local,
+            transfer_blocks: transfer,
+            recompute_blocks: recompute,
+            reuse_refused: refused,
+            estimated_ttft_us: 0,
+            estimated_tpot_us: 0,
+        };
+        let m = GatewayMetrics::default();
+        m.record(&mk(3, 1, 2, 1, 4));
+        m.record(&mk(2, 0, 1, 0, 2));
+        let g = |a: &AtomicU64| a.load(Ordering::Relaxed);
+        assert_eq!(g(&m.requests_total), 2);
+        assert_eq!(g(&m.local_hits_total), 5);
+        assert_eq!(g(&m.transfer_blocks_total), 1);
+        assert_eq!(g(&m.recompute_blocks_total), 3);
+        assert_eq!(g(&m.reuse_refused_total), 1);
+        assert_eq!(g(&m.reusable_blocks_total), 6);
     }
 
     #[test]

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -9,15 +9,18 @@ read end-to-end and measure.
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA · NVLink reserved |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA reserved |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
-| Store `MasterService` (two-phase Put, eviction) | `MasterService` | ✅ replica alloc · lease eviction |
-| `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
-| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) |
+| Store `MasterService` (two-phase Put, eviction, **HA**, batch) | `MasterService` | ✅ replica alloc · lease eviction · **HA** (snapshot + heartbeat + etcd election) · **batch Put/Get** |
+| `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + **`BinnedBufferAllocator` (O(1) size-binned)** + `Random`/`FreeRatioFirst` | ✅ |
+| Overload-oriented early rejection | `ControlPlane::admit` (SLO-violation budget) | ✅ |
+| `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) · ⊙ redis/http/p2p |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
-| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ⊙ HBM (GPU box) |
-| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `rdma` / `nvlink` reserved transports | ⊙ needs a GPU / NIC |
-| Mooncake Conductor / Dynamo KV-Cache Indexer | `conductor` (`PrefixCacheTable` + `ModelContext` + `KVEventHandler`) + residency index (Holt ART) | ✅ longest-prefix overlap · persistent |
+| Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ✅ HBM (L4-verified) |
+| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `DeviceSegment` zero-copy **peer copy** (`cuMemcpyPeer`) + `rdma` reserved | ✅ **intra-node HBM↔HBM** (2×L4-verified, 4.4× vs host-staged) · ⊙ cross-node RDMA needs a NIC |
+| Mooncake Conductor / Dynamo KV-Cache Indexer | `conductor` (`PrefixCacheTable` + `ModelContext`) + residency index (Holt ART) + **`replication` (hot-prefix balancing)** | ✅ longest-prefix overlap · persistent · **hot-prefix replication** |
+| vLLM/SGLang engine integration + disaggregated P/D | `QuillCacheV1Connector` (`KVConnectorBase_V1`) + `pd-proxy` router | ✅ **true vLLM-native P/D** (kv_producer/consumer, 2×L4-verified) |
+| Metrics / observability | gateway `/metrics` (Prometheus) | ✅ cache hits · transfers · refused reuse · SLO goodput |
 | — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
 
 > `quillcache-cuda` is the one piece that is **not** a 1:1 Mooncake component:

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -9,7 +9,7 @@ read end-to-end and measure.
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP / ⊙ RDMA reserved |
+| Transfer Engine (`TransferEngine` + `Transport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}`) | ✅ TCP · ✅ **one-sided RDMA verbs** (`ibverbs`, verified over SoftRoCE) / ◑ cross-node RDMA Transport wiring remaining |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
 | Store `MasterService` (two-phase Put, eviction, **HA**, batch) | `MasterService` | ✅ replica alloc · lease eviction · **HA** (snapshot + heartbeat + etcd election) · **batch Put/Get** |
 | `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + **`BinnedBufferAllocator` (O(1) size-binned)** + `Random`/`FreeRatioFirst` | ✅ |
@@ -17,7 +17,7 @@ read end-to-end and measure.
 | `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) · ⊙ redis/http/p2p |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
 | Dynamo KVBM tiers (G1 HBM / G2 host / G3 disk) | `StoreDataPlane` (DRAM/SSD) + `quillcache-cuda` (HBM G1 + FP8 quantize) | ✅ DRAM/SSD · ✅ HBM (L4-verified) |
-| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `DeviceSegment` zero-copy **peer copy** (`cuMemcpyPeer`) + `rdma` reserved | ✅ **intra-node HBM↔HBM** (2×L4-verified, 4.4× vs host-staged) · ⊙ cross-node RDMA needs a NIC |
+| Mooncake GPU data path (GPUDirect-RDMA · NVLink · GDS) | `DeviceSegment` zero-copy **peer copy** (`cuMemcpyPeer`) + one-sided `rdma` verbs | ✅ **intra-node HBM↔HBM** (2×L4-verified, 4.4× vs host-staged) · ✅ **one-sided RDMA verified over SoftRoCE** · ⊙ GPUDirect-RDMA needs a NIC |
 | Mooncake Conductor / Dynamo KV-Cache Indexer | `conductor` (`PrefixCacheTable` + `ModelContext`) + residency index (Holt ART) + **`replication` (hot-prefix balancing)** | ✅ longest-prefix overlap · persistent · **hot-prefix replication** |
 | vLLM/SGLang engine integration + disaggregated P/D | `QuillCacheV1Connector` (`KVConnectorBase_V1`) + `pd-proxy` router | ✅ **true vLLM-native P/D** (kv_producer/consumer, 2×L4-verified) |
 | Metrics / observability | gateway `/metrics` (Prometheus) | ✅ cache hits · transfers · refused reuse · SLO goodput |


### PR DESCRIPTION
The achievable production-gap closers from the review, each implemented + verified. The headline new one needed real hardware, which a local Ubuntu box (SoftRoCE) provided.

## ⓪ Real one-sided RDMA (ibverbs) — verified over SoftRoCE  ⭐ NEW
Mooncake's primary data path / core IP. `transport/rdma.rs` (behind `--features rdma`, raw `ibverbs-sys`) now opens an ibverbs device, registers MRs with remote access, connects an RC queue-pair (INIT→RTR→RTS, RoCEv2 GRH/GID), and does **RDMA WRITE + READ** by `(remote_addr, rkey)` — QuillCache's `(segment, offset)` model, kernel-bypass, no remote CPU. **Verified over SoftRoCE (rxe) on Ubuntu 24.04**: a 4 KB payload round-trips byte-identical through real verbs. Functional (software RoCE), a real NIC is a drop-in; the cross-node Transport-trait wiring is the remaining increment. Default build/CI unchanged (feature-gated off).

## ① Zero-copy GPU↔GPU peer data path (`cuMemcpyPeer`)
No-NIC equivalent of GPUDirect: HBM→HBM directly, no host bounce. **2×L4-verified**: correctness + **11.3 vs 2.6 GB/s = 4.4×** over host-staged.

## ② Hot-prefix replication scheduling
The Conductor-depth gap: a hot, singly-held prefix is spread to least-loaded workers (pure deterministic planner + `HotnessTracker`, wired into `ControlPlane`). 9 tests.

## ③ Observability: Prometheus `/metrics`
Cache effectiveness, the identity guard (refused reuse), SLO goodput, residency — as fleet totals.

## ④ Docs: Mooncake/Dynamo mapping refreshed
Now reflects HA, batch, admission, binned allocator, HBM tier, the peer path, replication, connector + true P/D, `/metrics`, and RDMA (verified over SoftRoCE).

## Verification
`cargo test` 88 pass; `fmt` + `clippy --all-targets` clean; `cuda` + `rdma` features compile-checked, `rdma` clippy-clean + the one-sided round-trip **passing over SoftRoCE** on the box; site builds. Still clearly reserved (need hardware/a team): cross-node RDMA Transport wiring + real NIC perf, multi-node/3FS, scale load-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cache hotspot replication for frequently accessed data prefixes
  * GPU peer-to-peer zero-copy transfers via CUDA P2P for improved transfer performance
  * Prometheus metrics endpoint exposing fleet-wide routing and cache statistics
  * RDMA one-sided transport support for network optimization

* **Documentation**
  * Updated architecture reference mapping with expanded component details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->