### PR TITLE
Update FP8 qualification status

### DIFF
--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -132,9 +132,9 @@ the boundary or an isolated implementation is measurably useful.
 
 ## Implementation Order
 
-1. Finish H20 and clean-wheel qualification for the static FP8 E4M3
-   quantize-on-write path, then prove cache bytes, admitted context/batch,
-   quality, and TPOT together.
+1. Finish system-level qualification for the static FP8 E4M3 quantize-on-write
+   path by proving cache bytes, admitted context/batch, quality, TTFT, and TPOT
+   together; H20 operator and clean-wheel qualification are complete.
 2. Complete the sampling tail with fused preprocessing, penalties, top-k/top-p,
    renormalization, deterministic RNG, and top-k logprobs.
 3. Add KV block movement for a real prefix-cache, preemption, or compaction


### PR DESCRIPTION
## Summary

Update the operator catalog to reflect the current FP8 KV cache qualification status.

## Changes

- Mark H20 operator and clean-wheel qualification as complete.
- Clarify that the remaining gate is system-level validation covering:
  - Generation quality
  - KV cache memory usage
  - Supported context length or batch size
  - TTFT
  - TPOT

## Motivation

The implementation order in `operator-catalog.md` was outdated and inconsistent with `fp8-kv-cache.md`, where the first four qualification gates are already recorded as complete.

## Impact

Documentation only. No runtime behavior is changed.

## Validation

- Ran `git diff --check`
- Cross-checked the status against `docs/design/fp8-kv-cache.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the implementation qualification sequence for the static FP8 E4M3 quantize-on-write path.
  * Clarified that system-level validation covers cache usage, admitted context and batch size, quality, TTFT, and TPOT.
  * Documented completion of H20 operator and clean-wheel qualification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->