### PR TITLE
feat(store,transfer): faithful Mooncake alignment — offset_allocator, MasterService API, bounded QP pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "etcd-client",
  "quillcache-core",
  "quillcache-transfer-engine",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/README.md
+++ b/README.md
@@ -162,14 +162,18 @@ QuillCache makes the contract explicit: every block carries an `IdentityScope`
 (model · tokenizer · adapter · tenant), and the guard is enforced at **every**
 serving point — `LocalKvStore::get` and `DiskTier::get` (the byte tiers) and
 `MasterService::get_replica_list` (the metadata layer, *before* any byte moves) —
-refusing a cross-identity read with `ReuseViolation` rather than leaking. Mooncake
-keys are identity-agnostic; this is QuillCache's addition, and it is the same
-guard in memory, on disk, and after crash recovery.
+refusing a cross-identity read with `ReuseViolation` rather than leaking.
+Mooncake's store already isolates by `tenant_id`, but not by model / tokenizer /
+adapter — so QuillCache's addition is extending the guard to the **full**
+identity (the model / tokenizer / adapter correctness axes), enforced the same
+way in memory, on disk, and after crash recovery.
 
 ## Crash-consistent durable tier
 
-Mooncake's pool is volatile DRAM. QuillCache adds a durable `DiskTier` for `Disk`
-replicas, so KV bytes survive a restart — backed by `LocalKvStore`'s SSD tier,
+Mooncake's local byte-disk tier recovers by scanning on-disk files and trusting
+them by size — no per-block validation. QuillCache's `DiskTier` adds block-level
+integrity for `Disk` replicas, so KV bytes survive a restart **and** torn /
+half-written / corrupted blocks are caught — backed by `LocalKvStore`'s SSD tier,
 which uses NoKV-style **object-first atomic publish + a WAL**: write the block
 file → `fsync` → append + `fsync` a commit record (the single publish point). On
 `recover` the WAL is replayed and each surviving commit is verified against its
@@ -182,8 +186,10 @@ by test:
 - a **corrupted** block (length / CRC mismatch) is dropped on recovery;
 - a missing file never becomes a **dangling pointer** (no stale entries recovered).
 
-This is the seam Mooncake's volatile-DRAM pool does not occupy: a durable,
-crash-consistent, immediately-reusable persistent tier.
+This is the byte-tier integrity Mooncake's trust-by-size recovery does not
+provide: a durable, crash-consistent, immediately-reusable persistent tier.
+(Mooncake's *metadata* HA — its OpLog — is itself crash-consistent; this refines
+the *byte* tier it leaves unchecked.)
 
 ## Quick start
 

--- a/crates/quillcache-store/Cargo.toml
+++ b/crates/quillcache-store/Cargo.toml
@@ -11,6 +11,7 @@ quillcache-core = { version = "1.0.0-alpha.1", path = "../quillcache-core" }
 quillcache-transfer-engine = { version = "1.0.0-alpha.1", path = "../quillcache-transfer-engine" }
 bytes = "1"
 crc32fast = "1"
+regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quillcache-store/src/allocation_strategy.rs
+++ b/crates/quillcache-store/src/allocation_strategy.rs
@@ -139,13 +139,13 @@ pub fn create_allocation_strategy(name: &str) -> Box<dyn AllocationStrategy> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::OffsetBufferAllocator;
+    use crate::allocator::FirstFitBufferAllocator;
 
     fn fleet() -> Vec<Box<dyn BufferAllocator>> {
         vec![
-            Box::new(OffsetBufferAllocator::new("seg-0", 100)),
-            Box::new(OffsetBufferAllocator::new("seg-1", 100)),
-            Box::new(OffsetBufferAllocator::new("seg-2", 100)),
+            Box::new(FirstFitBufferAllocator::new("seg-0", 100)),
+            Box::new(FirstFitBufferAllocator::new("seg-1", 100)),
+            Box::new(FirstFitBufferAllocator::new("seg-2", 100)),
         ]
     }
 

--- a/crates/quillcache-store/src/allocator.rs
+++ b/crates/quillcache-store/src/allocator.rs
@@ -1,12 +1,14 @@
 //! Buffer allocator (Mooncake's `mooncake-store/include/allocator.h` +
 //! `offset_allocator/`). A mounted RAM segment is a fixed-size byte arena; the
-//! allocator hands out offset ranges within it. Two backends behind the
+//! allocator hands out offset ranges within it. The store's default is the
+//! faithful Aaltonen port in [`crate::offset_allocator`] (Mooncake's
+//! `OffsetBufferAllocator`); these are two simpler alternatives behind the
 //! [`BufferAllocator`] trait:
-//! - [`OffsetBufferAllocator`] — a first-fit free-list with coalescing-on-free
-//!   (simple, the default; alloc scans the free list).
-//! - [`BinnedBufferAllocator`] — Mooncake's size-binned design: free regions are
-//!   bucketed by size class and a bitmask finds the smallest fitting bin in O(1)
-//!   (alloc is O(1) bin-select; coalescing on free uses a by-offset index).
+//! - [`FirstFitBufferAllocator`] — a first-fit free-list with coalescing-on-free
+//!   (simple; alloc scans the free list — O(n)).
+//! - [`BinnedBufferAllocator`] — a 64-bin power-of-two approximation of the
+//!   offset allocator (O(1) bin-select via a `u64` bitmask, but the floor bin is
+//!   scanned for a fit; superseded by the faithful 256-bin port).
 
 use crate::types::SegmentName;
 use serde::{Deserialize, Serialize};
@@ -49,7 +51,7 @@ pub trait BufferAllocator: std::fmt::Debug + Send + Sync {
 /// First-fit offset allocator over a sorted free-list of `offset -> length`
 /// regions, coalescing adjacent free ranges on `deallocate`.
 #[derive(Debug)]
-pub struct OffsetBufferAllocator {
+pub struct FirstFitBufferAllocator {
     segment_name: SegmentName,
     capacity: u64,
     /// Non-overlapping free regions, keyed by offset (so neighbours are adjacent).
@@ -57,7 +59,7 @@ pub struct OffsetBufferAllocator {
     allocated: u64,
 }
 
-impl OffsetBufferAllocator {
+impl FirstFitBufferAllocator {
     pub fn new(segment_name: impl Into<SegmentName>, capacity: u64) -> Self {
         let mut free = BTreeMap::new();
         if capacity > 0 {
@@ -72,7 +74,7 @@ impl OffsetBufferAllocator {
     }
 }
 
-impl BufferAllocator for OffsetBufferAllocator {
+impl BufferAllocator for FirstFitBufferAllocator {
     fn segment_name(&self) -> &str {
         &self.segment_name
     }
@@ -167,7 +169,7 @@ impl BufferAllocator for OffsetBufferAllocator {
 /// bucketed by size class (bin `k` holds regions of size in `[2^k, 2^(k+1))`); a
 /// `u64` bitmask of non-empty bins finds the smallest fitting bin in O(1), so
 /// `allocate` does not scan the whole free list. Coalescing on `deallocate` uses
-/// a by-offset index. Same contract as [`OffsetBufferAllocator`].
+/// a by-offset index. Same contract as [`FirstFitBufferAllocator`].
 #[derive(Debug)]
 pub struct BinnedBufferAllocator {
     segment_name: SegmentName,
@@ -339,7 +341,7 @@ mod tests {
 
     #[test]
     fn allocate_split_and_fail_when_too_fragmented() {
-        let mut a = OffsetBufferAllocator::new("seg-0", 100);
+        let mut a = FirstFitBufferAllocator::new("seg-0", 100);
         let b1 = a.allocate(40).unwrap();
         assert_eq!(b1.offset, 0);
         let b2 = a.allocate(40).unwrap();
@@ -352,7 +354,7 @@ mod tests {
 
     #[test]
     fn deallocate_coalesces_adjacent_free_regions() {
-        let mut a = OffsetBufferAllocator::new("seg-0", 100);
+        let mut a = FirstFitBufferAllocator::new("seg-0", 100);
         let b1 = a.allocate(50).unwrap(); // [0,50)
         let b2 = a.allocate(50).unwrap(); // [50,100) — segment full
         assert_eq!(a.largest_free_region(), 0);

--- a/crates/quillcache-store/src/count_min_sketch.rs
+++ b/crates/quillcache-store/src/count_min_sketch.rs
@@ -1,0 +1,163 @@
+//! Count-Min Sketch (Mooncake's `mooncake-store/include/count_min_sketch.h`) —
+//! a compact, approximate key-frequency counter. Mooncake uses it for the
+//! frequency-admission policy (whether a key is hot enough to promote into the
+//! local hot cache); the [`crate::MasterService`] records every guarded `get` so
+//! eviction / promotion can favour hot keys over a pure LRU.
+//!
+//! `depth` independent rows × `width` `u8` counters; `increment`/`count` take the
+//! **min** across rows (the CMS estimate, which never under-counts). Counters
+//! saturate at 255 and all halve (`>>= 1`) once `width * depth` increments have
+//! accumulated, so the sketch ages instead of saturating — a faithful port,
+//! single-threaded (the master holds its own lock, so no internal mutex).
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+const DEFAULT_WIDTH: usize = 4096;
+const DEFAULT_DEPTH: usize = 4;
+
+/// Approximate frequency counter over string keys.
+#[derive(Debug)]
+pub struct CountMinSketch {
+    width: usize,
+    depth: usize,
+    table: Vec<Vec<u8>>,
+    total_increments: usize,
+}
+
+impl Default for CountMinSketch {
+    fn default() -> Self {
+        Self::new(DEFAULT_WIDTH, DEFAULT_DEPTH)
+    }
+}
+
+impl CountMinSketch {
+    /// `width` counters per row × `depth` rows. Zero falls back to the defaults
+    /// (4096 × 4), matching Mooncake.
+    pub fn new(width: usize, depth: usize) -> Self {
+        let width = if width > 0 { width } else { DEFAULT_WIDTH };
+        let depth = if depth > 0 { depth } else { DEFAULT_DEPTH };
+        Self {
+            width,
+            depth,
+            table: vec![vec![0u8; width]; depth],
+            total_increments: 0,
+        }
+    }
+
+    /// Per-row hash: a base hash of the key mixed with the row seed (fmix64
+    /// finalizer), so each row is an independent hash — faithfully Mooncake's.
+    fn hash(&self, key: &str, seed: usize) -> usize {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let mut h = hasher.finish();
+        h ^= (seed as u64)
+            .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+            .wrapping_add(0x517c_c1b7_2722_0a95);
+        h ^= h >> 33;
+        h = h.wrapping_mul(0xff51_afd7_ed55_8ccd);
+        h ^= h >> 33;
+        h as usize
+    }
+
+    /// Increment `key`'s count and return the (post-increment) min estimate.
+    /// Triggers a decay once `width * depth` increments accumulate.
+    pub fn increment(&mut self, key: &str) -> u8 {
+        let mut min_val = u8::MAX;
+        for i in 0..self.depth {
+            let idx = self.hash(key, i) % self.width;
+            // Saturating: counters cap at 255 (Mooncake's `< UINT8_MAX` guard).
+            self.table[i][idx] = self.table[i][idx].saturating_add(1);
+            min_val = min_val.min(self.table[i][idx]);
+        }
+        self.total_increments += 1;
+        if self.total_increments >= self.width * self.depth {
+            self.decay();
+        }
+        min_val
+    }
+
+    /// The estimated count for `key` (read-only; the min across rows).
+    pub fn count(&self, key: &str) -> u8 {
+        let mut min_val = u8::MAX;
+        for i in 0..self.depth {
+            let idx = self.hash(key, i) % self.width;
+            min_val = min_val.min(self.table[i][idx]);
+        }
+        min_val
+    }
+
+    /// Halve every counter (periodic aging). Resets the decay accumulator.
+    pub fn decay(&mut self) {
+        for row in &mut self.table {
+            for counter in row.iter_mut() {
+                *counter >>= 1;
+            }
+        }
+        self.total_increments = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_grow_with_repeated_increments() {
+        let mut cms = CountMinSketch::new(256, 4);
+        assert_eq!(cms.count("a"), 0);
+        for expected in 1..=10u8 {
+            assert_eq!(cms.increment("a"), expected);
+        }
+        assert_eq!(cms.count("a"), 10);
+        // An un-incremented key reads ~0 (no collisions in a 256-wide sketch).
+        assert_eq!(cms.count("never"), 0);
+    }
+
+    #[test]
+    fn hotter_keys_estimate_higher() {
+        let mut cms = CountMinSketch::new(1024, 4);
+        for _ in 0..50 {
+            cms.increment("hot");
+        }
+        for _ in 0..3 {
+            cms.increment("cold");
+        }
+        assert!(cms.count("hot") > cms.count("cold"));
+    }
+
+    #[test]
+    fn counters_saturate_without_overflow() {
+        let mut cms = CountMinSketch::new(1024, 4); // big enough: no auto-decay
+        for _ in 0..500 {
+            cms.increment("x");
+        }
+        assert_eq!(
+            cms.count("x"),
+            u8::MAX,
+            "counter saturates at 255, never wraps"
+        );
+    }
+
+    #[test]
+    fn decay_halves_counters() {
+        let mut cms = CountMinSketch::new(1024, 4);
+        for _ in 0..40 {
+            cms.increment("x");
+        }
+        let before = cms.count("x");
+        cms.decay();
+        assert_eq!(cms.count("x"), before / 2);
+    }
+
+    #[test]
+    fn auto_decay_keeps_counters_bounded() {
+        // Tiny sketch: width*depth = 4, so decay fires every 4 increments.
+        let mut cms = CountMinSketch::new(2, 2);
+        for _ in 0..100 {
+            cms.increment("x");
+        }
+        // Without aging this would have saturated; auto-decay keeps it small.
+        assert!(cms.count("x") < u8::MAX);
+    }
+}

--- a/crates/quillcache-store/src/disk_tier.rs
+++ b/crates/quillcache-store/src/disk_tier.rs
@@ -1,8 +1,10 @@
 //! Crash-consistent durable tier for the store's `Disk` replicas — QuillCache's
-//! persistent, immediately-reusable tier. **Mooncake's pool is volatile DRAM**,
-//! so a durable replica surviving a process restart is our 2nd differentiator
-//! (the seam from the novelty positioning: the safety invariant held across
-//! tiering / eviction / crash-recovery).
+//! persistent, immediately-reusable tier. **Mooncake's local byte tier recovers
+//! by trusting on-disk files by size**, so block-level integrity on recovery
+//! (WAL + CRC, dropping torn / half-written / corrupt blocks) is our 2nd
+//! differentiator (the seam from the novelty positioning: the safety invariant
+//! held across tiering / eviction / crash-recovery). Mooncake's *metadata* HA is
+//! itself crash-consistent; this refines the *byte* tier.
 //!
 //! It reuses [`LocalKvStore`]'s SSD tier — object-first atomic publish (file
 //! fsynced, then a single WAL commit fsynced) + recover-on-reopen + the identity

--- a/crates/quillcache-store/src/lib.rs
+++ b/crates/quillcache-store/src/lib.rs
@@ -15,8 +15,8 @@
 //!   buffer) or `Disk` (a durable file-backed replica).
 //! - Byte movement is the `quillcache-transfer-engine` crate (segment/offset).
 //!
-//! What QuillCache adds over Mooncake (whose keys are identity-agnostic and whose
-//! pool is volatile DRAM):
+//! What QuillCache adds over Mooncake (which isolates by `tenant_id` only, and
+//! whose local byte tier recovers by trusting on-disk files by size):
 //! - the **identity guard** — a replica is served only when the requester's
 //!   model · tokenizer · adapter · tenant matches the writer's (woven into
 //!   [`MasterService::get_replica_list`] and [`DiskTier`]);
@@ -45,10 +45,12 @@ use std::path::PathBuf;
 pub mod allocation_strategy;
 pub mod allocator;
 pub mod client;
+pub mod count_min_sketch;
 pub mod disk_tier;
 #[cfg(feature = "etcd")]
 pub mod master_election;
 pub mod master_service;
+pub mod offset_allocator;
 pub mod replica;
 pub mod types;
 
@@ -56,12 +58,14 @@ pub use allocation_strategy::{
     create_allocation_strategy, AllocationStrategy, FreeRatioFirstAllocationStrategy,
     RandomAllocationStrategy,
 };
-pub use allocator::{AllocatedBuffer, BufferAllocator, OffsetBufferAllocator};
+pub use allocator::{AllocatedBuffer, BufferAllocator, FirstFitBufferAllocator};
 pub use client::{DummyClient, RealClient};
+pub use count_min_sketch::CountMinSketch;
 pub use disk_tier::DiskTier;
 #[cfg(feature = "etcd")]
 pub use master_election::{Leadership, MasterElection};
 pub use master_service::{MasterService, MasterSnapshot, ObjectSnapshot, SegmentSnapshot};
+pub use offset_allocator::{Allocation, OffsetAllocator, OffsetBufferAllocator};
 pub use replica::{Replica, ReplicaData, ReplicaList, ReplicaStatus};
 pub use types::{ErrorCode, ObjectKey, ReplicaId, ReplicateConfig, SegmentName, Slice};
 

--- a/crates/quillcache-store/src/master_service.rs
+++ b/crates/quillcache-store/src/master_service.rs
@@ -14,14 +14,18 @@
 //!
 //! **QuillCache's identity guard** is woven into [`MasterService::get_replica_list`]:
 //! each object records the [`IdentityScope`] that wrote it, and a get from a
-//! mismatched identity is refused with [`ErrorCode::UnsafeReuse`] — Mooncake keys
-//! are identity-agnostic, so this is our addition.
+//! mismatched identity is refused with [`ErrorCode::UnsafeReuse`] — Mooncake
+//! isolates by `tenant_id` but not by model / tokenizer / adapter, so extending
+//! the guard to the full identity is our addition.
 
 use crate::allocation_strategy::{create_allocation_strategy, AllocationStrategy};
-use crate::allocator::{AllocatedBuffer, BufferAllocator, OffsetBufferAllocator};
+use crate::allocator::{AllocatedBuffer, BufferAllocator};
+use crate::count_min_sketch::CountMinSketch;
+use crate::offset_allocator::OffsetBufferAllocator;
 use crate::replica::{Replica, ReplicaData, ReplicaList, ReplicaStatus};
 use crate::types::{ErrorCode, ObjectKey, ReplicaId, ReplicateConfig, SegmentName};
 use quillcache_core::IdentityScope;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -102,6 +106,9 @@ pub struct MasterService {
     /// Ticks a segment may miss before it is treated as dead. `0` disables the
     /// health check (every mounted segment is considered alive).
     segment_ttl: u64,
+    /// Approximate per-key access frequency (Mooncake's CountMinSketch), bumped on
+    /// every guarded read so eviction / promotion can favour hot keys.
+    hotness: CountMinSketch,
 }
 
 impl MasterService {
@@ -118,6 +125,7 @@ impl MasterService {
             eviction_ratio: 0.1,
             segment_heartbeat: HashMap::new(),
             segment_ttl: 0,
+            hotness: CountMinSketch::default(),
         }
     }
 
@@ -267,6 +275,8 @@ impl MasterService {
     ) -> Result<Vec<Replica>, ErrorCode> {
         let now = self.clock;
         let lease_ttl = self.lease_ttl;
+        // Record this access in the frequency sketch (hot-key tracking).
+        self.hotness.increment(key);
         // Failure detection: a Memory replica on a segment whose node stopped
         // heartbeating is treated as lost; a Disk replica is durable, so kept.
         let alive: HashSet<String> = self
@@ -338,6 +348,78 @@ impl MasterService {
         Ok(())
     }
 
+    /// Revoke many in-flight Puts (free their allocations). Errors on the first
+    /// key not in flight.
+    pub fn batch_put_revoke(&mut self, keys: &[String]) -> Result<(), ErrorCode> {
+        for key in keys {
+            self.put_revoke(key)?;
+        }
+        Ok(())
+    }
+
+    // ---- upsert (Mooncake's UpsertStart/End/Revoke) ----
+
+    /// Mooncake's `UpsertStart`. If the key is absent (or only in-flight) this is
+    /// [`Self::put_start`]. If it exists complete at the **same** size, reuse its
+    /// buffers in place — return them and flip the replicas back to `Initialized`
+    /// so the client rewrites them (no re-allocation). If the size **differs**,
+    /// free the old replicas and allocate new ones. Refused with
+    /// [`ErrorCode::ObjectNotReady`] while a read lease is active (the object is
+    /// busy), mirroring Mooncake's `OBJECT_REPLICA_BUSY`.
+    pub fn upsert_start(
+        &mut self,
+        key: ObjectKey,
+        identity: IdentityScope,
+        size: u64,
+        config: &ReplicateConfig,
+    ) -> Result<Vec<AllocatedBuffer>, ErrorCode> {
+        let (exists_complete, leased, existing_size) = match self.objects.get(&key) {
+            None => (false, false, 0),
+            Some(o) => (
+                o.has_complete_replica(),
+                o.lease_until > self.clock,
+                o.replicas.values().next().map(|r| r.size()).unwrap_or(0),
+            ),
+        };
+        if !exists_complete {
+            // Absent or only an in-flight leftover — PutStart reclaims + allocates.
+            return self.put_start(key, identity, size, config);
+        }
+        if leased {
+            return Err(ErrorCode::ObjectNotReady);
+        }
+        if existing_size == size {
+            // In-place: reuse the existing buffers, re-open for writing.
+            let now = self.clock;
+            let object = self.objects.get_mut(&key).expect("object present");
+            object.identity = identity;
+            object.last_access = now;
+            let mut buffers = Vec::new();
+            for replica in object.replicas.values_mut() {
+                replica.status = ReplicaStatus::Initialized;
+                if let ReplicaData::Memory(buffer) = &replica.data {
+                    buffers.push(buffer.clone());
+                }
+            }
+            Ok(buffers)
+        } else {
+            // Size changed: free the old replicas, then allocate fresh.
+            let old = self.objects.remove(&key).expect("object present");
+            self.free_replicas(&old.replicas);
+            self.put_start(key, identity, size, config)
+        }
+    }
+
+    /// Mooncake's `UpsertEnd` — same as committing a Put.
+    pub fn upsert_end(&mut self, key: &str) -> Result<(), ErrorCode> {
+        self.put_end(key)
+    }
+
+    /// Mooncake's `UpsertRevoke` — same as aborting a Put.
+    pub fn upsert_revoke(&mut self, key: &str) -> Result<(), ErrorCode> {
+        self.put_revoke(key)
+    }
+
     /// Identity-guarded Get for many keys. Errors on the first key that is
     /// missing / not ready / refused (the connector wants all of a prefix's
     /// layers, or it recomputes the prefix).
@@ -357,6 +439,38 @@ impl MasterService {
         self.objects
             .get(key)
             .is_some_and(ObjectMetadata::has_complete_replica)
+    }
+
+    /// Existence for many keys in one call (Mooncake's `BatchExistKey`).
+    pub fn batch_exist_key(&self, keys: &[String]) -> Vec<bool> {
+        keys.iter().map(|k| self.exist_key(k)).collect()
+    }
+
+    /// Mooncake's `GetReplicaListByRegex`: every object whose key matches
+    /// `pattern` and whose identity the requester is allowed to read, mapped to
+    /// its complete replicas. Cross-identity matches are skipped (the guard), not
+    /// errored — a bulk query returns what the caller may see.
+    pub fn get_replica_list_by_regex(
+        &mut self,
+        pattern: &str,
+        requester: &IdentityScope,
+    ) -> Result<HashMap<String, Vec<Replica>>, ErrorCode> {
+        let re = Regex::new(pattern).map_err(|e| ErrorCode::Io(format!("bad regex: {e}")))?;
+        // Collect matching keys first so the &mut get_replica_list calls don't
+        // alias the iteration over `objects`.
+        let keys: Vec<String> = self
+            .objects
+            .keys()
+            .filter(|k| re.is_match(k))
+            .cloned()
+            .collect();
+        let mut out = HashMap::new();
+        for key in keys {
+            if let Ok(replicas) = self.get_replica_list(&key, requester) {
+                out.insert(key, replicas);
+            }
+        }
+        Ok(out)
     }
 
     /// Remove an object and free its replicas. Blocked while a read lease is
@@ -387,6 +501,12 @@ impl MasterService {
     }
     pub fn allocated(&self) -> u64 {
         self.allocators.iter().map(|a| a.allocated()).sum()
+    }
+
+    /// Approximate access frequency for `key` (Mooncake's CountMinSketch
+    /// estimate) — how hot the key is, for frequency-aware eviction / promotion.
+    pub fn hotness(&self, key: &str) -> u8 {
+        self.hotness.count(key)
     }
 
     // ---- HA: snapshot + recovery (Mooncake's metadata snapshot thread) ----
@@ -879,5 +999,137 @@ mod tests {
             .is_err());
         assert_eq!(m.object_count(), 0);
         assert_eq!(m.allocated(), 0);
+    }
+
+    #[test]
+    fn upsert_reuses_buffers_in_place_when_size_unchanged() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        let bufs = m
+            .put_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("k").unwrap();
+        let off = bufs[0].offset;
+        let used = m.allocated();
+        // Same size → reuse the buffer in place, no extra allocation.
+        let bufs2 = m
+            .upsert_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        assert_eq!(bufs2[0].offset, off, "in-place upsert reuses the buffer");
+        assert_eq!(
+            m.allocated(),
+            used,
+            "no re-allocation for a same-size upsert"
+        );
+        assert!(!m.exist_key("k"), "re-opened for writing until committed");
+        m.upsert_end("k").unwrap();
+        assert!(m.exist_key("k"));
+    }
+
+    #[test]
+    fn upsert_reallocates_when_size_changes() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        m.put_start("k".into(), id.clone(), 40, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("k").unwrap();
+        assert_eq!(m.allocated(), 40);
+        m.upsert_start("k".into(), id.clone(), 100, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.upsert_end("k").unwrap();
+        assert_eq!(m.allocated(), 100, "size change frees old + allocates new");
+    }
+
+    #[test]
+    fn upsert_is_refused_while_leased() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        m.put_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("k").unwrap();
+        m.get_replica_list("k", &id).unwrap(); // grants a read lease → busy
+        assert_eq!(
+            m.upsert_start("k".into(), id.clone(), 64, &ReplicateConfig::replicas(1)),
+            Err(ErrorCode::ObjectNotReady)
+        );
+    }
+
+    #[test]
+    fn get_replica_list_by_regex_matches_allowed_keys_only() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let a = scope("ten-a");
+        let b = scope("ten-b");
+        for k in ["qc/a/1", "qc/a/2", "other"] {
+            m.put_start(k.into(), a.clone(), 16, &ReplicateConfig::replicas(1))
+                .unwrap();
+            m.put_end(k).unwrap();
+        }
+        // Same-pattern key under a different tenant must NOT leak to tenant-a.
+        m.put_start("qc/a/secret".into(), b, 16, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("qc/a/secret").unwrap();
+
+        let got = m.get_replica_list_by_regex("^qc/a/.*", &a).unwrap();
+        let mut keys: Vec<&str> = got.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["qc/a/1", "qc/a/2"]);
+    }
+
+    #[test]
+    fn batch_exist_key_reports_committed_only() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        let items = vec![
+            ("a".to_string(), id.clone(), 16u64),
+            ("b".to_string(), id.clone(), 16u64),
+        ];
+        m.batch_put_start(items, &ReplicateConfig::replicas(1))
+            .unwrap();
+        assert_eq!(
+            m.batch_exist_key(&["a".into(), "b".into()]),
+            vec![false, false]
+        );
+        m.batch_put_end(&["a".into(), "b".into()]).unwrap();
+        assert_eq!(
+            m.batch_exist_key(&["a".into(), "b".into(), "z".into()]),
+            vec![true, true, false]
+        );
+    }
+
+    #[test]
+    fn batch_put_revoke_frees_inflight() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        let items = vec![
+            ("a".to_string(), id.clone(), 16u64),
+            ("b".to_string(), id, 16u64),
+        ];
+        m.batch_put_start(items, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.batch_put_revoke(&["a".into(), "b".into()]).unwrap();
+        assert_eq!(m.allocated(), 0);
+        assert_eq!(m.object_count(), 0);
+    }
+
+    #[test]
+    fn guarded_reads_bump_key_hotness() {
+        let mut m = MasterService::new("random");
+        m.mount_segment("seg-0", 1000);
+        let id = scope("ten-a");
+        m.put_start("hot".into(), id.clone(), 16, &ReplicateConfig::replicas(1))
+            .unwrap();
+        m.put_end("hot").unwrap();
+        assert_eq!(m.hotness("hot"), 0);
+        for _ in 0..5 {
+            m.get_replica_list("hot", &id).unwrap();
+        }
+        assert_eq!(m.hotness("hot"), 5, "each guarded read bumps the sketch");
+        assert_eq!(m.hotness("cold"), 0);
     }
 }

--- a/crates/quillcache-store/src/offset_allocator.rs
+++ b/crates/quillcache-store/src/offset_allocator.rs
@@ -1,0 +1,844 @@
+//! Faithful Rust port of Sebastian Aaltonen's OffsetAllocator (MIT, 2023) — the
+//! exact allocator Mooncake wraps in `OffsetBufferAllocator`
+//! (`mooncake-store/src/offset_allocator.cpp`).
+//!
+//! Hard real-time **O(1)** allocate/free. Free regions are bucketed into 256
+//! "small float" size bins (`NUM_TOP_BINS=32` × `BINS_PER_LEAF=8`); a two-level
+//! bitmap (`used_bins_top: u32` + `used_bins[32]: u8`) finds the smallest fitting
+//! bin with two bit-scans, and an intrusive node pool with neighbour links gives
+//! O(1) coalescing on free. This is strictly more faithful than the project's
+//! earlier `BinnedBufferAllocator` (64 power-of-2 bins, BTree free-lists, a scan
+//! within the floor bin): the 3-bit mantissa rounds each request *up* to a bin
+//! whose every member fits, so allocate never scans.
+//!
+//! Ported line-for-line from the C++; including Mooncake's one modification —
+//! rounding an allocation's stored size up to the bin size so a later free lands
+//! back in the same bin (`OFFSET_ALLOCATOR_NOT_ROUND_UP` off by default there).
+
+use crate::allocator::{AllocatedBuffer, BufferAllocator};
+use crate::types::SegmentName;
+use std::collections::HashMap;
+
+const NUM_TOP_BINS: usize = 32;
+const BINS_PER_LEAF: usize = 8;
+const TOP_BINS_INDEX_SHIFT: u32 = 3;
+const LEAF_BINS_INDEX_MASK: u32 = 0x7;
+const NUM_LEAF_BINS: usize = NUM_TOP_BINS * BINS_PER_LEAF; // 256
+
+/// Sentinel for "no node" / "no free space" (C++ `Node::unused` / `NO_SPACE`).
+const UNUSED: u32 = 0xffff_ffff;
+
+/// `mooncake::offset_allocator::SmallFloat` — an 8-bit float (5-bit exponent +
+/// 3-bit mantissa) binning so each size class carries the same average overhead.
+mod small_float {
+    pub const MANTISSA_BITS: u32 = 3;
+    pub const MANTISSA_VALUE: u32 = 1 << MANTISSA_BITS; // 8
+    pub const MANTISSA_MASK: u32 = MANTISSA_VALUE - 1;
+    /// Largest size a single core allocator addresses (3.75 GiB); above this the
+    /// outer `OffsetAllocator` scales sizes down by `multiplier_bits`.
+    pub const MAX_BIN_SIZE: u64 = 4_026_531_840;
+
+    /// Round a size **up** to the smallest bin index that still fits it.
+    pub fn uint_to_float_round_up(size: u32) -> u32 {
+        let mut exp = 0u32;
+        let mut mantissa;
+        if size < MANTISSA_VALUE {
+            mantissa = size; // denorm: 0..(MANTISSA_VALUE-1)
+        } else {
+            // Normalized: hidden high bit always 1, not stored (just like float).
+            let highest_set_bit = 31 - size.leading_zeros();
+            let mantissa_start_bit = highest_set_bit - MANTISSA_BITS;
+            exp = mantissa_start_bit + 1;
+            mantissa = (size >> mantissa_start_bit) & MANTISSA_MASK;
+            let low_bits_mask = (1u32 << mantissa_start_bit) - 1;
+            // Round up!
+            if (size & low_bits_mask) != 0 {
+                mantissa += 1;
+            }
+        }
+        // `+` (not `|`) lets a mantissa overflow carry into the exponent.
+        (exp << MANTISSA_BITS) + mantissa
+    }
+
+    /// Round a size **down** to the largest bin index it covers.
+    pub fn uint_to_float_round_down(size: u32) -> u32 {
+        let mut exp = 0u32;
+        let mantissa;
+        if size < MANTISSA_VALUE {
+            mantissa = size;
+        } else {
+            let highest_set_bit = 31 - size.leading_zeros();
+            let mantissa_start_bit = highest_set_bit - MANTISSA_BITS;
+            exp = mantissa_start_bit + 1;
+            mantissa = (size >> mantissa_start_bit) & MANTISSA_MASK;
+        }
+        (exp << MANTISSA_BITS) | mantissa
+    }
+
+    /// Inverse: the byte size a bin index represents.
+    pub fn float_to_uint(float_value: u32) -> u32 {
+        let exponent = float_value >> MANTISSA_BITS;
+        let mantissa = float_value & MANTISSA_MASK;
+        if exponent == 0 {
+            mantissa // denorms
+        } else {
+            (mantissa | MANTISSA_VALUE) << (exponent - 1)
+        }
+    }
+}
+
+/// Lowest set bit at-or-after `start_bit_index`, or [`UNUSED`] if none.
+fn find_lowest_set_bit_after(bit_mask: u32, start_bit_index: u32) -> u32 {
+    if start_bit_index >= 32 {
+        return UNUSED;
+    }
+    let mask_before_start = (1u32 << start_bit_index) - 1;
+    let bits_after = bit_mask & !mask_before_start;
+    if bits_after == 0 {
+        return UNUSED;
+    }
+    bits_after.trailing_zeros()
+}
+
+/// The result of an allocation: where it sits (`offset`) plus the node index that
+/// owns it (`metadata`), which `free` needs. Mirrors C++ `OffsetAllocation`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OffsetAllocation {
+    pub offset: u32,
+    pub metadata: u32,
+}
+
+impl OffsetAllocation {
+    pub const NO_SPACE: u32 = UNUSED;
+
+    pub fn is_no_space(&self) -> bool {
+        self.metadata == Self::NO_SPACE
+    }
+}
+
+/// A free or allocated region. Two intrusive doubly-linked lists thread through
+/// the pool: `bin_list_*` (other regions in the same size bin) and `neighbor_*`
+/// (the physically adjacent regions, for O(1) coalescing on free).
+#[derive(Debug, Clone, Copy)]
+struct Node {
+    data_offset: u32,
+    data_size: u32,
+    bin_list_prev: u32,
+    bin_list_next: u32,
+    neighbor_prev: u32,
+    neighbor_next: u32,
+    used: bool,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            data_offset: 0,
+            data_size: 0,
+            bin_list_prev: UNUSED,
+            bin_list_next: UNUSED,
+            neighbor_prev: UNUSED,
+            neighbor_next: UNUSED,
+            used: false,
+        }
+    }
+}
+
+/// Free-space totals (C++ `OffsetAllocStorageReport`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorageReport {
+    pub total_free_space: u32,
+    pub largest_free_region: u32,
+}
+
+/// The core allocator (C++ `__Allocator`), addressing a `[0, size)` span in
+/// abstract units. The `nodes`/`free_nodes` pool grows lazily up to
+/// `max_capacity`.
+#[derive(Debug)]
+pub struct CoreAllocator {
+    size: u32,
+    current_capacity: u32,
+    max_capacity: u32,
+    free_storage: u32,
+    used_bins_top: u32,
+    used_bins: [u8; NUM_TOP_BINS],
+    bin_indices: [u32; NUM_LEAF_BINS],
+    nodes: Vec<Node>,
+    /// Free-node stack: `free_nodes[free_offset]` is the next index to hand out.
+    free_nodes: Vec<u32>,
+    free_offset: u32,
+}
+
+impl CoreAllocator {
+    pub fn new(size: u32, init_capacity: u32, max_capacity: u32) -> Self {
+        let mut a = Self {
+            size,
+            current_capacity: init_capacity,
+            max_capacity: init_capacity.max(max_capacity),
+            free_storage: 0,
+            used_bins_top: 0,
+            used_bins: [0; NUM_TOP_BINS],
+            bin_indices: [UNUSED; NUM_LEAF_BINS],
+            nodes: Vec::new(),
+            free_nodes: Vec::new(),
+            free_offset: 0,
+        };
+        a.reset();
+        a
+    }
+
+    fn reset(&mut self) {
+        self.free_storage = 0;
+        self.used_bins_top = 0;
+        self.free_offset = 0;
+        self.used_bins = [0; NUM_TOP_BINS];
+        self.bin_indices = [UNUSED; NUM_LEAF_BINS];
+
+        self.nodes.clear();
+        self.free_nodes.clear();
+        self.nodes.reserve(self.max_capacity as usize);
+        self.free_nodes.reserve(self.max_capacity as usize);
+        self.nodes
+            .resize(self.current_capacity as usize, Node::default());
+        self.free_nodes.resize(self.current_capacity as usize, 0);
+        // Freelist is a stack; fill so index 0 pops first.
+        for i in 0..self.current_capacity {
+            self.free_nodes[i as usize] = i;
+        }
+
+        // Start state: the whole span as one big free node.
+        self.insert_node_into_bin(self.size, 0);
+    }
+
+    /// Allocate `size` units; [`OffsetAllocation::is_no_space`] on failure.
+    pub fn allocate(&mut self, size: u32) -> OffsetAllocation {
+        // Out of node handles?
+        if self.free_offset == self.max_capacity {
+            return OffsetAllocation {
+                offset: UNUSED,
+                metadata: UNUSED,
+            };
+        }
+        if self.free_offset == self.current_capacity {
+            self.free_nodes.push(self.current_capacity);
+            self.nodes.push(Node::default());
+            self.current_capacity += 1;
+        }
+
+        // Round up to a bin whose every member fits, then find the smallest
+        // non-empty such bin via the two-level bitmap.
+        let min_bin_index = small_float::uint_to_float_round_up(size);
+        let min_top_bin_index = min_bin_index >> TOP_BINS_INDEX_SHIFT;
+        let min_leaf_bin_index = min_bin_index & LEAF_BINS_INDEX_MASK;
+
+        let mut top_bin_index = min_top_bin_index;
+        let mut leaf_bin_index = UNUSED;
+
+        // If that top bin has any leaves, scan from the rounded-up leaf.
+        if self.used_bins_top & (1 << top_bin_index) != 0 {
+            leaf_bin_index = find_lowest_set_bit_after(
+                self.used_bins[top_bin_index as usize] as u32,
+                min_leaf_bin_index,
+            );
+        }
+
+        // Otherwise search the next non-empty top bin (its leaves all fit).
+        if leaf_bin_index == UNUSED {
+            top_bin_index = find_lowest_set_bit_after(self.used_bins_top, min_top_bin_index + 1);
+            if top_bin_index == UNUSED {
+                return OffsetAllocation {
+                    offset: UNUSED,
+                    metadata: UNUSED,
+                };
+            }
+            // The top bit was set, so at least one leaf bit is set — can't fail.
+            leaf_bin_index = (self.used_bins[top_bin_index as usize] as u32).trailing_zeros();
+        }
+
+        let bin_index = (top_bin_index << TOP_BINS_INDEX_SHIFT) | leaf_bin_index;
+
+        // Pop the bin's head node.
+        let node_index = self.bin_indices[bin_index as usize];
+        let node_total_size = self.nodes[node_index as usize].data_size;
+        let node_data_offset = self.nodes[node_index as usize].data_offset;
+        let node_bin_list_next = self.nodes[node_index as usize].bin_list_next;
+        let node_neighbor_next = self.nodes[node_index as usize].neighbor_next;
+
+        // Mooncake modification: store the bin-rounded size so a later free lands
+        // back in this same bin instead of a smaller one.
+        let roundup_size = small_float::float_to_uint(min_bin_index);
+        self.nodes[node_index as usize].data_size = roundup_size;
+        self.nodes[node_index as usize].used = true;
+
+        self.bin_indices[bin_index as usize] = node_bin_list_next;
+        if node_bin_list_next != UNUSED {
+            self.nodes[node_bin_list_next as usize].bin_list_prev = UNUSED;
+        }
+        self.free_storage -= node_total_size;
+
+        // Bin emptied? Clear the leaf bit, and the top bit if all leaves gone.
+        if self.bin_indices[bin_index as usize] == UNUSED {
+            self.used_bins[top_bin_index as usize] &= !(1 << leaf_bin_index);
+            if self.used_bins[top_bin_index as usize] == 0 {
+                self.used_bins_top &= !(1 << top_bin_index);
+            }
+        }
+
+        // Push the remainder back as a smaller free node, linked as our neighbour.
+        let reminder_size = node_total_size - roundup_size;
+        if reminder_size > 0 {
+            let new_node_index =
+                self.insert_node_into_bin(reminder_size, node_data_offset + roundup_size);
+            if node_neighbor_next != UNUSED {
+                self.nodes[node_neighbor_next as usize].neighbor_prev = new_node_index;
+            }
+            self.nodes[new_node_index as usize].neighbor_prev = node_index;
+            self.nodes[new_node_index as usize].neighbor_next = node_neighbor_next;
+            self.nodes[node_index as usize].neighbor_next = new_node_index;
+        }
+
+        OffsetAllocation {
+            offset: node_data_offset,
+            metadata: node_index,
+        }
+    }
+
+    /// Free a prior allocation, coalescing with free physical neighbours.
+    pub fn free(&mut self, allocation: OffsetAllocation) {
+        debug_assert!(allocation.metadata != UNUSED);
+        if self.nodes.is_empty() {
+            return;
+        }
+        let node_index = allocation.metadata;
+        debug_assert!(self.nodes[node_index as usize].used);
+
+        let mut offset = self.nodes[node_index as usize].data_offset;
+        let mut size = self.nodes[node_index as usize].data_size;
+
+        // Merge with the previous physical neighbour if it is free.
+        let neighbor_prev = self.nodes[node_index as usize].neighbor_prev;
+        if neighbor_prev != UNUSED && !self.nodes[neighbor_prev as usize].used {
+            offset = self.nodes[neighbor_prev as usize].data_offset;
+            size += self.nodes[neighbor_prev as usize].data_size;
+            self.remove_node_from_bin(neighbor_prev);
+            self.nodes[node_index as usize].neighbor_prev =
+                self.nodes[neighbor_prev as usize].neighbor_prev;
+        }
+
+        // Merge with the next physical neighbour if it is free.
+        let neighbor_next = self.nodes[node_index as usize].neighbor_next;
+        if neighbor_next != UNUSED && !self.nodes[neighbor_next as usize].used {
+            size += self.nodes[neighbor_next as usize].data_size;
+            self.remove_node_from_bin(neighbor_next);
+            self.nodes[node_index as usize].neighbor_next =
+                self.nodes[neighbor_next as usize].neighbor_next;
+        }
+
+        let final_neighbor_next = self.nodes[node_index as usize].neighbor_next;
+        let final_neighbor_prev = self.nodes[node_index as usize].neighbor_prev;
+
+        // Return the node to the freelist, then re-insert the combined region.
+        self.free_offset -= 1;
+        self.free_nodes[self.free_offset as usize] = node_index;
+        let combined_node_index = self.insert_node_into_bin(size, offset);
+
+        // Relink the combined node with the surviving neighbours.
+        if final_neighbor_next != UNUSED {
+            self.nodes[combined_node_index as usize].neighbor_next = final_neighbor_next;
+            self.nodes[final_neighbor_next as usize].neighbor_prev = combined_node_index;
+        }
+        if final_neighbor_prev != UNUSED {
+            self.nodes[combined_node_index as usize].neighbor_prev = final_neighbor_prev;
+            self.nodes[final_neighbor_prev as usize].neighbor_next = combined_node_index;
+        }
+    }
+
+    fn insert_node_into_bin(&mut self, size: u32, data_offset: u32) -> u32 {
+        // Round down so the bin's size class is <= the region (every member fits).
+        let bin_index = small_float::uint_to_float_round_down(size);
+        let top_bin_index = bin_index >> TOP_BINS_INDEX_SHIFT;
+        let leaf_bin_index = bin_index & LEAF_BINS_INDEX_MASK;
+
+        // Bin was empty? Set both bitmap levels.
+        if self.bin_indices[bin_index as usize] == UNUSED {
+            self.used_bins[top_bin_index as usize] |= 1 << leaf_bin_index;
+            self.used_bins_top |= 1 << top_bin_index;
+        }
+
+        let top_node_index = self.bin_indices[bin_index as usize];
+        let node_index = self.free_nodes[self.free_offset as usize];
+        self.free_offset += 1;
+
+        self.nodes[node_index as usize] = Node {
+            data_offset,
+            data_size: size,
+            bin_list_prev: UNUSED,
+            bin_list_next: top_node_index,
+            neighbor_prev: UNUSED,
+            neighbor_next: UNUSED,
+            used: false,
+        };
+        if top_node_index != UNUSED {
+            self.nodes[top_node_index as usize].bin_list_prev = node_index;
+        }
+        self.bin_indices[bin_index as usize] = node_index;
+        self.free_storage += size;
+        node_index
+    }
+
+    fn remove_node_from_bin(&mut self, node_index: u32) {
+        let bin_list_prev = self.nodes[node_index as usize].bin_list_prev;
+        let bin_list_next = self.nodes[node_index as usize].bin_list_next;
+
+        if bin_list_prev != UNUSED {
+            // Middle of the bin list — just unlink.
+            self.nodes[bin_list_prev as usize].bin_list_next = bin_list_next;
+            if bin_list_next != UNUSED {
+                self.nodes[bin_list_next as usize].bin_list_prev = bin_list_prev;
+            }
+        } else {
+            // Head of the bin — find the bin and repoint it.
+            let bin_index =
+                small_float::uint_to_float_round_down(self.nodes[node_index as usize].data_size);
+            let top_bin_index = bin_index >> TOP_BINS_INDEX_SHIFT;
+            let leaf_bin_index = bin_index & LEAF_BINS_INDEX_MASK;
+
+            self.bin_indices[bin_index as usize] = bin_list_next;
+            if bin_list_next != UNUSED {
+                self.nodes[bin_list_next as usize].bin_list_prev = UNUSED;
+            }
+            if self.bin_indices[bin_index as usize] == UNUSED {
+                self.used_bins[top_bin_index as usize] &= !(1 << leaf_bin_index);
+                if self.used_bins[top_bin_index as usize] == 0 {
+                    self.used_bins_top &= !(1 << top_bin_index);
+                }
+            }
+        }
+
+        self.free_offset -= 1;
+        self.free_nodes[self.free_offset as usize] = node_index;
+        self.free_storage -= self.nodes[node_index as usize].data_size;
+    }
+
+    pub fn storage_report(&self) -> StorageReport {
+        let mut largest_free_region = 0;
+        let mut free_storage = 0;
+        if self.free_offset < self.max_capacity {
+            free_storage = self.free_storage;
+            if self.used_bins_top != 0 {
+                let top_bin_index = 31 - self.used_bins_top.leading_zeros();
+                let leaf_bin_index =
+                    31 - (self.used_bins[top_bin_index as usize] as u32).leading_zeros();
+                largest_free_region = small_float::float_to_uint(
+                    (top_bin_index << TOP_BINS_INDEX_SHIFT) | leaf_bin_index,
+                );
+            }
+        }
+        StorageReport {
+            total_free_space: free_storage,
+            largest_free_region,
+        }
+    }
+
+    /// Grow the lazily-allocated node pool so at least `n` slots are poppable,
+    /// bounded by `max_capacity`. Returns false if the cap is reached.
+    fn ensure_capacity(&mut self, n: u32) -> bool {
+        while self.current_capacity - self.free_offset < n {
+            if self.current_capacity == self.max_capacity {
+                return false;
+            }
+            self.free_nodes.push(self.current_capacity);
+            self.nodes.push(Node::default());
+            self.current_capacity += 1;
+        }
+        true
+    }
+
+    /// Carve an exact `[offset, offset+size)` range out of whatever free region
+    /// covers it, mark it used, and return its handle. Aaltonen has no
+    /// addressed-reserve, so master recovery rebuilds an *equivalent* valid state
+    /// from the snapshot's per-replica ranges this way. `None` if the range is not
+    /// entirely free.
+    pub fn reserve_exact(&mut self, offset: u32, size: u32) -> Option<OffsetAllocation> {
+        if size == 0 {
+            return None;
+        }
+        let end = offset.checked_add(size)?;
+        // up to 3 nodes (before-free, used, after-free); we free 1 (the covering).
+        if !self.ensure_capacity(3) {
+            return None;
+        }
+
+        // Find the free region covering [offset, end) by walking the bin lists.
+        let mut covering = UNUSED;
+        'outer: for bin in 0..NUM_LEAF_BINS {
+            let mut idx = self.bin_indices[bin];
+            while idx != UNUSED {
+                let n = &self.nodes[idx as usize];
+                if n.data_offset <= offset && n.data_offset + n.data_size >= end {
+                    covering = idx;
+                    break 'outer;
+                }
+                idx = n.bin_list_next;
+            }
+        }
+        if covering == UNUSED {
+            return None;
+        }
+
+        let r_off = self.nodes[covering as usize].data_offset;
+        let r_len = self.nodes[covering as usize].data_size;
+        let nb_prev = self.nodes[covering as usize].neighbor_prev;
+        let nb_next = self.nodes[covering as usize].neighbor_next;
+        self.remove_node_from_bin(covering);
+
+        // before-free [r_off, offset)
+        let before = if offset > r_off {
+            Some(self.insert_node_into_bin(offset - r_off, r_off))
+        } else {
+            None
+        };
+
+        // used [offset, end) — popped from the freelist, kept out of every bin.
+        let used = self.free_nodes[self.free_offset as usize];
+        self.free_offset += 1;
+        self.nodes[used as usize] = Node {
+            data_offset: offset,
+            data_size: size,
+            bin_list_prev: UNUSED,
+            bin_list_next: UNUSED,
+            neighbor_prev: UNUSED,
+            neighbor_next: UNUSED,
+            used: true,
+        };
+
+        // after-free [end, r_off+r_len)
+        let after = if r_off + r_len > end {
+            Some(self.insert_node_into_bin((r_off + r_len) - end, end))
+        } else {
+            None
+        };
+
+        // Re-thread neighbours: nb_prev <-> before <-> used <-> after <-> nb_next.
+        let mut prev = nb_prev;
+        for &cur in [before, Some(used), after].iter().flatten() {
+            self.nodes[cur as usize].neighbor_prev = prev;
+            if prev != UNUSED {
+                self.nodes[prev as usize].neighbor_next = cur;
+            }
+            prev = cur;
+        }
+        self.nodes[prev as usize].neighbor_next = nb_next;
+        if nb_next != UNUSED {
+            self.nodes[nb_next as usize].neighbor_prev = prev;
+        }
+
+        Some(OffsetAllocation {
+            offset,
+            metadata: used,
+        })
+    }
+}
+
+/// Number of times `size` must be halved to fit under [`small_float::MAX_BIN_SIZE`].
+fn calculate_multiplier(size: u64) -> u32 {
+    let mut multiplier_bits = 0u32;
+    while small_float::MAX_BIN_SIZE < (size >> multiplier_bits) {
+        multiplier_bits += 1;
+    }
+    multiplier_bits
+}
+
+/// One allocation handed out by [`OffsetAllocator`]: the byte `offset` (already
+/// shifted by the segment base) and `size` the caller asked for, plus the core
+/// handle needed to free it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Allocation {
+    pub offset: u64,
+    pub size: u64,
+    core: OffsetAllocation,
+}
+
+/// The byte-addressed allocator (C++ `OffsetAllocator`): adds a segment `base`
+/// and a `multiplier_bits` size-scaling so spans larger than 3.75 GiB still map
+/// onto the 32-bit core. Single-threaded; the store wraps it under its own lock.
+#[derive(Debug)]
+pub struct OffsetAllocator {
+    core: CoreAllocator,
+    base: u64,
+    multiplier_bits: u32,
+    capacity: u64,
+    allocated_size: u64,
+    allocated_num: u64,
+}
+
+impl OffsetAllocator {
+    pub fn new(base: u64, size: u64, init_capacity: u32, max_capacity: u32) -> Self {
+        let multiplier_bits = calculate_multiplier(size);
+        let core = CoreAllocator::new(
+            (size >> multiplier_bits) as u32,
+            init_capacity,
+            max_capacity,
+        );
+        Self {
+            core,
+            base,
+            multiplier_bits,
+            capacity: size,
+            allocated_size: 0,
+            allocated_num: 0,
+        }
+    }
+
+    /// Allocate `size` bytes; `None` if no region fits or `size` is 0/too large.
+    pub fn allocate(&mut self, size: u64) -> Option<Allocation> {
+        if size == 0 {
+            return None;
+        }
+        let fake_size = if self.multiplier_bits > 0 {
+            (size + (1u64 << self.multiplier_bits) - 1) >> self.multiplier_bits
+        } else {
+            size
+        };
+        if fake_size > small_float::MAX_BIN_SIZE {
+            return None;
+        }
+        let allocation = self.core.allocate(fake_size as u32);
+        if allocation.is_no_space() {
+            return None;
+        }
+        self.allocated_size += size;
+        self.allocated_num += 1;
+        Some(Allocation {
+            offset: self.base + ((allocation.offset as u64) << self.multiplier_bits),
+            size,
+            core: allocation,
+        })
+    }
+
+    pub fn free(&mut self, allocation: &Allocation) {
+        self.core.free(allocation.core);
+        self.allocated_size = self.allocated_size.saturating_sub(allocation.size);
+        self.allocated_num = self.allocated_num.saturating_sub(1);
+    }
+
+    /// Reserve an exact byte range (master recovery). Only supported when sizes
+    /// aren't scaled (`multiplier_bits == 0`, i.e. segments ≤ 3.75 GiB) — larger
+    /// segments must restore allocator state directly rather than by range.
+    pub fn reserve_exact(&mut self, offset: u64, size: u64) -> Option<Allocation> {
+        if size == 0 || offset < self.base || self.multiplier_bits != 0 {
+            return None;
+        }
+        let core_off = u32::try_from(offset - self.base).ok()?;
+        let core_size = u32::try_from(size).ok()?;
+        let core = self.core.reserve_exact(core_off, core_size)?;
+        self.allocated_size += size;
+        self.allocated_num += 1;
+        Some(Allocation { offset, size, core })
+    }
+
+    pub fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    pub fn allocated_size(&self) -> u64 {
+        self.allocated_size
+    }
+
+    /// Free totals in bytes (scaled back up by `multiplier_bits`).
+    pub fn storage_report(&self) -> (u64, u64) {
+        let r = self.core.storage_report();
+        (
+            (r.total_free_space as u64) << self.multiplier_bits,
+            (r.largest_free_region as u64) << self.multiplier_bits,
+        )
+    }
+}
+
+/// The store's per-segment `BufferAllocator`, backed by the faithful
+/// [`OffsetAllocator`] — this is Mooncake's `OffsetBufferAllocator` (the
+/// Aaltonen-backed one) and the store's default, since it strictly dominates the
+/// earlier first-fit allocator on both speed (O(1)) and fragmentation. The trait
+/// deallocates by `(offset, size)` while the core frees by handle, so a small
+/// `offset -> handle` map bridges them.
+#[derive(Debug)]
+pub struct OffsetBufferAllocator {
+    segment_name: SegmentName,
+    inner: OffsetAllocator,
+    live: HashMap<u64, Allocation>,
+}
+
+impl OffsetBufferAllocator {
+    pub fn new(segment_name: impl Into<SegmentName>, capacity: u64) -> Self {
+        Self {
+            segment_name: segment_name.into(),
+            // The node pool grows lazily (≈ one node per live region); cap high.
+            inner: OffsetAllocator::new(0, capacity, 256, 1 << 22),
+            live: HashMap::new(),
+        }
+    }
+}
+
+impl BufferAllocator for OffsetBufferAllocator {
+    fn segment_name(&self) -> &str {
+        &self.segment_name
+    }
+
+    fn capacity(&self) -> u64 {
+        self.inner.capacity()
+    }
+
+    fn allocated(&self) -> u64 {
+        self.inner.allocated_size()
+    }
+
+    fn allocate(&mut self, size: u64) -> Option<AllocatedBuffer> {
+        let a = self.inner.allocate(size)?;
+        self.live.insert(a.offset, a);
+        Some(AllocatedBuffer {
+            segment_name: self.segment_name.clone(),
+            offset: a.offset,
+            size,
+        })
+    }
+
+    fn deallocate(&mut self, buffer: &AllocatedBuffer) {
+        if let Some(a) = self.live.remove(&buffer.offset) {
+            self.inner.free(&a);
+        }
+    }
+
+    fn largest_free_region(&self) -> u64 {
+        self.inner.storage_report().1
+    }
+
+    fn reserve(&mut self, offset: u64, size: u64) -> bool {
+        match self.inner.reserve_exact(offset, size) {
+            Some(a) => {
+                self.live.insert(a.offset, a);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_float_round_trips_and_orders() {
+        // Denorm range (< 8) is exact.
+        for s in 1..8u32 {
+            assert_eq!(
+                small_float::float_to_uint(small_float::uint_to_float_round_down(s)),
+                s
+            );
+        }
+        // Round-up bin always fits the request; round-down never exceeds it.
+        for &s in &[8u32, 9, 15, 16, 100, 1000, 65537, 1 << 20] {
+            let up = small_float::float_to_uint(small_float::uint_to_float_round_up(s));
+            let down = small_float::float_to_uint(small_float::uint_to_float_round_down(s));
+            assert!(up >= s, "round-up bin {up} must fit {s}");
+            assert!(down <= s, "round-down bin {down} must not exceed {s}");
+            // 3-bit mantissa ⇒ at most ~1/8 overhead.
+            assert!(up <= s + s / 8 + 8, "round-up overhead too large for {s}");
+        }
+    }
+
+    #[test]
+    fn allocate_basic_offsets_and_free() {
+        let mut a = OffsetAllocator::new(0, 1 << 16, 128, 4096);
+        let x = a.allocate(1337).unwrap();
+        assert_eq!(x.offset, 0);
+        let y = a.allocate(123).unwrap();
+        assert!(y.offset >= 1337); // past x's (bin-rounded) extent
+        let z = a.allocate(64).unwrap();
+        a.free(&y);
+        // Freed region is reused by a same-class request.
+        let y2 = a.allocate(123).unwrap();
+        assert_eq!(y2.offset, y.offset);
+        a.free(&x);
+        a.free(&z);
+        a.free(&y2);
+        // Everything back ⇒ the whole span is one free region again.
+        let (free, largest) = a.storage_report();
+        assert_eq!(free, 1 << 16);
+        assert_eq!(largest, 1 << 16);
+    }
+
+    #[test]
+    fn coalesces_neighbours_on_free() {
+        // Two adjacent half-segment allocations, freed in both orders, must merge
+        // back into one full-size region (not stay as two fragments).
+        for forward in [true, false] {
+            let mut a = OffsetAllocator::new(0, 1024, 16, 256);
+            let b1 = a.allocate(512).unwrap();
+            let b2 = a.allocate(512).unwrap();
+            assert_eq!(a.storage_report().1, 0); // full
+            if forward {
+                a.free(&b1);
+                a.free(&b2);
+            } else {
+                a.free(&b2);
+                a.free(&b1);
+            }
+            assert_eq!(a.storage_report().1, 1024, "neighbours must coalesce");
+            assert!(a.allocate(1024).is_some());
+        }
+    }
+
+    #[test]
+    fn fragmentation_blocks_oversized_request() {
+        let mut a = OffsetAllocator::new(0, 256, 16, 256);
+        // Bins round up to multiples; carve the span into power-of-two chunks.
+        let b1 = a.allocate(128).unwrap();
+        let _b2 = a.allocate(64).unwrap();
+        let _b3 = a.allocate(64).unwrap();
+        // Span is full now — a fresh request must fail.
+        assert!(a.allocate(64).is_none());
+        // Free a hole; only that hole's worth can be re-allocated, not more.
+        a.free(&b1);
+        assert!(a.allocate(128).is_some());
+        assert!(a.allocate(64).is_none());
+    }
+
+    #[test]
+    fn base_offset_is_applied() {
+        let mut a = OffsetAllocator::new(4096, 1 << 16, 64, 1024);
+        let x = a.allocate(100).unwrap();
+        assert_eq!(x.offset, 4096); // base + 0
+        assert!(a.allocate(100).unwrap().offset > 4096);
+    }
+
+    #[test]
+    fn large_span_uses_multiplier() {
+        // 8 GiB span > MAX_BIN_SIZE (3.75 GiB) ⇒ multiplier_bits > 0, still works.
+        let mut a = OffsetAllocator::new(0, 8u64 << 30, 64, 4096);
+        let x = a.allocate(1 << 20).unwrap();
+        assert_eq!(x.offset, 0);
+        let y = a.allocate(1 << 20).unwrap();
+        assert!(y.offset >= (1 << 20));
+        a.free(&x);
+        a.free(&y);
+    }
+
+    #[test]
+    fn exhausts_node_pool_gracefully() {
+        // max_capacity caps the node pool; allocation fails cleanly, never panics.
+        let mut a = OffsetAllocator::new(0, 1 << 20, 4, 8);
+        let mut held = Vec::new();
+        for _ in 0..100 {
+            match a.allocate(16) {
+                Some(h) => held.push(h),
+                None => break,
+            }
+        }
+        // Freeing restores capacity.
+        for h in &held {
+            a.free(h);
+        }
+        assert_eq!(a.storage_report().0, 1 << 20);
+    }
+}

--- a/crates/quillcache-store/src/replica.rs
+++ b/crates/quillcache-store/src/replica.rs
@@ -2,7 +2,8 @@
 //! bytes can live in several places at once; each is a [`Replica`]. A replica is
 //! either in a mounted RAM segment ([`ReplicaData::Memory`]) or on a node's
 //! durable disk tier ([`ReplicaData::Disk`]) — the latter is QuillCache's
-//! crash-consistent persistent tier (Mooncake's pool is volatile DRAM).
+//! crash-consistent persistent tier (block-level WAL + CRC on recovery, which
+//! Mooncake's trust-by-size byte tier omits).
 
 use crate::allocator::AllocatedBuffer;
 use crate::types::ReplicaId;

--- a/crates/quillcache-store/src/types.rs
+++ b/crates/quillcache-store/src/types.rs
@@ -72,8 +72,9 @@ pub enum ErrorCode {
     Io(String),
     /// QuillCache's identity guard: the object is resident but was written by a
     /// different identity, so serving it would be a cross-tenant leak or a
-    /// cross-adapter/model correctness error. Mooncake keys are identity-agnostic;
-    /// this variant is our addition.
+    /// cross-adapter/model correctness error. Mooncake isolates by `tenant_id`
+    /// but not by model / tokenizer / adapter; extending the guard to the full
+    /// identity is our addition.
     #[error("unsafe cross-identity reuse refused ({0:?})")]
     UnsafeReuse(quillcache_core::ReuseViolation),
 }

--- a/crates/quillcache-transfer-engine/src/endpoint_store.rs
+++ b/crates/quillcache-transfer-engine/src/endpoint_store.rs
@@ -1,0 +1,205 @@
+//! Bounded endpoint cache (Mooncake's `endpoint_store.h`) — a fixed-capacity,
+//! evicting cache of per-peer connections, plus a **reclaim** waiting-list so a
+//! connection still in flight is not torn down until its last user drops it
+//! (Mooncake can't destroy a QP with outstanding work).
+//!
+//! Generic over the connection type `V`, so the eviction + reclaim logic is
+//! unit-tested without an RDMA NIC; [`crate::transport::rdma`] instantiates it
+//! with the real QP type behind `--features rdma`. Two policies, matching
+//! Mooncake: **FIFO** and **SIEVE** (the second-chance lazy-promotion algorithm).
+//!
+//! This replaces the transport's earlier unbounded `HashMap` pool, which never
+//! evicted or reclaimed — the gap called out in the Mooncake comparison.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+/// Which endpoint a full cache evicts to make room.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionPolicy {
+    /// Evict the oldest-inserted endpoint.
+    Fifo,
+    /// SIEVE: scan from a hand, giving a recently-used entry one second chance
+    /// (clear its visited bit and skip) before evicting the first unvisited one.
+    Sieve,
+}
+
+/// A bounded, evicting cache of `Arc<V>` connections keyed by a peer string.
+#[derive(Debug)]
+pub struct EndpointStore<V> {
+    max_size: usize,
+    policy: EvictionPolicy,
+    map: HashMap<String, Arc<V>>,
+    /// SIEVE second-chance bits, parallel to `map`.
+    visited: HashMap<String, bool>,
+    /// Insertion order (front = oldest); FIFO pops the front, SIEVE scans it.
+    order: VecDeque<String>,
+    /// SIEVE hand position into `order`.
+    hand: usize,
+    /// Evicted endpoints still referenced elsewhere (in flight) — kept alive
+    /// until [`Self::reclaim`] finds them unreferenced, so a QP isn't destroyed
+    /// mid-operation.
+    waiting: Vec<Arc<V>>,
+}
+
+impl<V> EndpointStore<V> {
+    pub fn new(max_size: usize, policy: EvictionPolicy) -> Self {
+        Self {
+            max_size: max_size.max(1),
+            policy,
+            map: HashMap::new(),
+            visited: HashMap::new(),
+            order: VecDeque::new(),
+            hand: 0,
+            waiting: Vec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Number of evicted-but-not-yet-reclaimed endpoints (still in flight).
+    pub fn waiting_len(&self) -> usize {
+        self.waiting.len()
+    }
+
+    /// Get `key`'s connection, or build + insert it via `make` on a miss. A hit
+    /// marks the entry used (SIEVE second chance). Inserting past `max_size`
+    /// evicts one entry per the policy first.
+    pub fn get_or_insert<E, F>(&mut self, key: &str, make: F) -> Result<Arc<V>, E>
+    where
+        F: FnOnce() -> Result<V, E>,
+    {
+        if let Some(conn) = self.map.get(key) {
+            self.visited.insert(key.to_string(), true);
+            return Ok(conn.clone());
+        }
+        let conn = Arc::new(make()?);
+        if self.map.len() >= self.max_size {
+            self.evict_one();
+        }
+        self.map.insert(key.to_string(), conn.clone());
+        self.visited.insert(key.to_string(), false);
+        self.order.push_back(key.to_string());
+        Ok(conn)
+    }
+
+    /// Read-only lookup — no second-chance bump (for tests / observability).
+    pub fn peek(&self, key: &str) -> Option<Arc<V>> {
+        self.map.get(key).cloned()
+    }
+
+    fn evict_one(&mut self) {
+        let victim = match self.policy {
+            EvictionPolicy::Fifo => self.order.pop_front(),
+            EvictionPolicy::Sieve => self.sieve_victim(),
+        };
+        if let Some(key) = victim {
+            self.visited.remove(&key);
+            if let Some(conn) = self.map.remove(&key) {
+                // Still referenced (a transfer holds it)? Defer destruction.
+                if Arc::strong_count(&conn) > 1 {
+                    self.waiting.push(conn);
+                }
+            }
+        }
+    }
+
+    /// SIEVE victim: from the hand, clear+skip visited entries, evict the first
+    /// unvisited one (removing it from `order`).
+    fn sieve_victim(&mut self) -> Option<String> {
+        if self.order.is_empty() {
+            return None;
+        }
+        loop {
+            if self.hand >= self.order.len() {
+                self.hand = 0;
+            }
+            let key = self.order[self.hand].clone();
+            if *self.visited.get(&key).unwrap_or(&false) {
+                self.visited.insert(key, false); // used its second chance
+                self.hand += 1;
+            } else {
+                self.order.remove(self.hand); // hand now points at the next entry
+                return Some(key);
+            }
+        }
+    }
+
+    /// Drop any deferred (evicted-but-in-flight) endpoints now unreferenced —
+    /// Mooncake's reclaim pass for safe QP destruction.
+    pub fn reclaim(&mut self) {
+        self.waiting.retain(|conn| Arc::strong_count(conn) > 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(max: usize, policy: EvictionPolicy) -> EndpointStore<i32> {
+        EndpointStore::new(max, policy)
+    }
+
+    fn insert(s: &mut EndpointStore<i32>, key: &str, val: i32) -> Arc<i32> {
+        s.get_or_insert::<(), _>(key, || Ok(val)).unwrap()
+    }
+
+    #[test]
+    fn get_or_insert_builds_once_then_hits() {
+        let mut s = store(4, EvictionPolicy::Fifo);
+        let a1 = insert(&mut s, "a", 1);
+        // A hit returns the same Arc and does NOT rebuild (closure would panic).
+        let a2 = s
+            .get_or_insert::<(), _>("a", || panic!("should not rebuild on a hit"))
+            .unwrap();
+        assert!(Arc::ptr_eq(&a1, &a2));
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn fifo_evicts_oldest_and_stays_bounded() {
+        let mut s = store(2, EvictionPolicy::Fifo);
+        insert(&mut s, "a", 1);
+        insert(&mut s, "b", 2);
+        insert(&mut s, "c", 3); // over capacity → evict oldest ("a")
+        assert_eq!(s.len(), 2, "stays bounded at max_size");
+        assert!(s.peek("a").is_none(), "oldest evicted");
+        assert!(s.peek("b").is_some() && s.peek("c").is_some());
+    }
+
+    #[test]
+    fn sieve_gives_a_used_entry_a_second_chance() {
+        let mut s = store(2, EvictionPolicy::Sieve);
+        insert(&mut s, "a", 1);
+        insert(&mut s, "b", 2);
+        // Touch "a" → visited. Inserting "c" should spare "a" and evict "b".
+        let _ = s.get_or_insert::<(), _>("a", || unreachable!()).unwrap();
+        insert(&mut s, "c", 3);
+        assert!(s.peek("a").is_some(), "recently-used entry kept");
+        assert!(s.peek("b").is_none(), "unvisited entry evicted");
+        assert!(s.peek("c").is_some());
+    }
+
+    #[test]
+    fn reclaim_defers_destruction_until_inflight_ref_drops() {
+        let mut s = store(1, EvictionPolicy::Fifo);
+        let held = insert(&mut s, "a", 1); // hold an external ref (a "transfer")
+        insert(&mut s, "b", 2); // evicts "a" while it is still referenced
+        assert_eq!(
+            s.waiting_len(),
+            1,
+            "in-flight eviction deferred, not dropped"
+        );
+        s.reclaim();
+        assert_eq!(s.waiting_len(), 1, "still held → still deferred");
+        drop(held);
+        s.reclaim();
+        assert_eq!(s.waiting_len(), 0, "ref dropped → reclaimed");
+    }
+}

--- a/crates/quillcache-transfer-engine/src/lib.rs
+++ b/crates/quillcache-transfer-engine/src/lib.rs
@@ -29,6 +29,7 @@
 
 #[cfg(feature = "cuda")]
 pub mod device_segment;
+pub mod endpoint_store;
 pub mod engine;
 pub mod metadata;
 #[cfg(feature = "etcd")]
@@ -39,6 +40,7 @@ pub mod transport;
 
 #[cfg(feature = "cuda")]
 pub use device_segment::{serve_device_segment, DeviceSegment};
+pub use endpoint_store::{EndpointStore, EvictionPolicy};
 pub use engine::TransferEngine;
 pub use metadata::{BufferDesc, InMemoryMetadata, MetadataBackend, SegmentDesc};
 #[cfg(feature = "etcd")]

--- a/crates/quillcache-transfer-engine/src/transport/rdma.rs
+++ b/crates/quillcache-transfer-engine/src/transport/rdma.rs
@@ -21,14 +21,17 @@ use bytes::Bytes;
 /// [`serve_rdma_segment`] over a TCP side-channel and do one-sided RDMA READ /
 /// WRITE by `(addr + offset, rkey)`. Real under `--features rdma`; an
 /// `Unsupported` stub otherwise, so the default build needs no NIC.
-/// Per-endpoint pool of reusable RDMA connections (one RC QP each; ops serialized
-/// by the inner mutex). Reusing the QP turns a transfer into register + post +
-/// poll instead of a full handshake every call.
+/// Bounded per-endpoint pool of reusable RDMA connections (one RC QP each; ops
+/// serialized by the inner mutex). Reusing the QP turns a transfer into register
+/// + post + poll instead of a full handshake every call; the bounded
+/// [`EndpointStore`](crate::endpoint_store) caps the live QP count and reclaims
+/// evicted QPs once no transfer still holds them (Mooncake's `EndpointStore`).
+#[cfg(feature = "rdma")]
+const MAX_POOLED_QPS: usize = 256;
+
 #[cfg(feature = "rdma")]
 type RdmaPool = std::sync::Arc<
-    std::sync::Mutex<
-        std::collections::HashMap<String, std::sync::Arc<std::sync::Mutex<verbs::RdmaConnection>>>,
-    >,
+    std::sync::Mutex<crate::endpoint_store::EndpointStore<std::sync::Mutex<verbs::RdmaConnection>>>,
 >;
 
 #[derive(Clone)]
@@ -56,15 +59,14 @@ fn pool_connect(
     device: &str,
     gid_index: u8,
 ) -> Result<std::sync::Arc<std::sync::Mutex<verbs::RdmaConnection>>, String> {
-    let mut map = pool.lock().map_err(|_| "rdma pool poisoned".to_string())?;
-    if let Some(conn) = map.get(endpoint) {
-        return Ok(conn.clone());
-    }
-    let conn = std::sync::Arc::new(std::sync::Mutex::new(verbs::RdmaConnection::connect(
-        endpoint, device, gid_index,
-    )?));
-    map.insert(endpoint.to_string(), conn.clone());
-    Ok(conn)
+    let mut store = pool.lock().map_err(|_| "rdma pool poisoned".to_string())?;
+    // Reuse the pooled QP, or open one on a miss; the bounded store evicts +
+    // reclaims (FIFO) so the live QP count stays capped.
+    store.get_or_insert(endpoint, || {
+        Ok::<_, String>(std::sync::Mutex::new(verbs::RdmaConnection::connect(
+            endpoint, device, gid_index,
+        )?))
+    })
 }
 
 impl Default for RdmaTransport {
@@ -74,7 +76,12 @@ impl Default for RdmaTransport {
             device: "rxe0".into(),
             gid_index: 1,
             #[cfg(feature = "rdma")]
-            pool: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pool: std::sync::Arc::new(std::sync::Mutex::new(
+                crate::endpoint_store::EndpointStore::new(
+                    MAX_POOLED_QPS,
+                    crate::endpoint_store::EvictionPolicy::Fifo,
+                ),
+            )),
         }
     }
 }

--- a/web/src/content/docs/crash-consistency.md
+++ b/web/src/content/docs/crash-consistency.md
@@ -4,8 +4,9 @@ description: A durable DiskTier survives a restart with object-first atomic publ
 ---
 
 The durable `DiskTier` holds real KV bytes (`Disk` replicas) that should survive a
-restart, so it needs a durable, **crash-consistent** catalog. Mooncake's pool is
-volatile DRAM (rebuilt on restart); QuillCache occupies the seam it leaves open —
+restart, so it needs a durable, **crash-consistent** catalog. Mooncake's local
+byte tier recovers by trusting on-disk files by size (no per-block validation);
+QuillCache occupies the seam it leaves open —
 a durable, immediately-reusable persistent tier — backed by `LocalKvStore`'s SSD
 tier, using the same pattern as the author's NoKV distributed file system:
 **object-first atomic publish + a WAL**.

--- a/web/src/content/docs/identity-safe-reuse.md
+++ b/web/src/content/docs/identity-safe-reuse.md
@@ -52,4 +52,5 @@ keeping every safe same-identity hit.
 
 It is the **same guard** in memory (`LocalKvStore`), on disk (`DiskTier`), and at
 the master (`MasterService`) — and it still holds after a crash and recovery. This
-is QuillCache's addition; Mooncake's keys are identity-agnostic.
+is QuillCache's addition: Mooncake isolates by `tenant_id` but not by model /
+tokenizer / adapter, so this extends the guard to the full identity.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -53,7 +53,8 @@ how far each piece is integrated:
 ## Differentiation
 
 The reference designs (Mooncake / Dynamo / LMCache / KVBM) key reuse on a
-block's **content hash** and keep the cache mostly volatile. QuillCache adds:
+block's **content hash** (Mooncake adds only a tenant scope) and leave byte-tier
+crash-integrity to the caller. QuillCache adds:
 
 1. **Identity-governed safe reuse** — a block is served only when the requester's
    model · tokenizer · adapter · tenant matches, so cross-tenant leaks and
@@ -64,4 +65,4 @@ block's **content hash** and keep the cache mostly volatile. QuillCache adds:
 2. **A crash-consistent persistent tier** — a durable `DiskTier` survives a
    restart with object-first atomic publish + a WAL, so durable blocks are
    immediately reusable and corrupt/half-written ones are never served (Mooncake's
-   pool is volatile DRAM). See [Crash-consistent tier](/crash-consistency/).
+   byte tier trusts on-disk files by size on recovery). See [Crash-consistent tier](/crash-consistency/).

--- a/web/src/content/docs/reference-mapping.md
+++ b/web/src/content/docs/reference-mapping.md
@@ -9,10 +9,10 @@ read end-to-end and measure.
 
 | Mooncake / Dynamo | QuillCache | Status |
 | --- | --- | --- |
-| Transfer Engine (`TransferEngine` + `Transport` + `MultiTransport.selectTransport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}` + `MultiTransport::select_best`) | ✅ TCP · ✅ **one-sided RDMA Transport** (`ibverbs`, **pooled QPs**, end-to-end verified over SoftRoCE — 10× from QP reuse) · ✅ topology-aware backend select (RDMA over TCP) / ⊙ real-NIC perf |
+| Transfer Engine (`TransferEngine` + `Transport` + `MultiTransport.selectTransport`) | `quillcache-transfer-engine` (`engine` + `transport::{tcp,rdma,nvlink}` + `MultiTransport::select_best`) | ✅ TCP · ✅ **one-sided RDMA Transport** (`ibverbs`, **pooled QPs**, end-to-end verified over SoftRoCE — 10× from QP reuse) · ✅ link-class backend select (RDMA over TCP — our own ranking; Mooncake's `selectTransport` matches the target's declared protocol) / ⊙ real-NIC perf |
 | Store `Client` (`PutStart`/`PutEnd`/`Get`) | `DummyClient` / `RealClient` | ✅ end-to-end over the transfer engine |
-| Store `MasterService` (two-phase Put, eviction, **HA**, batch) | `MasterService` | ✅ replica alloc · lease eviction · **HA** (snapshot + heartbeat + etcd election) · **batch Put/Get** |
-| `BufferAllocator` + `AllocationStrategy` | `OffsetBufferAllocator` + **`BinnedBufferAllocator` (O(1) size-binned)** + `Random`/`FreeRatioFirst` | ✅ |
+| Store `MasterService` (two-phase Put, Upsert, eviction, **HA**, batch) | `MasterService` | ✅ replica alloc · lease eviction · **Upsert** · **hot-key (CountMinSketch)** · **HA** (snapshot + heartbeat + etcd election) · **batch Put/Get + regex** |
+| `BufferAllocator` (CacheLib slab + `offset_allocator`) + `AllocationStrategy` | **`OffsetBufferAllocator`** (faithful 256-bin Aaltonen port — default) + `FirstFitBufferAllocator` + `Random`/`FreeRatioFirst` | ✅ |
 | Overload-oriented early rejection | `ControlPlane::admit` (SLO-violation budget) | ✅ |
 | `TransferMetadata` (etcd/redis/http/p2p) | `MetadataBackend`: `InMemoryMetadata` / `EtcdMetadata` (feature `etcd`) | ✅ in-memory · ✅ etcd (verified vs real etcd) · ⊙ redis/http/p2p |
 | Dynamo KV-router cost function | `DynamoCostRouter` | ✅ reproduces the worked example |
@@ -21,7 +21,7 @@ read end-to-end and measure.
 | Mooncake Conductor / Dynamo KV-Cache Indexer | `conductor` (`PrefixCacheTable` + `ModelContext`) + residency index (Holt ART) + **`replication` (hot-prefix balancing)** | ✅ longest-prefix overlap · persistent · **hot-prefix replication** |
 | vLLM/SGLang engine integration + disaggregated P/D | `QuillCacheV1Connector` (`KVConnectorBase_V1`) + `pd-proxy` router | ✅ **true vLLM-native P/D** (kv_producer/consumer, 2×L4-verified) |
 | Metrics / observability | gateway `/metrics` (Prometheus) | ✅ cache hits · transfers · refused reuse · SLO goodput |
-| — *(neither does this)* | **identity guard + crash-consistent `DiskTier`** | 🎯 differentiation |
+| Mooncake: tenant scope + crash-consistent metadata OpLog | **full-identity guard (adds model/tokenizer/adapter) + block-level CRC-on-recovery in the byte tier** | 🎯 differentiation |
 
 > `quillcache-cuda` is the one piece that is **not** a 1:1 Mooncake component:
 > Mooncake puts GPU in the Transfer Engine (the `rdma` / `nvlink` transports


### PR DESCRIPTION
## What

Faithful alignment of QuillCache's store + transfer internals with the real Mooncake source (`mooncake-store` / `mooncake-transfer-engine`), found by reading the cloned upstream side-by-side. Also corrects positioning docs that overstated the differences vs Mooncake.

## Changes

**Store**
- **`offset_allocator`** — faithful Rust port of Sebastian Aaltonen's OffsetAllocator (the one Mooncake wraps): 256-bin 2-level bitmap (32 top × 8 leaf "small-float" bins), intrusive node pool with neighbour links, O(1) alloc/free. Now the **default** `BufferAllocator` (the old naive O(n) first-fit is renamed `FirstFitBufferAllocator`). `reserve_exact` rebuilds allocator state on snapshot recovery.
- **`MasterService`** — `Upsert` (in-place reuse / realloc / busy-on-lease), `batch_put_revoke`, `batch_exist_key`, identity-guarded `get_replica_list_by_regex`, and **CountMinSketch** hot-key tracking on guarded reads.

**Transfer**
- **`EndpointStore`** — bounded QP pool with **FIFO + SIEVE** eviction and a reclaim waiting-list (a QP is not torn down while a transfer still holds it), replacing the unbounded `HashMap` pool. Generic + unit-tested; wired into the `rdma` Transport behind `--features rdma`.

**Docs**
- Corrected "Mooncake is identity-agnostic / volatile DRAM" to the accurate, narrower claims: Mooncake scopes objects by `tenant_id` (QuillCache adds the model/tokenizer/adapter axes), and its local byte tier recovers by trusting on-disk files by size (QuillCache adds block-level WAL+CRC). Fixed the `select_best` framing across README + web docs.

## Tests
- store **52** + transfer **6** unit tests green; `fmt` + `clippy` clean.
- The `rdma`-feature wiring is type-reviewed locally (no libibverbs on the dev box); CI compiles it on Linux.

## Notes
Part of a larger faithful-alignment effort. Deliberately **not** in this PR (separate decision — larger refactors of limited value for a single-node store): MasterService sharding, an OpLog-style HA rewrite, an async transfer worker-pool, and client_id mount lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hotness tracking per key for frequency analysis
  * Introduced batch revoke operations
  * Added upsert support with smart buffer reuse
  * Enabled regex-based key listing with identity filtering
  * Implemented bounded connection cache with FIFO/SIEVE eviction policies

* **Bug Fixes**
  * Strengthened identity isolation to cover model, tokenizer, and adapter dimensions in addition to tenant isolation

* **Documentation**
  * Clarified block-level integrity mechanisms in crash-consistent tier
  * Expanded identity safety guarantees documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->