### PR TITLE
feat!: add fixed BF16 cuBLASLt provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,31 @@
 
 ## Unreleased
 
+### Added
+
+- Added a contiguous BF16 GEMM contract and CPU reference with F32 accumulation.
+- Added one fixed cuBLASLt plan with checked layouts, spans, alignment,
+  workspace, context, and caller-owned stream.
+- Added H20 correctness coverage for standalone GEMM, row-major transpose,
+  capacity and buffer rejection, plan reuse, and an RMSNorm-to-GEMM chain.
+
+### Changed
+
+- Generalized command scopes to retain Rust kernel functions and external
+  provider plans under one completion fence.
+- Renamed launch-specific command capacity APIs to provider-neutral command
+  terminology.
+- Separated external provider submission errors from CUDA driver errors.
+
+## 1.0.0-alpha.1
+
 ### Breaking
 
 - Reduced the workspace to `loom-infer` and `loom-infer-cuda`.
 - Removed the Python package, CUDA C++ kernels, C bridge, raw FFI crate,
   compatibility paths, benchmark scripts, spikes, and historical result set.
-- Removed all operator APIs except the RMSNorm slice that has a Rust device
-  implementation in progress.
+- Removed all operator APIs except the RMSNorm slice with a permanent Rust
+  device implementation.
 - Made cuda-oxide the only custom GPU-kernel toolchain.
 
 ### Added
@@ -18,7 +36,3 @@
   plan, and H20 correctness program.
 - Added a two-crate architecture, operator catalog, staged roadmap, and strict
   evidence contract.
-
-## 1.0.0-alpha.1
-
-- Reserved for the first published Rust-native Loom Infer release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -173,6 +173,15 @@ dependencies = [
  "quote",
  "reserved-oxide-symbols",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
+dependencies = [
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -281,11 +290,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libnvvm-sys"
 version = "0.2.1"
 source = "git+https://github.com/NVlabs/cuda-oxide.git?rev=868f8ec4ef900bae7e67e7f9508b2da66eee5472#868f8ec4ef900bae7e67e7f9508b2da66eee5472"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
  "thiserror",
 ]
 
@@ -309,6 +328,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "cudarc",
  "half",
  "loom-infer",
  "thiserror",
@@ -341,7 +361,7 @@ name = "nvjitlink-sys"
 version = "0.2.1"
 source = "git+https://github.com/NVlabs/cuda-oxide.git?rev=868f8ec4ef900bae7e67e7f9508b2da66eee5472#868f8ec4ef900bae7e67e7f9508b2da66eee5472"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
  "thiserror",
 ]
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </p>
 </div>
 
-Loom Infer is a high-performance inference kernel library written in Rust. It
+Loom Infer is an inference GPU operator library written in Rust. It
 provides checked operator contracts, CPU references, and Rust CUDA kernels
 compiled with [cuda-oxide](https://github.com/NVlabs/cuda-oxide).
 
@@ -26,31 +26,39 @@ The repository contains two crates:
 | `loom-infer` | Safe operator contracts and CPU reference implementations |
 | `loom-infer-cuda` | Rust host code and Rust CUDA kernels built with cuda-oxide |
 
-The first device path is contiguous RMSNorm for F32, FP16, and BF16. Its public
-flow is:
+The current device paths are:
+
+| Operator | Provider | H20 state |
+| --- | --- | --- |
+| Contiguous RMSNorm F32, FP16, BF16 | Rust device kernels compiled with cuda-oxide | Device correct |
+| Contiguous BF16 GEMM with F32 accumulation | One fixed cuBLASLt algorithm | Device correct |
+
+Both use the same public flow:
 
 ```text
-RmsNormSpec::new
-  -> RmsNormProvider::load
-  -> RmsNormProvider::plan_{f32,f16,bf16}
+validated spec
+  -> provider::load
+  -> immutable plan
   -> CommandQueue::bindings
   -> CommandQueue::begin
-  -> prepared plan::enqueue_into
+  -> plan::enqueue_into
   -> CommandScope::finish
   -> CommandCompletion::wait
 ```
 
-All three dtypes have passed permanent-provider H20 correctness gates. FP16 and
-BF16 use scalar access for odd widths and packed 32-bit access for even widths.
-Attention, sampling, KV-cache, MoE, quantization, and vendor GEMM remain roadmap
-work.
+The GEMM contract is `D[M,N] = A[M,K] * W[N,K]^T` over contiguous row-major
+BF16 tensors. Algorithm selection happens during planning. Enqueue does not
+tune or fall back.
+
+Attention, sampling, KV-cache, MoE, quantization, graph
+replay, and performance qualification remain roadmap work.
 
 ### Execution
 
-The command scope chains operators on one caller-owned stream and holds mixed
-F32, FP16, BF16, and byte buffers. Typed handles prevent dtype confusion, and
-one preallocated event completes the scope. The cuda-oxide launcher still
-allocates its argument vector during enqueue.
+The command scope chains Rust kernels and vendor calls on one caller-owned
+stream. It retains typed buffers, loaded kernel functions, and external plans
+until one completion event settles the scope. The cuda-oxide launcher still
+allocates its argument vector during Rust-kernel enqueue.
 
 ## Source boundary
 
@@ -58,8 +66,8 @@ allocates its argument vector during enqueue.
 - Custom device kernels are Rust compiled with cuda-oxide.
 - The repository has no Python product API, CUDA C++, compatibility layer, or
   silent fallback.
-- CUDA drivers and established GEMM or collective libraries remain vendor
-  dependencies when Loom adds those paths.
+- CUDA drivers and cuBLASLt are current vendor dependencies. Other established
+  GEMM and collective libraries may enter through explicit providers.
 - The caller owns streams and device buffers. Checked bindings retain borrowed
   resources while the GPU uses them.
 
@@ -81,6 +89,8 @@ H20 device validation uses the pinned nightly and cuda-oxide revision:
 cd crates/loom-infer-cuda
 cargo oxide doctor
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
+cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
+cargo oxide test --arch sm_90 -- --workspace --features cuda --release
 ```
 
 See the [H20 validation contract](docs/development/h20-validation.md) before
@@ -92,9 +102,12 @@ Operator correctness, kernel latency, graph execution, engine integration, and
 serving performance are separate claims. A microbenchmark does not establish
 an engine or serving speedup.
 
+The current GEMM record makes no performance, CUDA Graph, Compute Sanitizer,
+engine, or serving claim.
+
 See the [architecture](docs/design/loom-infer-architecture.md),
 [operator catalog](docs/operator-catalog.md), [roadmap](docs/roadmap.md), and
-[low-precision RMSNorm result](docs/results/h20-rms-norm-low-precision-20260802.json).
+[BF16 cuBLASLt result](docs/results/h20-bf16-cublaslt-correctness-20260802.json).
 
 ## License
 

--- a/crates/loom-infer-cuda/Cargo.toml
+++ b/crates/loom-infer-cuda/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [features]
 default = []
-cuda = ["dep:cuda-core", "dep:cuda-device", "dep:cuda-host"]
+cuda = ["dep:cuda-core", "dep:cuda-device", "dep:cuda-host", "dep:cudarc"]
 
 [dependencies]
 half.workspace = true
@@ -20,8 +20,14 @@ thiserror.workspace = true
 cuda-core = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "868f8ec4ef900bae7e67e7f9508b2da66eee5472", optional = true }
 cuda-device = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "868f8ec4ef900bae7e67e7f9508b2da66eee5472", optional = true }
 cuda-host = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "868f8ec4ef900bae7e67e7f9508b2da66eee5472", optional = true }
+cudarc = { version = "=0.19.8", default-features = false, features = ["std", "cublaslt", "cuda-13010", "dynamic-linking"], optional = true }
 
 [[bin]]
 name = "rms_norm_h20"
 path = "src/bin/rms_norm_h20.rs"
+required-features = ["cuda"]
+
+[[bin]]
+name = "bf16_gemm_h20"
+path = "src/bin/bf16_gemm_h20.rs"
 required-features = ["cuda"]

--- a/crates/loom-infer-cuda/README.md
+++ b/crates/loom-infer-cuda/README.md
@@ -1,19 +1,23 @@
 # loom-infer-cuda
 
 `loom-infer-cuda` contains Loom Infer's Rust CUDA host and device code.
-`cuda-oxide` compiles each Loom-owned kernel. The crate does not use CUDA C++,
-`nvcc`, Python, or framework bindings.
+`cuda-oxide` compiles each Loom-owned kernel. Audited Rust FFI calls qualified
+vendor libraries. The crate does not use CUDA C++, Python, or framework
+bindings.
 
 The default feature set keeps CPU-only workspace checks platform independent.
 Enable `cuda` only inside the pinned CUDA build environment.
 
 ```bash
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
+cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
 ```
 
-## Current provider
+## Current providers
 
-The current provider implements contiguous F32, FP16, and BF16 RMSNorm with
-typed heterogeneous bindings and one completion event. Scalar and packed paths
-pass H20 correctness gates. Fixed argument packs, graph, sanitizer, and
-performance gates remain open.
+The Rust provider implements contiguous F32, FP16, and BF16 RMSNorm. The first
+vendor provider freezes one contiguous BF16 cuBLASLt GEMM algorithm during
+planning. Both use typed heterogeneous bindings and one completion event.
+
+Their declared H20 correctness gates pass. Fixed Rust-kernel argument packs,
+graph, sanitizer, and performance gates remain open.

--- a/crates/loom-infer-cuda/src/bin/bf16_gemm_h20.rs
+++ b/crates/loom-infer-cuda/src/bin/bf16_gemm_h20.rs
@@ -1,0 +1,488 @@
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer};
+use half::bf16;
+use loom_infer::{Bf16GemmSpec, DType, RmsNormSpec, bf16_gemm_reference, rms_norm_bf16_reference};
+use loom_infer_cuda::command::{CommandError, CommandQueue};
+use loom_infer_cuda::gemm::{Bf16GemmArgs, Bf16GemmEnqueueError, Bf16GemmPlan, CublasLtProvider};
+use loom_infer_cuda::rms_norm::{RmsNormArgs, RmsNormProvider};
+use std::error::Error;
+use std::sync::Arc;
+
+const LARGE_M: usize = 1;
+const LARGE_N: usize = 4096;
+const LARGE_K: usize = 4096;
+
+#[derive(Clone, Copy, Debug)]
+struct Comparison {
+    max_abs: f32,
+    bit_mismatches: usize,
+    digest: u64,
+}
+
+fn compare(actual: &[bf16], expected: &[bf16]) -> Result<Comparison, Box<dyn Error>> {
+    if actual.len() != expected.len() {
+        return Err(format!(
+            "comparison length mismatch: actual={}, expected={}",
+            actual.len(),
+            expected.len()
+        )
+        .into());
+    }
+
+    let mut max_abs = 0.0_f32;
+    let mut bit_mismatches = 0_usize;
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if !actual.to_f32().is_finite() {
+            return Err(format!("non-finite output at index {index}").into());
+        }
+        max_abs = max_abs.max((actual.to_f32() - expected.to_f32()).abs());
+        bit_mismatches += usize::from(actual.to_bits() != expected.to_bits());
+        digest ^= u64::from(actual.to_bits());
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+
+    Ok(Comparison {
+        max_abs,
+        bit_mismatches,
+        digest,
+    })
+}
+
+fn require_bit_exact(case: &str, comparison: Comparison) -> Result<(), Box<dyn Error>> {
+    if comparison.bit_mismatches == 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "{case} had {} BF16 bit mismatches; max_abs={:.9e}",
+            comparison.bit_mismatches, comparison.max_abs
+        )
+        .into())
+    }
+}
+
+fn large_fixture(spec: Bf16GemmSpec) -> (Vec<bf16>, Vec<bf16>) {
+    let activation = vec![bf16::ONE; spec.a_numel()];
+    let mut weight = Vec::with_capacity(spec.weight_numel());
+    for row in 0..spec.n() {
+        let magnitude = ((row % 16) + 1) as f32 / 256.0;
+        let sign = if (row / 16).is_multiple_of(2) {
+            1.0
+        } else {
+            -1.0
+        };
+        weight.extend(std::iter::repeat_n(
+            bf16::from_f32(sign * magnitude),
+            spec.k(),
+        ));
+    }
+    (activation, weight)
+}
+
+fn workspace_len(plan: &Bf16GemmPlan) -> usize {
+    plan.workspace_required_bytes()
+}
+
+fn check_standalone(queue: &mut CommandQueue, plan: &Bf16GemmPlan) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let spec = plan.spec();
+    let (activation_host, weight_host) = large_fixture(spec);
+    let mut expected = vec![bf16::ZERO; spec.output_numel()];
+    bf16_gemm_reference(&activation_host, &weight_host, &mut expected, spec)?;
+
+    let activation = DeviceBuffer::from_host(&stream, &activation_host)?;
+    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
+    let mut first_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let mut second_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let mut bindings = queue.bindings(5)?;
+    let activation_handle = bindings.bind_read(&activation)?;
+    let weight_handle = bindings.bind_read(&weight)?;
+    let first_output_handle = bindings.bind_read_write(&mut first_output)?;
+    let second_output_handle = bindings.bind_read_write(&mut second_output)?;
+    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+
+    for output_handle in [first_output_handle.write(), second_output_handle.write()] {
+        let mut scope = queue.begin(bindings)?;
+        plan.enqueue_into(
+            &mut scope,
+            Bf16GemmArgs::new(
+                activation_handle,
+                weight_handle,
+                output_handle,
+                workspace_handle.write(),
+            ),
+        )?;
+        let completion = scope.finish();
+        if completion.submitted() != 1 {
+            return Err("standalone GEMM completion covered the wrong command count".into());
+        }
+        bindings = completion.wait()?;
+    }
+    drop(bindings);
+
+    let first_actual = first_output.to_host_vec(&stream)?;
+    let second_actual = second_output.to_host_vec(&stream)?;
+    let first_comparison = compare(&first_actual, &expected)?;
+    let second_comparison = compare(&second_actual, &expected)?;
+    require_bit_exact("first standalone GEMM scope", first_comparison)?;
+    require_bit_exact("second standalone GEMM scope", second_comparison)?;
+    println!(
+        "gate=bf16_gemm_h20 case=standalone status=pass m={} n={} k={} scopes=2 \
+         commands_per_scope=1 queue_reused=true bindings_reused=true plan_reused=true \
+         first_bit_mismatches={} second_bit_mismatches={} max_abs={:.9e} \
+         first_digest={:016x} second_digest={:016x}",
+        spec.m(),
+        spec.n(),
+        spec.k(),
+        first_comparison.bit_mismatches,
+        second_comparison.bit_mismatches,
+        first_comparison.max_abs.max(second_comparison.max_abs),
+        first_comparison.digest,
+        second_comparison.digest,
+    );
+    Ok(())
+}
+
+fn check_row_major_transpose(
+    queue: &mut CommandQueue,
+    plan: &Bf16GemmPlan,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let spec = plan.spec();
+    let activation_host = [
+        bf16::from_f32(1.0),
+        bf16::from_f32(2.0),
+        bf16::from_f32(3.0),
+        bf16::from_f32(4.0),
+        bf16::from_f32(-2.0),
+        bf16::from_f32(0.5),
+        bf16::from_f32(1.0),
+        bf16::from_f32(-1.0),
+    ];
+    let weight_host = [
+        bf16::from_f32(1.0),
+        bf16::from_f32(0.0),
+        bf16::from_f32(2.0),
+        bf16::from_f32(-1.0),
+        bf16::from_f32(-1.0),
+        bf16::from_f32(3.0),
+        bf16::from_f32(0.5),
+        bf16::from_f32(2.0),
+        bf16::from_f32(4.0),
+        bf16::from_f32(-2.0),
+        bf16::from_f32(1.0),
+        bf16::from_f32(0.25),
+    ];
+    let mut expected = vec![bf16::ZERO; spec.output_numel()];
+    bf16_gemm_reference(&activation_host, &weight_host, &mut expected, spec)?;
+
+    let activation = DeviceBuffer::from_host(&stream, &activation_host)?;
+    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
+    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let mut bindings = queue.bindings(4)?;
+    let activation_handle = bindings.bind_read(&activation)?;
+    let weight_handle = bindings.bind_read(&weight)?;
+    let output_handle = bindings.bind_read_write(&mut output)?;
+    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let mut scope = queue.begin(bindings)?;
+    plan.enqueue_into(
+        &mut scope,
+        Bf16GemmArgs::new(
+            activation_handle,
+            weight_handle,
+            output_handle.write(),
+            workspace_handle.write(),
+        ),
+    )?;
+    let completion = scope.finish();
+    if completion.submitted() != 1 {
+        return Err("transpose-sensitive GEMM completion covered the wrong command count".into());
+    }
+    drop(completion.wait()?);
+
+    let actual = output.to_host_vec(&stream)?;
+    let comparison = compare(&actual, &expected)?;
+    require_bit_exact("transpose-sensitive GEMM", comparison)?;
+    println!(
+        "gate=bf16_gemm_h20 case=row_major_transpose status=pass m={} n={} k={} \
+         bit_mismatches={} max_abs={:.9e} digest={:016x}",
+        spec.m(),
+        spec.n(),
+        spec.k(),
+        comparison.bit_mismatches,
+        comparison.max_abs,
+        comparison.digest,
+    );
+    Ok(())
+}
+
+fn expect_length_rejection(
+    queue: &mut CommandQueue,
+    plan: &Bf16GemmPlan,
+    operand: &'static str,
+    activation_len: usize,
+    weight_len: usize,
+    output_len: usize,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let activation = DeviceBuffer::<bf16>::zeroed(&stream, activation_len)?;
+    let weight = DeviceBuffer::<bf16>::zeroed(&stream, weight_len)?;
+    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, output_len)?;
+    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let mut bindings = queue.bindings(4)?;
+    let activation_handle = bindings.bind_read(&activation)?;
+    let weight_handle = bindings.bind_read(&weight)?;
+    let output_handle = bindings.bind_read_write(&mut output)?;
+    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let mut scope = queue.begin(bindings)?;
+    let result = plan.enqueue_into(
+        &mut scope,
+        Bf16GemmArgs::new(
+            activation_handle,
+            weight_handle,
+            output_handle.write(),
+            workspace_handle.write(),
+        ),
+    );
+    match result {
+        Err(Bf16GemmEnqueueError::LengthMismatch {
+            operand: actual, ..
+        }) if actual == operand => {}
+        other => {
+            return Err(
+                format!("short {operand} buffer returned the wrong result: {other:?}").into(),
+            );
+        }
+    }
+    drop(scope);
+    Ok(())
+}
+
+fn check_short_buffers(
+    queue: &mut CommandQueue,
+    plan: &Bf16GemmPlan,
+) -> Result<(), Box<dyn Error>> {
+    let spec = plan.spec();
+    expect_length_rejection(
+        queue,
+        plan,
+        "A",
+        spec.a_numel() - 1,
+        spec.weight_numel(),
+        spec.output_numel(),
+    )?;
+    expect_length_rejection(
+        queue,
+        plan,
+        "W",
+        spec.a_numel(),
+        spec.weight_numel() - 1,
+        spec.output_numel(),
+    )?;
+    expect_length_rejection(
+        queue,
+        plan,
+        "D",
+        spec.a_numel(),
+        spec.weight_numel(),
+        spec.output_numel() - 1,
+    )?;
+
+    let workspace_required = plan.workspace_required_bytes();
+    let workspace_gate = if workspace_required == 0 {
+        "not_applicable_zero_required"
+    } else {
+        let stream = queue.stream().clone();
+        let activation = DeviceBuffer::<bf16>::zeroed(&stream, spec.a_numel())?;
+        let weight = DeviceBuffer::<bf16>::zeroed(&stream, spec.weight_numel())?;
+        let mut output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+        let mut workspace =
+            DeviceBuffer::<u8>::zeroed(&stream, workspace_required.saturating_sub(1))?;
+        let mut bindings = queue.bindings(4)?;
+        let activation_handle = bindings.bind_read(&activation)?;
+        let weight_handle = bindings.bind_read(&weight)?;
+        let output_handle = bindings.bind_read_write(&mut output)?;
+        let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+        let mut scope = queue.begin(bindings)?;
+        let result = plan.enqueue_into(
+            &mut scope,
+            Bf16GemmArgs::new(
+                activation_handle,
+                weight_handle,
+                output_handle.write(),
+                workspace_handle.write(),
+            ),
+        );
+        match result {
+            Err(Bf16GemmEnqueueError::WorkspaceTooSmall { required, actual })
+                if required == workspace_required && actual == workspace_required - 1 => {}
+            other => {
+                return Err(format!("short workspace returned the wrong result: {other:?}").into());
+            }
+        }
+        drop(scope);
+        "rejected"
+    };
+
+    println!(
+        "gate=bf16_gemm_h20 case=short_buffers status=pass a=rejected w=rejected d=rejected \
+         workspace={} workspace_required={}",
+        workspace_gate, workspace_required,
+    );
+    Ok(())
+}
+
+fn check_command_capacity(
+    stream: &Arc<CudaStream>,
+    plan: &Bf16GemmPlan,
+) -> Result<(), Box<dyn Error>> {
+    let spec = plan.spec();
+    let mut queue = CommandQueue::new(stream.clone(), 1)?;
+    let activation = DeviceBuffer::<bf16>::zeroed(stream, spec.a_numel())?;
+    let weight = DeviceBuffer::<bf16>::zeroed(stream, spec.weight_numel())?;
+    let mut output = DeviceBuffer::<bf16>::zeroed(stream, spec.output_numel())?;
+    let mut workspace = DeviceBuffer::<u8>::zeroed(stream, workspace_len(plan))?;
+    let mut bindings = queue.bindings(4)?;
+    let activation_handle = bindings.bind_read(&activation)?;
+    let weight_handle = bindings.bind_read(&weight)?;
+    let output_handle = bindings.bind_read_write(&mut output)?;
+    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let args = Bf16GemmArgs::new(
+        activation_handle,
+        weight_handle,
+        output_handle.write(),
+        workspace_handle.write(),
+    );
+    let mut scope = queue.begin(bindings)?;
+    plan.enqueue_into(&mut scope, args)?;
+    match plan.enqueue_into(&mut scope, args) {
+        Err(Bf16GemmEnqueueError::Command(CommandError::CommandCapacityExceeded {
+            capacity: 1,
+        })) => {}
+        other => return Err(format!("second command returned the wrong result: {other:?}").into()),
+    }
+    let completion = scope.finish();
+    if completion.submitted() != 1 {
+        return Err("capacity rejection changed the submitted command count".into());
+    }
+    drop(completion.wait()?);
+
+    println!(
+        "gate=bf16_gemm_h20 case=command_capacity status=pass capacity=1 \
+         first_submitted=true second_rejected_before_ffi=true submitted=1"
+    );
+    Ok(())
+}
+
+fn check_rms_norm_gemm_chain(
+    queue: &mut CommandQueue,
+    rms_provider: &RmsNormProvider,
+    gemm_plan: &Bf16GemmPlan,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let gemm_spec = gemm_plan.spec();
+    let rms_spec = RmsNormSpec::new(1, LARGE_K, 1.0e-5, DType::Bf16)?;
+    let rms_plan = rms_provider.plan_bf16(rms_spec)?;
+    let input_host = vec![bf16::ONE; rms_spec.numel()];
+    let norm_weight_host = vec![bf16::ONE; rms_spec.hidden_size()];
+    let (_, gemm_weight_host) = large_fixture(gemm_spec);
+    let mut intermediate_expected = vec![bf16::ZERO; rms_spec.numel()];
+    let mut expected = vec![bf16::ZERO; gemm_spec.output_numel()];
+    rms_norm_bf16_reference(
+        &input_host,
+        &norm_weight_host,
+        &mut intermediate_expected,
+        rms_spec,
+    )?;
+    bf16_gemm_reference(
+        &intermediate_expected,
+        &gemm_weight_host,
+        &mut expected,
+        gemm_spec,
+    )?;
+
+    let input = DeviceBuffer::from_host(&stream, &input_host)?;
+    let norm_weight = DeviceBuffer::from_host(&stream, &norm_weight_host)?;
+    let mut intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let gemm_weight = DeviceBuffer::from_host(&stream, &gemm_weight_host)?;
+    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, gemm_spec.output_numel())?;
+    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(gemm_plan))?;
+    let mut bindings = queue.bindings(6)?;
+    let input_handle = bindings.bind_read(&input)?;
+    let norm_weight_handle = bindings.bind_read(&norm_weight)?;
+    let intermediate_handle = bindings.bind_read_write(&mut intermediate)?;
+    let gemm_weight_handle = bindings.bind_read(&gemm_weight)?;
+    let output_handle = bindings.bind_read_write(&mut output)?;
+    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let mut scope = queue.begin(bindings)?;
+    rms_plan.enqueue_into(
+        &mut scope,
+        RmsNormArgs::new(
+            input_handle,
+            norm_weight_handle,
+            intermediate_handle.write(),
+        ),
+    )?;
+    gemm_plan.enqueue_into(
+        &mut scope,
+        Bf16GemmArgs::new(
+            intermediate_handle.read(),
+            gemm_weight_handle,
+            output_handle.write(),
+            workspace_handle.write(),
+        ),
+    )?;
+    let completion = scope.finish();
+    if completion.submitted() != 2 {
+        return Err("RMSNorm to GEMM completion covered the wrong command count".into());
+    }
+    drop(completion.wait()?);
+
+    let actual = output.to_host_vec(&stream)?;
+    let comparison = compare(&actual, &expected)?;
+    require_bit_exact("RMSNorm to GEMM chain", comparison)?;
+    println!(
+        "gate=bf16_gemm_h20 case=rms_norm_gemm_chain status=pass rows=1 hidden=4096 \
+         m={} n={} k={} commands=2 completion_records=1 intermediate_waits=0 \
+         gemm_plan_reused=true bit_mismatches={} max_abs={:.9e} digest={:016x}",
+        gemm_spec.m(),
+        gemm_spec.n(),
+        gemm_spec.k(),
+        comparison.bit_mismatches,
+        comparison.max_abs,
+        comparison.digest,
+    );
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let context = CudaContext::new(0)?;
+    let rms_provider = RmsNormProvider::load(&context)?;
+    let gemm_provider = CublasLtProvider::load(&context)?;
+    let stream: Arc<CudaStream> = context.new_stream()?;
+    let mut queue = CommandQueue::new(stream, 2)?;
+
+    let large_spec = Bf16GemmSpec::new(LARGE_M, LARGE_N, LARGE_K)?;
+    let large_plan = gemm_provider.plan_bf16(large_spec)?;
+    let small_plan = gemm_provider.plan_bf16(Bf16GemmSpec::new(2, 3, 4)?)?;
+    println!(
+        "gate=bf16_gemm_h20 case=plan status=pass library_version={} \
+         workspace_limit={} large_workspace_required={} large_waves={:.6} \
+         small_workspace_required={} small_waves={:.6}",
+        gemm_provider.library_version(),
+        gemm_provider.workspace_limit_bytes(),
+        large_plan.workspace_required_bytes(),
+        large_plan.heuristic_waves_count(),
+        small_plan.workspace_required_bytes(),
+        small_plan.heuristic_waves_count(),
+    );
+
+    check_standalone(&mut queue, &large_plan)?;
+    check_row_major_transpose(&mut queue, &small_plan)?;
+    check_short_buffers(&mut queue, &small_plan)?;
+    check_command_capacity(queue.stream(), &small_plan)?;
+    check_rms_norm_gemm_chain(&mut queue, &rms_provider, &large_plan)?;
+    println!("gate=bf16_gemm_h20 suite=all status=pass");
+    Ok(())
+}

--- a/crates/loom-infer-cuda/src/bin/rms_norm_h20.rs
+++ b/crates/loom-infer-cuda/src/bin/rms_norm_h20.rs
@@ -236,7 +236,7 @@ fn check_low_precision_case<T: LowPrecision>(
     )?;
     let completion = scope.finish();
     if completion.submitted() != 1 {
-        return Err(format!("{} single scope retained the wrong launch count", T::NAME).into());
+        return Err(format!("{} single scope retained the wrong command count", T::NAME).into());
     }
     drop(completion.wait()?);
 
@@ -441,7 +441,7 @@ fn check_f32_chained_scope(
 
     println!(
         "rms_norm_f32 chained rows=8 hidden=4096 stream=non_default scopes=2 \
-         launches_per_scope=2 completion_records_per_scope=1 intermediate_waits=0 \
+         commands_per_scope=2 completion_records_per_scope=1 intermediate_waits=0 \
          queue_reused=true bindings_reused=true max_abs_error={max_abs_error:.9e}"
     );
     Ok(())
@@ -643,7 +643,7 @@ fn check_low_precision_chained_scope<T: LowPrecision>(
         let completion = scope.finish();
         if completion.submitted() != 2 {
             return Err(
-                format!("{} chained scope retained the wrong launch count", T::NAME).into(),
+                format!("{} chained scope retained the wrong command count", T::NAME).into(),
             );
         }
         bindings = completion.wait()?;
@@ -663,7 +663,7 @@ fn check_low_precision_chained_scope<T: LowPrecision>(
     }
     println!(
         "rms_norm_{} chained rows=8 hidden=4096 path={:?} scopes=2 \
-         launches_per_scope=2 completion_records_per_scope=1 intermediate_waits=0 \
+         commands_per_scope=2 completion_records_per_scope=1 intermediate_waits=0 \
          queue_reused=true bindings_reused=true heterogeneous_bindings=f32+u8+{} \
          max_abs_error={:.9e} max_ulp_error={}",
         T::NAME,

--- a/crates/loom-infer-cuda/src/command.rs
+++ b/crates/loom-infer-cuda/src/command.rs
@@ -4,6 +4,7 @@
 
 use cuda_core::{CudaEvent, CudaFunction, CudaStream, DeviceBuffer, DeviceCopy, DriverError};
 use half::{bf16, f16};
+use std::any::Any;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,24 +14,24 @@ static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 /// A reusable submission queue for one exact CUDA stream.
 ///
-/// The queue preallocates its completion event and function-retention storage.
+/// The queue preallocates its completion event and resource-retention storage.
 /// Rust's mutable borrow rules prevent a second scope from re-recording the
 /// event while an earlier completion is still alive.
 pub struct CommandQueue {
     id: u64,
     stream: Arc<CudaStream>,
     completion_event: CudaEvent,
-    retained_functions: Vec<CudaFunction>,
-    max_launches: usize,
+    retained_resources: Vec<RetainedResource>,
+    max_commands: usize,
     poisoned: bool,
 }
 
 impl CommandQueue {
-    /// Creates a queue for `stream` with storage for at most `max_launches`
+    /// Creates a queue for `stream` with storage for at most `max_commands`
     /// commands per scope.
-    pub fn new(stream: Arc<CudaStream>, max_launches: usize) -> Result<Self, CommandError> {
-        if max_launches == 0 {
-            return Err(CommandError::ZeroLaunchCapacity);
+    pub fn new(stream: Arc<CudaStream>, max_commands: usize) -> Result<Self, CommandError> {
+        if max_commands == 0 {
+            return Err(CommandError::ZeroCommandCapacity);
         }
 
         let id = fresh_id()?;
@@ -39,8 +40,8 @@ impl CommandQueue {
             id,
             stream,
             completion_event,
-            retained_functions: Vec::with_capacity(max_launches),
-            max_launches,
+            retained_resources: Vec::with_capacity(max_commands),
+            max_commands,
             poisoned: false,
         })
     }
@@ -50,8 +51,8 @@ impl CommandQueue {
         &self.stream
     }
 
-    pub const fn max_launches(&self) -> usize {
-        self.max_launches
+    pub const fn max_commands(&self) -> usize {
+        self.max_commands
     }
 
     /// Creates reusable checked binding storage outside the enqueue path.
@@ -86,7 +87,7 @@ impl CommandQueue {
         {
             return Err(CommandError::BindingsQueueMismatch);
         }
-        if !self.retained_functions.is_empty() {
+        if !self.retained_resources.is_empty() {
             self.poisoned = true;
             return Err(CommandError::QueuePoisoned);
         }
@@ -94,10 +95,28 @@ impl CommandQueue {
         Ok(CommandScope {
             queue: Some(self),
             bindings: Some(bindings),
+            scope_id: fresh_id()?,
             submitted: 0,
             submission_error: None,
             finished: false,
         })
+    }
+}
+
+impl Drop for CommandQueue {
+    fn drop(&mut self) {
+        if self.retained_resources.is_empty() {
+            return;
+        }
+
+        let synchronize_error = synchronize_stream_or_abort(self);
+        self.retained_resources.clear();
+        if let Some(error) = synchronize_error {
+            eprintln!(
+                "loom-infer-cuda command queue synchronized after a stream error during drop: \
+                 {error}"
+            );
+        }
     }
 }
 
@@ -325,8 +344,9 @@ pub struct Write<T: BindingElement> {
 pub struct CommandScope<'queue, 'buffer> {
     queue: Option<&'queue mut CommandQueue>,
     bindings: Option<CheckedBindings<'buffer>>,
+    scope_id: u64,
     submitted: usize,
-    submission_error: Option<DriverError>,
+    submission_error: Option<SubmissionError>,
     finished: bool,
 }
 
@@ -356,39 +376,48 @@ impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
         }
     }
 
-    pub(crate) fn ensure_launch_capacity(&self) -> Result<(), CommandError> {
+    pub(crate) fn prepare_command(&self) -> Result<CommandPermit, CommandError> {
         if self.submission_error.is_some() {
             return Err(CommandError::ScopePoisoned);
         }
         let queue = self.queue.as_ref().expect("live command scope has a queue");
-        if self.submitted == queue.max_launches {
-            Err(CommandError::LaunchCapacityExceeded {
-                capacity: queue.max_launches,
+        if self.submitted >= queue.max_commands {
+            Err(CommandError::CommandCapacityExceeded {
+                capacity: queue.max_commands,
             })
         } else {
-            Ok(())
+            Ok(CommandPermit {
+                queue_id: queue.id,
+                scope_id: self.scope_id,
+                submission_index: self.submitted,
+            })
         }
     }
 
-    pub(crate) fn resolve_triplet<T: ResolveElement>(
+    pub(crate) fn resolve_rrw<A, B, C>(
         &mut self,
-        input: Read<T>,
-        weight: Read<T>,
-        output: Write<T>,
-    ) -> Result<ResolvedTriplet<'_, T>, CommandError> {
+        first: Read<A>,
+        second: Read<B>,
+        third: Write<C>,
+    ) -> Result<ResolvedRrw<'_, A, B, C>, CommandError>
+    where
+        A: ResolveElement,
+        B: ResolveElement,
+        C: ResolveElement,
+    {
         let bindings = self
             .bindings
             .as_mut()
             .expect("live command scope has bindings");
-        for handle in [input.set_id, weight.set_id, output.set_id] {
+        for handle in [first.set_id, second.set_id, third.set_id] {
             if handle != bindings.set_id {
                 return Err(CommandError::BindingSetMismatch);
             }
         }
-        if input.slot == weight.slot || input.slot == output.slot || weight.slot == output.slot {
-            return Err(CommandError::AliasedOperands);
+        if first.slot == second.slot || first.slot == third.slot || second.slot == third.slot {
+            return Err(CommandError::DuplicateBindingSlot);
         }
-        for slot in [input.slot, weight.slot, output.slot] {
+        for slot in [first.slot, second.slot, third.slot] {
             if slot >= bindings.leases.len() {
                 return Err(CommandError::BindingSlotOutOfRange {
                     slot,
@@ -397,40 +426,170 @@ impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
             }
         }
 
-        let [input_lease, weight_lease, output_lease] = bindings
+        let [first_lease, second_lease, third_lease] = bindings
             .leases
-            .get_disjoint_mut([input.slot, weight.slot, output.slot])
+            .get_disjoint_mut([first.slot, second.slot, third.slot])
             .expect("validated binding slots are pairwise disjoint");
-        let input_buffer =
-            T::read(input_lease).map_err(|error| map_lease_error(error, input.slot))?;
-        let weight_buffer =
-            T::read(weight_lease).map_err(|error| map_lease_error(error, weight.slot))?;
-        let output_buffer =
-            T::write(output_lease).map_err(|error| map_lease_error(error, output.slot))?;
+        let first_buffer =
+            A::read(first_lease).map_err(|error| map_lease_error(error, first.slot))?;
+        let second_buffer =
+            B::read(second_lease).map_err(|error| map_lease_error(error, second.slot))?;
+        let third_buffer =
+            C::write(third_lease).map_err(|error| map_lease_error(error, third.slot))?;
         let queue = self.queue.as_ref().expect("live command scope has a queue");
 
-        Ok(ResolvedTriplet {
+        Ok(ResolvedRrw {
             stream: &queue.stream,
-            input: input_buffer,
-            weight: weight_buffer,
-            output: output_buffer,
+            first: first_buffer,
+            second: second_buffer,
+            third: third_buffer,
         })
     }
 
-    pub(crate) fn retain_launch(&mut self, function: CudaFunction) {
-        let queue = self.queue.as_mut().expect("live command scope has a queue");
-        debug_assert!(queue.retained_functions.len() < queue.max_launches);
-        queue.retained_functions.push(function);
-        self.submitted += 1;
+    pub(crate) fn resolve_rrww<A, B, C, D>(
+        &mut self,
+        first: Read<A>,
+        second: Read<B>,
+        third: Write<C>,
+        fourth: Write<D>,
+    ) -> Result<ResolvedRrww<'_, A, B, C, D>, CommandError>
+    where
+        A: ResolveElement,
+        B: ResolveElement,
+        C: ResolveElement,
+        D: ResolveElement,
+    {
+        let bindings = self
+            .bindings
+            .as_mut()
+            .expect("live command scope has bindings");
+        for handle in [first.set_id, second.set_id, third.set_id, fourth.set_id] {
+            if handle != bindings.set_id {
+                return Err(CommandError::BindingSetMismatch);
+            }
+        }
+        let slots = [first.slot, second.slot, third.slot, fourth.slot];
+        for (index, slot) in slots.iter().enumerate() {
+            if slots[..index].contains(slot) {
+                return Err(CommandError::DuplicateBindingSlot);
+            }
+            if *slot >= bindings.leases.len() {
+                return Err(CommandError::BindingSlotOutOfRange {
+                    slot: *slot,
+                    bindings: bindings.leases.len(),
+                });
+            }
+        }
+
+        let [first_lease, second_lease, third_lease, fourth_lease] = bindings
+            .leases
+            .get_disjoint_mut(slots)
+            .expect("validated binding slots are pairwise disjoint");
+        let first_buffer =
+            A::read(first_lease).map_err(|error| map_lease_error(error, first.slot))?;
+        let second_buffer =
+            B::read(second_lease).map_err(|error| map_lease_error(error, second.slot))?;
+        let third_buffer =
+            C::write(third_lease).map_err(|error| map_lease_error(error, third.slot))?;
+        let fourth_buffer =
+            D::write(fourth_lease).map_err(|error| map_lease_error(error, fourth.slot))?;
+        let queue = self.queue.as_ref().expect("live command scope has a queue");
+
+        Ok(ResolvedRrww {
+            stream: &queue.stream,
+            first: first_buffer,
+            second: second_buffer,
+            third: third_buffer,
+            fourth: fourth_buffer,
+        })
     }
 
-    pub(crate) fn retain_failed_launch(&mut self, function: CudaFunction, error: DriverError) {
-        let queue = self.queue.as_mut().expect("live command scope has a queue");
-        debug_assert!(queue.retained_functions.len() < queue.max_launches);
-        queue.retained_functions.push(function);
-        self.submitted += 1;
-        self.submission_error = Some(error);
+    pub(crate) fn record_cuda_submission(&mut self, permit: CommandPermit, function: CudaFunction) {
+        self.record_submission(
+            permit,
+            RetainedResource::Kernel {
+                _function: function,
+            },
+        );
     }
+
+    pub(crate) fn record_failed_cuda_submission(
+        &mut self,
+        permit: CommandPermit,
+        function: CudaFunction,
+        error: DriverError,
+    ) {
+        self.record_submission(
+            permit,
+            RetainedResource::Kernel {
+                _function: function,
+            },
+        );
+        self.submission_error = Some(SubmissionError::Driver(error));
+    }
+
+    pub(crate) fn record_external_submission<T>(&mut self, permit: CommandPermit, resource: Arc<T>)
+    where
+        T: Any + Send + Sync,
+    {
+        self.record_submission(
+            permit,
+            RetainedResource::External {
+                _resource: resource,
+            },
+        );
+    }
+
+    pub(crate) fn record_failed_external_submission<T>(
+        &mut self,
+        permit: CommandPermit,
+        resource: Arc<T>,
+        error: ExternalCommandError,
+    ) where
+        T: Any + Send + Sync,
+    {
+        self.record_submission(
+            permit,
+            RetainedResource::External {
+                _resource: resource,
+            },
+        );
+        self.submission_error = Some(SubmissionError::External(error));
+    }
+
+    pub(crate) fn record_preflight_driver_failure(&mut self, error: DriverError) {
+        self.submission_error = Some(SubmissionError::Driver(error));
+    }
+
+    fn record_submission(&mut self, permit: CommandPermit, resource: RetainedResource) {
+        let queue = self.queue.as_mut().expect("live command scope has a queue");
+        if permit.queue_id != queue.id
+            || permit.scope_id != self.scope_id
+            || permit.submission_index != self.submitted
+            || queue.retained_resources.len() != self.submitted
+            || self.submitted >= queue.max_commands
+        {
+            abort_after_bookkeeping_invariant();
+        }
+        queue.retained_resources.push(resource);
+        self.submitted += 1;
+    }
+}
+
+/// A single-use proof that one command fits in the preallocated queue.
+pub(crate) struct CommandPermit {
+    queue_id: u64,
+    scope_id: u64,
+    submission_index: usize,
+}
+
+enum RetainedResource {
+    Kernel {
+        _function: CudaFunction,
+    },
+    External {
+        _resource: Arc<dyn Any + Send + Sync>,
+    },
 }
 
 impl Drop for CommandScope<'_, '_> {
@@ -447,19 +606,47 @@ impl Drop for CommandScope<'_, '_> {
             if self.submission_error.is_some() || synchronize_error.is_some() {
                 queue.poisoned = true;
             }
-            if let Some(error) = self.submission_error.or(synchronize_error) {
+            let submission_driver_error = self
+                .submission_error
+                .and_then(SubmissionError::driver_error);
+            queue.retained_resources.clear();
+            if let Some(error) = submission_driver_error {
                 queue.stream.context().record_err::<()>(Err(error));
             }
+            if let Some(error) = synchronize_error {
+                queue.stream.context().record_err::<()>(Err(error));
+            }
+        } else {
+            queue.retained_resources.clear();
+            if let Some(error) = self.submission_error {
+                queue.poisoned = true;
+                if let Some(error) = error.driver_error() {
+                    queue.stream.context().record_err::<()>(Err(error));
+                }
+            }
         }
-        queue.retained_functions.clear();
     }
 }
 
-pub(crate) struct ResolvedTriplet<'scope, T: BindingElement> {
+pub(crate) struct ResolvedRrw<'scope, A: BindingElement, B: BindingElement, C: BindingElement> {
     pub(crate) stream: &'scope CudaStream,
-    pub(crate) input: &'scope DeviceBuffer<T>,
-    pub(crate) weight: &'scope DeviceBuffer<T>,
-    pub(crate) output: &'scope mut DeviceBuffer<T>,
+    pub(crate) first: &'scope DeviceBuffer<A>,
+    pub(crate) second: &'scope DeviceBuffer<B>,
+    pub(crate) third: &'scope mut DeviceBuffer<C>,
+}
+
+pub(crate) struct ResolvedRrww<
+    'scope,
+    A: BindingElement,
+    B: BindingElement,
+    C: BindingElement,
+    D: BindingElement,
+> {
+    pub(crate) stream: &'scope CudaStream,
+    pub(crate) first: &'scope DeviceBuffer<A>,
+    pub(crate) second: &'scope DeviceBuffer<B>,
+    pub(crate) third: &'scope mut DeviceBuffer<C>,
+    pub(crate) fourth: &'scope mut DeviceBuffer<D>,
 }
 
 /// The final fence and all leases retained by a completed command scope.
@@ -468,7 +655,7 @@ pub struct CommandCompletion<'queue, 'buffer> {
     queue: Option<&'queue mut CommandQueue>,
     bindings: Option<CheckedBindings<'buffer>>,
     submitted: usize,
-    submission_error: Option<DriverError>,
+    submission_error: Option<SubmissionError>,
     record_error: Option<DriverError>,
     poll_error: Option<DriverError>,
     complete: bool,
@@ -477,9 +664,6 @@ pub struct CommandCompletion<'queue, 'buffer> {
 impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
     /// Returns whether all submitted commands have completed without blocking.
     pub fn is_complete(&mut self) -> Result<bool, CommandError> {
-        if self.submitted == 0 {
-            return Ok(true);
-        }
         if let Some(error) = self.submission_error {
             return Err(error.into());
         }
@@ -488,6 +672,9 @@ impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
         }
         if let Some(error) = self.poll_error {
             return Err(error.into());
+        }
+        if self.submitted == 0 {
+            return Ok(true);
         }
         let queue = self.queue.as_ref().expect("live completion has a queue");
         match queue.completion_event.query() {
@@ -507,18 +694,18 @@ impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
                 self.queue
                     .as_mut()
                     .expect("live completion has a queue")
-                    .retained_functions
+                    .retained_resources
                     .clear();
                 Ok(self.bindings.take().expect("live completion has bindings"))
             }
-            Some(error) => {
+            Some(failure) => {
                 self.complete = true;
                 let queue = self.queue.as_mut().expect("live completion has a queue");
                 queue.poisoned = true;
-                queue.retained_functions.clear();
-                queue.stream.context().record_err::<()>(Err(error));
+                queue.retained_resources.clear();
+                record_settlement_errors(queue, failure);
                 self.bindings.take();
-                Err(error.into())
+                Err(failure.command_error())
             }
         }
     }
@@ -528,29 +715,38 @@ impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
         self.submitted
     }
 
-    fn settle(&self) -> Option<DriverError> {
+    fn settle(&self) -> Option<SettlementFailure> {
         if self.submitted == 0 {
-            return self.submission_error;
+            return self.submission_error.map(|reported| SettlementFailure {
+                reported,
+                synchronize_error: None,
+            });
         }
         let queue = self.queue.as_ref().expect("live completion has a queue");
         if let Some(submission_error) = self.submission_error {
-            let _ = synchronize_stream_or_abort(queue);
-            return Some(submission_error);
+            return Some(SettlementFailure {
+                reported: submission_error,
+                synchronize_error: synchronize_stream_or_abort(queue),
+            });
         }
         if let Some(record_error) = self.record_error {
-            let _ = synchronize_stream_or_abort(queue);
-            return Some(record_error);
+            return Some(SettlementFailure {
+                reported: SubmissionError::Driver(record_error),
+                synchronize_error: synchronize_stream_or_abort(queue),
+            });
         }
         if let Some(poll_error) = self.poll_error {
-            let _ = synchronize_stream_or_abort(queue);
-            return Some(poll_error);
+            return Some(SettlementFailure {
+                reported: SubmissionError::Driver(poll_error),
+                synchronize_error: synchronize_stream_or_abort(queue),
+            });
         }
         match queue.completion_event.synchronize() {
             Ok(()) => None,
-            Err(event_error) => {
-                let _ = synchronize_stream_or_abort(queue);
-                Some(event_error)
-            }
+            Err(event_error) => Some(SettlementFailure {
+                reported: SubmissionError::Driver(event_error),
+                synchronize_error: synchronize_stream_or_abort(queue),
+            }),
         }
     }
 }
@@ -562,11 +758,13 @@ impl Drop for CommandCompletion<'_, '_> {
         }
         let result = self.settle();
         let queue = self.queue.as_mut().expect("live completion has a queue");
-        if let Some(error) = result {
+        if let Some(failure) = result {
             queue.poisoned = true;
-            queue.stream.context().record_err::<()>(Err(error));
+            queue.retained_resources.clear();
+            record_settlement_errors(queue, failure);
+        } else {
+            queue.retained_resources.clear();
         }
-        queue.retained_functions.clear();
         self.complete = true;
     }
 }
@@ -603,10 +801,87 @@ fn abort_after_sync_failure(stream_error: DriverError, context_error: DriverErro
     std::process::abort()
 }
 
+fn abort_after_bookkeeping_invariant() -> ! {
+    eprintln!(
+        "loom-infer-cuda detected an internal command-accounting violation after GPU submission; \
+         aborting to preserve resource safety"
+    );
+    std::process::abort()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[error("{provider} command submission failed with status {status}")]
+pub struct ExternalCommandError {
+    provider: &'static str,
+    status: i32,
+}
+
+impl ExternalCommandError {
+    pub const fn new(provider: &'static str, status: i32) -> Self {
+        Self { provider, status }
+    }
+
+    pub const fn provider(self) -> &'static str {
+        self.provider
+    }
+
+    pub const fn status(self) -> i32 {
+        self.status
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubmissionError {
+    Driver(DriverError),
+    External(ExternalCommandError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SettlementFailure {
+    reported: SubmissionError,
+    synchronize_error: Option<DriverError>,
+}
+
+impl SettlementFailure {
+    fn command_error(self) -> CommandError {
+        match self.synchronize_error {
+            Some(error) => CommandError::Driver(error),
+            None => self.reported.into(),
+        }
+    }
+}
+
+fn record_settlement_errors(queue: &CommandQueue, failure: SettlementFailure) {
+    if let Some(error) = failure.reported.driver_error() {
+        queue.stream.context().record_err::<()>(Err(error));
+    }
+    if let Some(error) = failure.synchronize_error {
+        queue.stream.context().record_err::<()>(Err(error));
+    }
+}
+
+impl SubmissionError {
+    const fn driver_error(self) -> Option<DriverError> {
+        match self {
+            Self::Driver(error) => Some(error),
+            Self::External(_) => None,
+        }
+    }
+}
+
+impl From<SubmissionError> for CommandError {
+    fn from(error: SubmissionError) -> Self {
+        match error {
+            SubmissionError::Driver(error) => Self::Driver(error),
+            SubmissionError::External(error) => Self::External(error),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum CommandError {
-    #[error("command queues require capacity for at least one launch")]
-    ZeroLaunchCapacity,
+    #[error("command queues require capacity for at least one command")]
+    ZeroCommandCapacity,
     #[error("checked bindings require capacity for at least one resource")]
     ZeroBindingCapacity,
     #[error("command queue identifier space is exhausted")]
@@ -615,7 +890,7 @@ pub enum CommandError {
     BindingsQueueMismatch,
     #[error("the command queue is poisoned by an earlier completion failure")]
     QueuePoisoned,
-    #[error("the command scope is poisoned by a CUDA launch failure")]
+    #[error("the command scope is poisoned by an earlier submission failure")]
     ScopePoisoned,
     #[error("checked binding capacity {capacity} is exhausted")]
     BindingCapacityExceeded { capacity: usize },
@@ -634,10 +909,12 @@ pub enum CommandError {
     BindingIsReadOnly { slot: usize },
     #[error("binding slot {slot} has a different element type than its resource handle")]
     BindingTypeMismatch { slot: usize },
-    #[error("one operator cannot alias its input, weight, or output bindings")]
-    AliasedOperands,
-    #[error("command scope launch capacity {capacity} is exhausted")]
-    LaunchCapacityExceeded { capacity: usize },
+    #[error("one command cannot use the same binding slot for multiple operands")]
+    DuplicateBindingSlot,
+    #[error("command scope capacity {capacity} is exhausted")]
+    CommandCapacityExceeded { capacity: usize },
+    #[error(transparent)]
+    External(#[from] ExternalCommandError),
     #[error(transparent)]
     Driver(#[from] DriverError),
 }

--- a/crates/loom-infer-cuda/src/gemm.rs
+++ b/crates/loom-infer-cuda/src/gemm.rs
@@ -1,0 +1,646 @@
+//! Fixed cuBLASLt plans for contiguous inference GEMM.
+
+use crate::command::{CommandError, CommandScope, ExternalCommandError, Read, ResolvedRrww, Write};
+use cuda_core::{CudaContext, DeviceBuffer, DriverError, IntoResult, sys as cuda_sys};
+use cudarc::cublaslt::{result, sys};
+use half::bf16;
+use loom_infer::Bf16GemmSpec;
+use std::ffi::c_void;
+use std::mem::{MaybeUninit, size_of};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI32, Ordering};
+use thiserror::Error;
+
+const CUBLASLT_PROVIDER: &str = "cuBLASLt";
+const HOPPER_WORKSPACE_LIMIT_BYTES: usize = 32 * 1024 * 1024;
+const TENSOR_ALIGNMENT_BYTES: u64 = 16;
+const WORKSPACE_ALIGNMENT_BYTES: u64 = 256;
+
+/// A cuBLASLt provider bound to one exact CUDA context.
+#[derive(Clone)]
+pub struct CublasLtProvider {
+    inner: Arc<ProviderInner>,
+}
+
+impl CublasLtProvider {
+    /// Creates one long-lived cuBLASLt handle in `context`.
+    pub fn load(context: &Arc<CudaContext>) -> Result<Self, Bf16GemmPlanError> {
+        context.bind_to_thread()?;
+        let handle = result::create_handle()?;
+        // SAFETY: cuBLASLt is loaded and initialized because handle creation
+        // succeeded. This query has no pointer or lifetime arguments.
+        let library_version = unsafe { sys::cublasLtGetVersion() };
+        Ok(Self {
+            inner: Arc::new(ProviderInner {
+                context: context.clone(),
+                handle,
+                library_version,
+                sticky_status: AtomicI32::new(0),
+            }),
+        })
+    }
+
+    pub const fn workspace_limit_bytes(&self) -> usize {
+        HOPPER_WORKSPACE_LIMIT_BYTES
+    }
+
+    pub fn library_version(&self) -> usize {
+        self.inner.library_version
+    }
+
+    /// Selects and freezes one BF16 algorithm for `spec`.
+    pub fn plan_bf16(&self, spec: Bf16GemmSpec) -> Result<Bf16GemmPlan, Bf16GemmPlanError> {
+        self.inner.require_healthy()?;
+        self.inner.context.bind_to_thread()?;
+        let dimensions = CheckedDimensions::new(spec)?;
+
+        let matmul_desc = MatmulDesc::new(self.inner.clone())?;
+        matmul_desc.set_transpose(
+            sys::cublasLtMatmulDescAttributes_t::CUBLASLT_MATMUL_DESC_TRANSA,
+            false,
+        )?;
+        matmul_desc.set_transpose(
+            sys::cublasLtMatmulDescAttributes_t::CUBLASLT_MATMUL_DESC_TRANSB,
+            true,
+        )?;
+
+        let a_layout = MatrixLayout::row_major(
+            self.inner.clone(),
+            dimensions.m,
+            dimensions.k,
+            dimensions.k_ld,
+        )?;
+        let weight_layout = MatrixLayout::row_major(
+            self.inner.clone(),
+            dimensions.n,
+            dimensions.k,
+            dimensions.k_ld,
+        )?;
+        let output_layout = MatrixLayout::row_major(
+            self.inner.clone(),
+            dimensions.m,
+            dimensions.n,
+            dimensions.n_ld,
+        )?;
+
+        let preference = MatmulPreference::new(self.inner.clone())?;
+        preference.set_workspace_limit(HOPPER_WORKSPACE_LIMIT_BYTES)?;
+        for attribute in [
+            sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES,
+            sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES,
+            sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES,
+            sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES,
+        ] {
+            preference.set_minimum_alignment(attribute, TENSOR_ALIGNMENT_BYTES as u32)?;
+        }
+
+        // SAFETY: every descriptor belongs to this live provider, is fully
+        // initialized, and remains owned until after the call returns.
+        let heuristic = unsafe {
+            result::get_matmul_algo_heuristic(
+                self.inner.handle,
+                matmul_desc.raw,
+                a_layout.raw,
+                weight_layout.raw,
+                output_layout.raw,
+                output_layout.raw,
+                preference.raw,
+            )?
+        };
+        if heuristic.workspaceSize > HOPPER_WORKSPACE_LIMIT_BYTES {
+            return Err(Bf16GemmPlanError::WorkspaceRequirementExceedsLimit {
+                required: heuristic.workspaceSize,
+                limit: HOPPER_WORKSPACE_LIMIT_BYTES,
+            });
+        }
+
+        Ok(Bf16GemmPlan {
+            inner: Arc::new(PlanInner {
+                provider: self.inner.clone(),
+                spec,
+                matmul_desc,
+                a_layout,
+                weight_layout,
+                output_layout,
+                algorithm: heuristic.algo,
+                workspace_required_bytes: heuristic.workspaceSize,
+                waves_count: heuristic.wavesCount,
+            }),
+        })
+    }
+}
+
+struct ProviderInner {
+    context: Arc<CudaContext>,
+    handle: sys::cublasLtHandle_t,
+    library_version: usize,
+    sticky_status: AtomicI32,
+}
+
+// SAFETY: cuBLASLt handles may be called concurrently. Every call binds the
+// owning cuda-oxide context first. The handle is immutable after construction
+// and is retained by every plan until all submitted work is quiescent.
+unsafe impl Send for ProviderInner {}
+// SAFETY: the same invariants permit shared access from multiple host threads.
+unsafe impl Sync for ProviderInner {}
+
+impl ProviderInner {
+    fn require_healthy(&self) -> Result<(), Bf16GemmPlanError> {
+        let status = self.sticky_status.load(Ordering::Acquire);
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(Bf16GemmPlanError::ProviderPoisoned { status })
+        }
+    }
+
+    fn record_cleanup_result(&self, cleanup: Result<(), result::CublasError>) {
+        if let Err(error) = cleanup {
+            let _ = self.sticky_status.compare_exchange(
+                0,
+                cublas_status(error),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
+    }
+
+    fn run_cleanup(&self, cleanup: impl FnOnce() -> Result<(), result::CublasError>) {
+        match bind_context_for_cleanup(&self.context) {
+            Ok(()) => self.record_cleanup_result(cleanup()),
+            Err(error) => self.context.record_err::<()>(Err(error)),
+        }
+    }
+}
+
+impl Drop for ProviderInner {
+    fn drop(&mut self) {
+        let handle = self.handle;
+        // SAFETY: this is the final Arc, so no plan or completion can still
+        // use the handle. cuBLASLt owns the pointed-to handle allocation.
+        self.run_cleanup(|| unsafe { result::destroy_handle(handle) });
+    }
+}
+
+struct MatmulDesc {
+    provider: Arc<ProviderInner>,
+    raw: sys::cublasLtMatmulDesc_t,
+}
+
+impl MatmulDesc {
+    fn new(provider: Arc<ProviderInner>) -> Result<Self, result::CublasError> {
+        let raw = result::create_matmul_desc(
+            sys::cublasComputeType_t::CUBLAS_COMPUTE_32F,
+            sys::cudaDataType_t::CUDA_R_32F,
+        )?;
+        Ok(Self { provider, raw })
+    }
+
+    fn set_transpose(
+        &self,
+        attribute: sys::cublasLtMatmulDescAttributes_t,
+        transpose: bool,
+    ) -> Result<(), result::CublasError> {
+        // cublasOperation_t is a 32-bit C enum: 0 is N and 1 is T.
+        let operation = i32::from(transpose);
+        // SAFETY: `raw` is live, `operation` has the ABI size expected by the
+        // attribute, and cuBLASLt copies the value before returning.
+        unsafe {
+            result::set_matmul_desc_attribute(
+                self.raw,
+                attribute,
+                (&operation as *const i32).cast(),
+                size_of::<i32>(),
+            )
+        }
+    }
+}
+
+impl Drop for MatmulDesc {
+    fn drop(&mut self) {
+        let raw = self.raw;
+        // SAFETY: this wrapper uniquely owns the live descriptor.
+        self.provider
+            .run_cleanup(|| unsafe { result::destroy_matmul_desc(raw) });
+    }
+}
+
+struct MatrixLayout {
+    provider: Arc<ProviderInner>,
+    raw: sys::cublasLtMatrixLayout_t,
+}
+
+impl MatrixLayout {
+    fn row_major(
+        provider: Arc<ProviderInner>,
+        rows: u64,
+        columns: u64,
+        leading_dimension: i64,
+    ) -> Result<Self, result::CublasError> {
+        let raw = result::create_matrix_layout(
+            sys::cudaDataType_t::CUDA_R_16BF,
+            rows,
+            columns,
+            leading_dimension,
+        )?;
+        let layout = Self { provider, raw };
+        let order = sys::cublasLtOrder_t::CUBLASLT_ORDER_ROW;
+        // SAFETY: `layout.raw` is live, and `order` has the exact enum type
+        // and size required by CUBLASLT_MATRIX_LAYOUT_ORDER.
+        unsafe {
+            result::set_matrix_layout_attribute(
+                layout.raw,
+                sys::cublasLtMatrixLayoutAttribute_t::CUBLASLT_MATRIX_LAYOUT_ORDER,
+                (&order as *const sys::cublasLtOrder_t).cast(),
+                size_of::<sys::cublasLtOrder_t>(),
+            )?;
+        }
+        Ok(layout)
+    }
+}
+
+impl Drop for MatrixLayout {
+    fn drop(&mut self) {
+        let raw = self.raw;
+        // SAFETY: this wrapper uniquely owns the live layout.
+        self.provider
+            .run_cleanup(|| unsafe { result::destroy_matrix_layout(raw) });
+    }
+}
+
+struct MatmulPreference {
+    provider: Arc<ProviderInner>,
+    raw: sys::cublasLtMatmulPreference_t,
+}
+
+impl MatmulPreference {
+    fn new(provider: Arc<ProviderInner>) -> Result<Self, result::CublasError> {
+        let raw = result::create_matmul_pref()?;
+        Ok(Self { provider, raw })
+    }
+
+    fn set_workspace_limit(&self, bytes: usize) -> Result<(), result::CublasError> {
+        let bytes = bytes as u64;
+        // SAFETY: `raw` is live and cuBLASLt copies the uint64 value before
+        // returning.
+        unsafe {
+            result::set_matmul_pref_attribute(
+                self.raw,
+                sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                (&bytes as *const u64).cast(),
+                size_of::<u64>(),
+            )
+        }
+    }
+
+    fn set_minimum_alignment(
+        &self,
+        attribute: sys::cublasLtMatmulPreferenceAttributes_t,
+        bytes: u32,
+    ) -> Result<(), result::CublasError> {
+        // SAFETY: `raw` is live and alignment attributes consume a u32 value.
+        unsafe {
+            result::set_matmul_pref_attribute(
+                self.raw,
+                attribute,
+                (&bytes as *const u32).cast(),
+                size_of::<u32>(),
+            )
+        }
+    }
+}
+
+impl Drop for MatmulPreference {
+    fn drop(&mut self) {
+        let raw = self.raw;
+        // SAFETY: this wrapper uniquely owns the live preference.
+        self.provider
+            .run_cleanup(|| unsafe { result::destroy_matmul_pref(raw) });
+    }
+}
+
+/// One immutable BF16 cuBLASLt algorithm and its exact layouts.
+#[derive(Clone)]
+pub struct Bf16GemmPlan {
+    inner: Arc<PlanInner>,
+}
+
+impl Bf16GemmPlan {
+    pub fn spec(&self) -> Bf16GemmSpec {
+        self.inner.spec
+    }
+
+    pub fn workspace_required_bytes(&self) -> usize {
+        self.inner.workspace_required_bytes
+    }
+
+    pub const fn tensor_alignment_bytes(&self) -> u64 {
+        TENSOR_ALIGNMENT_BYTES
+    }
+
+    pub const fn workspace_alignment_bytes(&self) -> u64 {
+        WORKSPACE_ALIGNMENT_BYTES
+    }
+
+    pub fn heuristic_waves_count(&self) -> f32 {
+        self.inner.waves_count
+    }
+
+    /// Enqueues the frozen algorithm on the scope's caller-owned stream.
+    pub fn enqueue_into(
+        &self,
+        scope: &mut CommandScope<'_, '_>,
+        args: Bf16GemmArgs,
+    ) -> Result<(), Bf16GemmEnqueueError> {
+        let permit = scope.prepare_command()?;
+        if let Err(error) = self.inner.provider.context.bind_to_thread() {
+            scope.record_preflight_driver_failure(error);
+            return Err(error.into());
+        }
+        let matmul_result = {
+            let resolved =
+                scope.resolve_rrww(args.activation, args.weight, args.output, args.workspace)?;
+            self.validate_resolved(&resolved)?;
+            let alpha = 1.0_f32;
+            let beta = 0.0_f32;
+            let output = mutable_device_ptr(resolved.third);
+            // SAFETY: the immutable plan fixes compatible descriptors and one
+            // heuristic algorithm. Exact spans, access modes, context,
+            // alignment, workspace size, and stream identity were validated
+            // above. The command scope retains every buffer and `PlanInner`
+            // until CUDA quiescence is confirmed.
+            unsafe {
+                result::matmul(
+                    self.inner.provider.handle,
+                    self.inner.matmul_desc.raw,
+                    (&alpha as *const f32).cast(),
+                    (&beta as *const f32).cast(),
+                    const_device_ptr(resolved.first),
+                    self.inner.a_layout.raw,
+                    const_device_ptr(resolved.second),
+                    self.inner.weight_layout.raw,
+                    output.cast_const(),
+                    self.inner.output_layout.raw,
+                    output,
+                    self.inner.output_layout.raw,
+                    &self.inner.algorithm,
+                    mutable_device_ptr(resolved.fourth),
+                    self.inner.workspace_required_bytes,
+                    resolved.stream.cu_stream() as sys::cudaStream_t,
+                )
+            }
+        };
+
+        match matmul_result {
+            Ok(()) => {
+                scope.record_external_submission(permit, self.inner.clone());
+                Ok(())
+            }
+            Err(error) => {
+                scope.record_failed_external_submission(
+                    permit,
+                    self.inner.clone(),
+                    ExternalCommandError::new(CUBLASLT_PROVIDER, cublas_status(error)),
+                );
+                Err(error.into())
+            }
+        }
+    }
+
+    fn validate_resolved(
+        &self,
+        resolved: &ResolvedRrww<'_, bf16, bf16, bf16, u8>,
+    ) -> Result<(), Bf16GemmEnqueueError> {
+        let spec = self.inner.spec;
+        require_exact_len("A", resolved.first.len(), spec.a_numel())?;
+        require_exact_len("W", resolved.second.len(), spec.weight_numel())?;
+        require_exact_len("D", resolved.third.len(), spec.output_numel())?;
+        if resolved.fourth.num_bytes() < self.inner.workspace_required_bytes {
+            return Err(Bf16GemmEnqueueError::WorkspaceTooSmall {
+                required: self.inner.workspace_required_bytes,
+                actual: resolved.fourth.num_bytes(),
+            });
+        }
+        require_alignment("A", resolved.first.cu_deviceptr(), TENSOR_ALIGNMENT_BYTES)?;
+        require_alignment("W", resolved.second.cu_deviceptr(), TENSOR_ALIGNMENT_BYTES)?;
+        require_alignment("D", resolved.third.cu_deviceptr(), TENSOR_ALIGNMENT_BYTES)?;
+        require_alignment(
+            "workspace",
+            resolved.fourth.cu_deviceptr(),
+            WORKSPACE_ALIGNMENT_BYTES,
+        )?;
+
+        let stream_context = resolved.stream.context();
+        if stream_context.cu_ctx() != self.inner.provider.context.cu_ctx() {
+            return Err(Bf16GemmEnqueueError::ContextMismatch {
+                plan_device: self.inner.provider.context.ordinal(),
+                stream_device: stream_context.ordinal(),
+            });
+        }
+        let sticky_status = self.inner.provider.sticky_status.load(Ordering::Acquire);
+        if sticky_status != 0 {
+            return Err(Bf16GemmEnqueueError::ProviderPoisoned {
+                status: sticky_status,
+            });
+        }
+        Ok(())
+    }
+}
+
+struct PlanInner {
+    provider: Arc<ProviderInner>,
+    spec: Bf16GemmSpec,
+    matmul_desc: MatmulDesc,
+    a_layout: MatrixLayout,
+    weight_layout: MatrixLayout,
+    output_layout: MatrixLayout,
+    algorithm: sys::cublasLtMatmulAlgo_t,
+    workspace_required_bytes: usize,
+    waves_count: f32,
+}
+
+// SAFETY: the plan contains immutable cuBLASLt descriptors and an immutable
+// algorithm. cuBLASLt permits concurrent calls, each call supplies its own
+// stream and workspace, and CommandScope enforces unique mutable output and
+// workspace leases. Drop binds the owning context before releasing resources.
+unsafe impl Send for PlanInner {}
+// SAFETY: sharing does not mutate descriptors or algorithm state.
+unsafe impl Sync for PlanInner {}
+
+/// Checked resource handles for one fixed BF16 GEMM command.
+#[derive(Clone, Copy, Debug)]
+pub struct Bf16GemmArgs {
+    activation: Read<bf16>,
+    weight: Read<bf16>,
+    output: Write<bf16>,
+    workspace: Write<u8>,
+}
+
+impl Bf16GemmArgs {
+    pub const fn new(
+        activation: Read<bf16>,
+        weight: Read<bf16>,
+        output: Write<bf16>,
+        workspace: Write<u8>,
+    ) -> Self {
+        Self {
+            activation,
+            weight,
+            output,
+            workspace,
+        }
+    }
+}
+
+struct CheckedDimensions {
+    m: u64,
+    n: u64,
+    k: u64,
+    n_ld: i64,
+    k_ld: i64,
+}
+
+impl CheckedDimensions {
+    fn new(spec: Bf16GemmSpec) -> Result<Self, Bf16GemmPlanError> {
+        Ok(Self {
+            m: checked_u64("M", spec.m())?,
+            n: checked_u64("N", spec.n())?,
+            k: checked_u64("K", spec.k())?,
+            n_ld: checked_i64("N", spec.n())?,
+            k_ld: checked_i64("K", spec.k())?,
+        })
+    }
+}
+
+fn checked_u64(name: &'static str, value: usize) -> Result<u64, Bf16GemmPlanError> {
+    u64::try_from(value).map_err(|_| Bf16GemmPlanError::DimensionOutOfRange { name, value })
+}
+
+fn checked_i64(name: &'static str, value: usize) -> Result<i64, Bf16GemmPlanError> {
+    i64::try_from(value).map_err(|_| Bf16GemmPlanError::DimensionOutOfRange { name, value })
+}
+
+fn require_exact_len(
+    operand: &'static str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), Bf16GemmEnqueueError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(Bf16GemmEnqueueError::LengthMismatch {
+            operand,
+            expected,
+            actual,
+        })
+    }
+}
+
+fn require_alignment(
+    operand: &'static str,
+    address: u64,
+    alignment: u64,
+) -> Result<(), Bf16GemmEnqueueError> {
+    if address.is_multiple_of(alignment) {
+        Ok(())
+    } else {
+        Err(Bf16GemmEnqueueError::MisalignedBuffer {
+            operand,
+            address,
+            alignment,
+        })
+    }
+}
+
+fn const_device_ptr<T>(buffer: &DeviceBuffer<T>) -> *const c_void {
+    buffer.cu_deviceptr() as usize as *const c_void
+}
+
+fn mutable_device_ptr<T>(buffer: &mut DeviceBuffer<T>) -> *mut c_void {
+    buffer.cu_deviceptr() as usize as *mut c_void
+}
+
+fn cublas_status(error: result::CublasError) -> i32 {
+    error.0 as i32
+}
+
+fn bind_context_for_cleanup(context: &CudaContext) -> Result<(), DriverError> {
+    let mut current = MaybeUninit::uninit();
+    // SAFETY: CUDA writes one context handle to `current`. Setting the exact
+    // live context is required before destroying cuBLASLt resources. These raw
+    // driver calls deliberately bypass cuda-oxide's sticky-error check so a
+    // prior asynchronous error cannot prevent resource cleanup.
+    unsafe {
+        cuda_sys::cuCtxGetCurrent(current.as_mut_ptr()).result()?;
+        let current = current.assume_init();
+        if current.is_null() || current != context.cu_ctx() {
+            cuda_sys::cuCtxSetCurrent(context.cu_ctx()).result()?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum Bf16GemmPlanError {
+    #[error("cuBLASLt provider is poisoned by cleanup status {status}")]
+    ProviderPoisoned { status: i32 },
+    #[error("GEMM dimension {name}={value} does not fit the cuBLASLt ABI")]
+    DimensionOutOfRange { name: &'static str, value: usize },
+    #[error("selected GEMM needs {required} workspace bytes, above the {limit}-byte plan limit")]
+    WorkspaceRequirementExceedsLimit { required: usize, limit: usize },
+    #[error(transparent)]
+    Driver(#[from] DriverError),
+    #[error(transparent)]
+    CublasLt(#[from] result::CublasError),
+}
+
+#[derive(Debug, Error)]
+pub enum Bf16GemmEnqueueError {
+    #[error(
+        "cuBLASLt plan belongs to CUDA device {plan_device}, but the stream belongs to device {stream_device}"
+    )]
+    ContextMismatch {
+        plan_device: usize,
+        stream_device: usize,
+    },
+    #[error("cuBLASLt provider is poisoned by cleanup status {status}")]
+    ProviderPoisoned { status: i32 },
+    #[error("{operand} length mismatch: expected {expected}, got {actual}")]
+    LengthMismatch {
+        operand: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("GEMM workspace is too small: need {required} bytes, got {actual}")]
+    WorkspaceTooSmall { required: usize, actual: usize },
+    #[error("{operand} must be {alignment}-byte aligned, got {address:#x}")]
+    MisalignedBuffer {
+        operand: &'static str,
+        address: u64,
+        alignment: u64,
+    },
+    #[error(transparent)]
+    Command(#[from] CommandError),
+    #[error(transparent)]
+    Driver(#[from] DriverError),
+    #[error(transparent)]
+    CublasLt(#[from] result::CublasError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alignment_gate_distinguishes_tensor_and_workspace_requirements() {
+        assert!(require_alignment("A", 0x1010, TENSOR_ALIGNMENT_BYTES).is_ok());
+        assert!(require_alignment("workspace", 0x1100, WORKSPACE_ALIGNMENT_BYTES).is_ok());
+        assert!(matches!(
+            require_alignment("workspace", 0x1010, WORKSPACE_ALIGNMENT_BYTES),
+            Err(Bf16GemmEnqueueError::MisalignedBuffer {
+                alignment: WORKSPACE_ALIGNMENT_BYTES,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/loom-infer-cuda/src/lib.rs
+++ b/crates/loom-infer-cuda/src/lib.rs
@@ -5,4 +5,6 @@
 #[cfg(feature = "cuda")]
 pub mod command;
 #[cfg(feature = "cuda")]
+pub mod gemm;
+#[cfg(feature = "cuda")]
 pub mod rms_norm;

--- a/crates/loom-infer-cuda/src/rms_norm.rs
+++ b/crates/loom-infer-cuda/src/rms_norm.rs
@@ -1,6 +1,6 @@
 //! cuda-oxide implementation and prepared launch for RMSNorm.
 
-use crate::command::{BindingElement, CommandError, CommandScope, Read, Write};
+use crate::command::{BindingElement, CommandError, CommandPermit, CommandScope, Read, Write};
 use cuda_core::{CudaContext, CudaFunction, LaunchConfig1D, LaunchContractError, PreparedLaunch};
 use cuda_device::{
     DisjointSlice, SharedArray, convert, cuda_module, float, kernel, launch_bounds,
@@ -492,21 +492,21 @@ impl RmsNormF32Plan {
         scope: &mut CommandScope<'_, '_>,
         args: RmsNormArgs<f32>,
     ) -> Result<(), RmsNormEnqueueError> {
-        scope.ensure_launch_capacity()?;
+        let permit = scope.prepare_command()?;
         let launch_result = {
-            let resolved = scope.resolve_triplet(args.input, args.weight, args.output)?;
+            let resolved = scope.resolve_rrw(args.input, args.weight, args.output)?;
             self.module.rms_norm_f32(
                 resolved.stream,
                 &self.launch,
                 self.spec.rows(),
                 self.spec.hidden_size(),
                 self.spec.epsilon(),
-                resolved.input,
-                resolved.weight,
-                resolved.output,
+                resolved.first,
+                resolved.second,
+                resolved.third,
             )
         };
-        record_launch(scope, self.launch.function().clone(), launch_result)
+        record_launch(scope, permit, self.launch.function().clone(), launch_result)
     }
 }
 
@@ -551,45 +551,45 @@ impl RmsNormF16Plan {
         scope: &mut CommandScope<'_, '_>,
         args: RmsNormArgs<f16>,
     ) -> Result<(), RmsNormEnqueueError> {
-        scope.ensure_launch_capacity()?;
+        let permit = scope.prepare_command()?;
         let (function, launch_result) = match &self.launch {
             RmsNormF16Launch::Scalar(launch) => {
                 let result = {
-                    let resolved = scope.resolve_triplet(args.input, args.weight, args.output)?;
+                    let resolved = scope.resolve_rrw(args.input, args.weight, args.output)?;
                     self.module.rms_norm_f16_scalar(
                         resolved.stream,
                         launch,
                         self.spec.rows(),
                         self.spec.hidden_size(),
                         self.spec.epsilon(),
-                        resolved.input,
-                        resolved.weight,
-                        resolved.output,
+                        resolved.first,
+                        resolved.second,
+                        resolved.third,
                     )
                 };
                 (launch.function().clone(), result)
             }
             RmsNormF16Launch::Packed2(launch) => {
                 let result = {
-                    let resolved = scope.resolve_triplet(args.input, args.weight, args.output)?;
-                    require_packed_alignment("input", resolved.input.cu_deviceptr())?;
-                    require_packed_alignment("weight", resolved.weight.cu_deviceptr())?;
-                    require_packed_alignment("output", resolved.output.cu_deviceptr())?;
+                    let resolved = scope.resolve_rrw(args.input, args.weight, args.output)?;
+                    require_packed_alignment("input", resolved.first.cu_deviceptr())?;
+                    require_packed_alignment("weight", resolved.second.cu_deviceptr())?;
+                    require_packed_alignment("output", resolved.third.cu_deviceptr())?;
                     self.module.rms_norm_f16_packed2(
                         resolved.stream,
                         launch,
                         self.spec.rows(),
                         self.spec.hidden_size(),
                         self.spec.epsilon(),
-                        resolved.input,
-                        resolved.weight,
-                        resolved.output,
+                        resolved.first,
+                        resolved.second,
+                        resolved.third,
                     )
                 };
                 (launch.function().clone(), result)
             }
         };
-        record_launch(scope, function, launch_result)
+        record_launch(scope, permit, function, launch_result)
     }
 }
 
@@ -625,45 +625,45 @@ impl RmsNormBf16Plan {
         scope: &mut CommandScope<'_, '_>,
         args: RmsNormArgs<bf16>,
     ) -> Result<(), RmsNormEnqueueError> {
-        scope.ensure_launch_capacity()?;
+        let permit = scope.prepare_command()?;
         let (function, launch_result) = match &self.launch {
             RmsNormBf16Launch::Scalar(launch) => {
                 let result = {
-                    let resolved = scope.resolve_triplet(args.input, args.weight, args.output)?;
+                    let resolved = scope.resolve_rrw(args.input, args.weight, args.output)?;
                     self.module.rms_norm_bf16_scalar(
                         resolved.stream,
                         launch,
                         self.spec.rows(),
                         self.spec.hidden_size(),
                         self.spec.epsilon(),
-                        resolved.input,
-                        resolved.weight,
-                        resolved.output,
+                        resolved.first,
+                        resolved.second,
+                        resolved.third,
                     )
                 };
                 (launch.function().clone(), result)
             }
             RmsNormBf16Launch::Packed2(launch) => {
                 let result = {
-                    let resolved = scope.resolve_triplet(args.input, args.weight, args.output)?;
-                    require_packed_alignment("input", resolved.input.cu_deviceptr())?;
-                    require_packed_alignment("weight", resolved.weight.cu_deviceptr())?;
-                    require_packed_alignment("output", resolved.output.cu_deviceptr())?;
+                    let resolved = scope.resolve_rrw(args.input, args.weight, args.output)?;
+                    require_packed_alignment("input", resolved.first.cu_deviceptr())?;
+                    require_packed_alignment("weight", resolved.second.cu_deviceptr())?;
+                    require_packed_alignment("output", resolved.third.cu_deviceptr())?;
                     self.module.rms_norm_bf16_packed2(
                         resolved.stream,
                         launch,
                         self.spec.rows(),
                         self.spec.hidden_size(),
                         self.spec.epsilon(),
-                        resolved.input,
-                        resolved.weight,
-                        resolved.output,
+                        resolved.first,
+                        resolved.second,
+                        resolved.third,
                     )
                 };
                 (launch.function().clone(), result)
             }
         };
-        record_launch(scope, function, launch_result)
+        record_launch(scope, permit, function, launch_result)
     }
 }
 
@@ -731,17 +731,18 @@ fn require_packed_alignment(
 
 fn record_launch(
     scope: &mut CommandScope<'_, '_>,
+    permit: CommandPermit,
     function: CudaFunction,
     result: Result<(), LaunchContractError>,
 ) -> Result<(), RmsNormEnqueueError> {
     match result {
         Ok(()) => {
-            scope.retain_launch(function);
+            scope.record_cuda_submission(permit, function);
             Ok(())
         }
         Err(error) => {
             if let LaunchContractError::Driver(driver_error) = &error {
-                scope.retain_failed_launch(function, *driver_error);
+                scope.record_failed_cuda_submission(permit, function, *driver_error);
             }
             Err(error.into())
         }

--- a/crates/loom-infer/README.md
+++ b/crates/loom-infer/README.md
@@ -3,5 +3,6 @@
 `loom-infer` defines backend-independent operator contracts and CPU reference
 implementations. The crate has no CUDA, FFI, runtime, or framework dependency.
 
-The current vertical slice contains RMSNorm for F32, FP16, and BF16. Loom Infer
-adds another contract only when its Rust device implementation starts.
+The current contracts cover RMSNorm for F32, FP16, and BF16, plus contiguous
+BF16 GEMM with F32 accumulation. Loom Infer adds another contract only when a
+permanent device provider starts.

--- a/crates/loom-infer/src/gemm.rs
+++ b/crates/loom-infer/src/gemm.rs
@@ -1,0 +1,104 @@
+//! Contiguous BF16 GEMM contract and CPU reference implementation.
+
+use crate::ContractError;
+use crate::error::require_len;
+use half::bf16;
+
+/// Contract for `D[M, N] = A[M, K] * W[N, K]^T`.
+///
+/// `A`, `W`, and `D` are contiguous row-major BF16 tensors. Each dot product
+/// accumulates in F32, and the completed result is rounded once to BF16.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Bf16GemmSpec {
+    m: usize,
+    n: usize,
+    k: usize,
+}
+
+impl Bf16GemmSpec {
+    /// Creates a fixed-shape contiguous BF16 GEMM contract.
+    pub fn new(m: usize, n: usize, k: usize) -> Result<Self, ContractError> {
+        if m == 0 || n == 0 || k == 0 {
+            return Err(ContractError::ZeroDimension);
+        }
+
+        m.checked_mul(k)
+            .ok_or(ContractError::ElementCountOverflow)?;
+        n.checked_mul(k)
+            .ok_or(ContractError::ElementCountOverflow)?;
+        m.checked_mul(n)
+            .ok_or(ContractError::ElementCountOverflow)?;
+
+        Ok(Self { m, n, k })
+    }
+
+    /// Returns the number of rows in `A` and `D`.
+    pub const fn m(self) -> usize {
+        self.m
+    }
+
+    /// Returns the number of rows in `W` and columns in `D`.
+    pub const fn n(self) -> usize {
+        self.n
+    }
+
+    /// Returns the shared reduction dimension.
+    pub const fn k(self) -> usize {
+        self.k
+    }
+
+    /// Returns the exact number of BF16 elements required by `A`.
+    pub const fn a_numel(self) -> usize {
+        self.m * self.k
+    }
+
+    /// Returns the exact number of BF16 elements required by `W`.
+    pub const fn weight_numel(self) -> usize {
+        self.n * self.k
+    }
+
+    /// Returns the exact number of BF16 elements required by `D`.
+    pub const fn output_numel(self) -> usize {
+        self.m * self.n
+    }
+}
+
+/// Computes the fixed contiguous BF16 GEMM contract on the CPU.
+///
+/// The reference visits the reduction dimension in ascending order and uses
+/// one F32 fused multiply-add per element. This fixes the oracle's reduction
+/// order; a parallel provider may require a declared numerical tolerance while
+/// still using F32 accumulation.
+pub fn bf16_gemm_reference(
+    a: &[bf16],
+    weight: &[bf16],
+    output: &mut [bf16],
+    spec: Bf16GemmSpec,
+) -> Result<(), ContractError> {
+    require_len("A", a.len(), spec.a_numel())?;
+    require_len("W", weight.len(), spec.weight_numel())?;
+    require_len("D", output.len(), spec.output_numel())?;
+
+    for (a_row, output_row) in a
+        .chunks_exact(spec.k())
+        .zip(output.chunks_exact_mut(spec.n()))
+    {
+        for (column, destination) in output_row.iter_mut().enumerate() {
+            let weight_row = &weight[column * spec.k()..(column + 1) * spec.k()];
+            let accumulator =
+                a_row
+                    .iter()
+                    .zip(weight_row)
+                    .fold(0.0_f32, |sum, (&a_value, &weight_value)| {
+                        a_value.to_f32().mul_add(weight_value.to_f32(), sum)
+                    });
+            *destination = bf16::from_f32(accumulator);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "gemm/tests.rs"]
+mod tests;

--- a/crates/loom-infer/src/gemm/tests.rs
+++ b/crates/loom-infer/src/gemm/tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+fn bf16_slice(values: &[f32]) -> Vec<bf16> {
+    values.iter().copied().map(bf16::from_f32).collect()
+}
+
+#[test]
+fn reference_multiplies_a_by_transposed_row_major_weight() {
+    let spec = Bf16GemmSpec::new(2, 3, 2).unwrap();
+    let a = bf16_slice(&[1.0, 2.0, 3.0, 4.0]);
+    let weight = bf16_slice(&[5.0, 6.0, 7.0, 8.0, -1.0, 0.5]);
+    let mut output = vec![bf16::ZERO; spec.output_numel()];
+
+    bf16_gemm_reference(&a, &weight, &mut output, spec).unwrap();
+
+    assert_eq!(output, bf16_slice(&[17.0, 23.0, 0.0, 39.0, 53.0, -1.0]));
+}
+
+#[test]
+fn reference_accumulates_in_f32_and_rounds_output_once() {
+    let spec = Bf16GemmSpec::new(1, 1, 3).unwrap();
+    let a = bf16_slice(&[1.0, 1.0, 1.0]);
+    let weight = bf16_slice(&[1.0, 0.003_906_25, 0.003_906_25]);
+    let mut output = [bf16::ZERO];
+
+    bf16_gemm_reference(&a, &weight, &mut output, spec).unwrap();
+
+    // Rounding each partial sum to BF16 would lose both 1/256 terms. The
+    // contract retains them in F32 and rounds only the completed dot product.
+    assert_eq!(output[0], bf16::from_f32(1.007_812_5));
+}
+
+#[test]
+fn reference_requires_exact_buffer_lengths() {
+    let spec = Bf16GemmSpec::new(2, 3, 4).unwrap();
+
+    for (actual, expected) in [
+        (
+            bf16_gemm_reference(
+                &[bf16::ZERO; 7],
+                &[bf16::ZERO; 12],
+                &mut [bf16::ZERO; 6],
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "A",
+                expected: 8,
+                actual: 7,
+            },
+        ),
+        (
+            bf16_gemm_reference(
+                &[bf16::ZERO; 8],
+                &[bf16::ZERO; 11],
+                &mut [bf16::ZERO; 6],
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "W",
+                expected: 12,
+                actual: 11,
+            },
+        ),
+        (
+            bf16_gemm_reference(
+                &[bf16::ZERO; 8],
+                &[bf16::ZERO; 12],
+                &mut [bf16::ZERO; 5],
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "D",
+                expected: 6,
+                actual: 5,
+            },
+        ),
+    ] {
+        assert_eq!(actual, Err(expected));
+    }
+}
+
+#[test]
+fn spec_rejects_zero_dimensions_and_each_element_count_overflow() {
+    for dimensions in [(0, 1, 1), (1, 0, 1), (1, 1, 0)] {
+        assert_eq!(
+            Bf16GemmSpec::new(dimensions.0, dimensions.1, dimensions.2),
+            Err(ContractError::ZeroDimension)
+        );
+    }
+
+    for dimensions in [(usize::MAX, 1, 2), (1, usize::MAX, 2), (usize::MAX, 2, 1)] {
+        assert_eq!(
+            Bf16GemmSpec::new(dimensions.0, dimensions.1, dimensions.2),
+            Err(ContractError::ElementCountOverflow)
+        );
+    }
+}
+
+#[test]
+fn spec_reports_fixed_tensor_shapes() {
+    let spec = Bf16GemmSpec::new(2, 3, 4).unwrap();
+
+    assert_eq!(spec.m(), 2);
+    assert_eq!(spec.n(), 3);
+    assert_eq!(spec.k(), 4);
+    assert_eq!(spec.a_numel(), 8);
+    assert_eq!(spec.weight_numel(), 12);
+    assert_eq!(spec.output_numel(), 6);
+}

--- a/crates/loom-infer/src/lib.rs
+++ b/crates/loom-infer/src/lib.rs
@@ -5,10 +5,12 @@
 mod dtype;
 mod error;
 
+pub mod gemm;
 pub mod rms_norm;
 
 pub use dtype::DType;
 pub use error::ContractError;
+pub use gemm::{Bf16GemmSpec, bf16_gemm_reference};
 pub use rms_norm::{
     RmsNormSpec, rms_norm_bf16_reference, rms_norm_f16_reference, rms_norm_f32_reference,
 };

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,9 @@ Loom Infer is a Rust-native GPU operator library for LLM inference.
   process.
 - [Evidence](results/README.md) indexes results from permanent providers.
 
-The root [README](../README.md) gives the short project overview.
+The root [README](../README.md) gives the short project overview. Current
+correctness evidence covers Rust RMSNorm kernels and one fixed BF16 cuBLASLt
+GEMM plan on H20.
 
 ## Documentation rules
 

--- a/docs/design/loom-infer-architecture.md
+++ b/docs/design/loom-infer-architecture.md
@@ -25,14 +25,14 @@ consumer engine
 | Crate | Responsibility |
 | --- | --- |
 | `loom-infer` | Public specifications, errors, capabilities, and CPU references |
-| `loom-infer-cuda` | Plans, CUDA execution, Rust device kernels, and future vendor calls |
+| `loom-infer-cuda` | Plans, CUDA execution, Rust device kernels, and explicit vendor calls |
 
 The workspace adds another crate only when a working vertical slice needs a
 separate ownership or safety boundary.
 
 ## Operator lifecycle
 
-The current RMSNorm slice implements this lifecycle:
+The current RMSNorm and BF16 GEMM slices implement this lifecycle:
 
 ```text
 validated specification
@@ -51,21 +51,25 @@ contract validates buffer spans before enqueue.
 ### Command resources
 
 `CommandQueue` owns one exact caller stream, one preallocated event, and fixed
-function-retention storage. One heterogeneous binding arena holds F32, FP16,
+resource-retention storage. One heterogeneous binding arena holds F32, FP16,
 BF16, and byte buffers. Typed handles preserve each element type. Opaque access
 handles cannot move between binding sets.
 
 One command scope submits several plans to the same stream. CUDA stream order
-makes each output available to the next launch without a host wait. `finish()`
-records the queue event once. The completion retains bindings and loaded
-functions until `wait()` or destruction confirms completion.
+makes each output available to the next launch without a host wait.
+
+`finish()` records the queue event once. The completion retains bindings, loaded kernel
+functions, and external provider plans until `wait()` or destruction confirms
+completion.
 
 ### Failure handling
 
-Contract errors are recoverable, while a CUDA driver launch error poisons the
-scope and queue. Cleanup tries stream synchronization, then context
-synchronization. If neither can prove quiescence, the process aborts before
-Rust releases any borrowed GPU resource.
+Contract errors are recoverable. CUDA driver failures and external provider
+submission failures poison the scope and queue.
+
+Cleanup tries stream
+synchronization, then context synchronization. If neither can prove
+quiescence, the process aborts before Rust releases any borrowed GPU resource.
 
 ### Enqueue admission
 
@@ -90,23 +94,31 @@ use F32 arithmetic and round the stored result to nearest-even.
 
 ## Vendor providers
 
-Loom Infer includes GEMM and communication in its planning surface. Planned
-vendor providers will use a qualified library implementation unless a measured
-Loom implementation wins on the same contract.
+Loom Infer includes GEMM and communication in its planning surface. Vendor
+providers use qualified library implementations unless a measured Loom
+implementation wins on the same contract.
 
 A vendor plan fixes the library, algorithm, layouts, packed weights, scales,
 epilogue, workspace, and graph policy. Provider selection never changes during
 enqueue.
+
+The first provider fixes one cuBLASLt algorithm for contiguous row-major BF16
+`D[M,N] = A[M,K] * W[N,K]^T` with F32 accumulation. It checks exact spans,
+16-byte tensor alignment, 256-byte workspace alignment, CUDA context, and the
+algorithm's actual workspace requirement. Planning allows up to 32 MiB.
+Enqueue has no tuning or fallback.
 
 ## Evidence boundary
 
 An operator advances through independent gates:
 
 1. Contract and CPU reference.
-2. Device correctness and memory safety.
-3. Matched kernel performance in both provider orders.
-4. Non-default stream and CUDA Graph behavior.
-5. Real engine invocation and model output.
-6. Serving latency, throughput, and memory.
+2. Device correctness.
+3. Command lifecycle and non-default-stream behavior.
+4. Compute Sanitizer.
+5. Matched kernel performance in both provider orders.
+6. CUDA Graph capture and replay.
+7. Real engine invocation and model output.
+8. Serving latency, throughput, and memory.
 
 Passing one gate does not imply that a later gate passes.

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -26,6 +26,7 @@ ssh <h20-validation-host>
 cd <loom-infer-checkout>/crates/loom-infer-cuda
 cargo oxide doctor
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
+cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
 cargo oxide test --arch sm_90 -- --workspace --features cuda --release
 ```
 
@@ -57,8 +58,27 @@ Both paths use F32 arithmetic and nearest-even output conversion.
 
 The current gate covers odd and even hidden sizes, all three short-buffer
 positions, signed zero, typed heterogeneous bindings, and a caller-owned
-non-default stream. It also covers two chained launches, queue reuse, and one
+non-default stream. It also covers two chained commands, queue reuse, and one
 partial F32 scope. CUDA Graph replay remains a separate gate.
+
+## BF16 GEMM correctness
+
+Validate the fixed cuBLASLt contract:
+
+```text
+D[M,N] = A[M,K] * W[N,K]^T
+A, W, D: contiguous row-major BF16
+accumulation: F32
+```
+
+The gate covers `(M,N,K) = (1,4096,4096)` across two reusable scopes and a
+transpose-sensitive `(2,3,4)` case. It rejects short A, W, and D buffers and a
+second command when queue capacity is one. It also chains BF16 RMSNorm
+`(1,4096)` into GEMM under one completion with no intermediate host wait.
+
+Record the selected algorithm's actual workspace requirement. Test a short
+workspace only when that requirement is nonzero. The current H20 selection
+requires zero workspace, so that rejection case is not applicable.
 
 ### Open checks
 
@@ -68,7 +88,7 @@ the release device test. Keep this boundary until the pinned revision changes.
 Run Compute Sanitizer before full provider admission, or record that the host
 does not provide it.
 
-## Performance
+## RMSNorm performance
 
 Measure `(1,4096)`, `(8,4096)`, `(64,4096)`, and `(16,8192)` with identical
 preallocated buffers and streams. Use CUDA events around launches only.
@@ -80,13 +100,23 @@ must not allocate, copy, compile, tune, or synchronize the host.
 Compare against the current named provider on the same revision and device.
 Do not reuse timings from a deleted implementation.
 
+## GEMM performance
+
+Benchmark the fixed BF16 contract against the same cuBLASLt contract through a
+named baseline. Keep algorithm, layouts, workspace, stream, and timing region
+identical.
+
+The correctness runner is not a benchmark. No GEMM performance gate has passed.
+
 ## Current state
 
-The permanent F32, FP16, and BF16 providers pass their declared H20 correctness
-gates. The maximum F32 absolute error is `4.768371582e-7`.
+The permanent F32, FP16, and BF16 RMSNorm providers and the fixed BF16
+cuBLASLt GEMM provider pass their declared H20 correctness gates. The maximum
+F32 RMSNorm absolute error is `4.768371582e-7`.
 
-The F32 two-launch chain reaches `7.152557373e-7` maximum absolute error. The
+The F32 two-command chain reaches `7.152557373e-7` maximum absolute error. The
 FP16 chain reaches two ULPs, and the BF16 chain reaches one ULP. Generated PTX
 uses scalar and packed instructions, targets `sm_90`, and assembles with CUDA
-13.1. Compute Sanitizer, CUDA Graph, fixed argument packs, and performance gates
-remain open.
+13.1. The GEMM correctness cases are BF16 bit-exact against their declared CPU
+fixtures. Compute Sanitizer, CUDA Graph, fixed Rust-kernel argument packs, and
+performance gates remain open.

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -11,32 +11,32 @@ FlashInfer or FlashAttention parity.
 | `in progress` | A permanent Rust device provider is under implementation |
 | `device correct` | The permanent provider passed its declared device correctness gate |
 | `planned` | The operator is in the roadmap |
-| `vendor` | Loom plans and calls a qualified vendor implementation |
 
 ## Current work
 
-| Operator | State | Current boundary |
-| --- | --- | --- |
-| RMSNorm F32 | device correct | Four shapes, checked bindings, reusable scopes, two-launch chaining, and partial-scope rejection pass on H20 |
-| RMSNorm FP16 and BF16 | device correct | Scalar and packed paths, eight shapes per dtype, three short-buffer checks, signed zero, and two-launch chaining pass on H20 |
+| Operator | Provider | State | Current boundary |
+| --- | --- | --- | --- |
+| RMSNorm F32 | Rust / cuda-oxide | device correct | Four shapes, checked bindings, reusable scopes, two-command chaining, and partial-scope rejection pass on H20 |
+| RMSNorm FP16 and BF16 | Rust / cuda-oxide | device correct | Scalar and packed paths, eight shapes per dtype, three short-buffer checks, signed zero, and two-command chaining pass on H20 |
+| BF16 dense GEMM | cuBLASLt | device correct | Fixed `D=A×Wᵀ` plan, two declared shapes, exact spans, capacity rejection, reuse, and RMSNorm-to-GEMM chaining pass on H20 |
 
 No permanent GPU provider has a published performance result yet. The
-[low-precision correctness record](results/h20-rms-norm-low-precision-20260802.json)
-contains the accepted and excluded claims.
+[BF16 GEMM correctness record](results/h20-bf16-cublaslt-correctness-20260802.json)
+contains its accepted and excluded claims.
 
 ## Target surface
 
-| Family | Operators | State |
-| --- | --- | --- |
-| Normalization | RMSNorm, Add+RMSNorm, quantized output | planned |
-| Attention | Ragged prefill, paged decode, split-K, state merge | planned |
-| KV cache | RoPE append, gather, scatter, compaction, quantized storage | planned |
-| Decode tail | Logits processing, penalties, top-k, top-p, Min-P, logprobs, sampling | planned |
-| Speculation | Greedy, stochastic, and tree verification | planned |
-| MoE | Routing support, permutation, grouped-GEMM input, combine | planned |
-| Quantization | Scale, pack, unpack, dequantize, layout conversion | planned |
-| Matrix work | Dense, quantized, and grouped GEMM | vendor |
-| Communication | Tensor-parallel and expert-parallel collectives | vendor |
+| Family | Operators | Provider | State |
+| --- | --- | --- | --- |
+| Normalization | RMSNorm, Add+RMSNorm, quantized output | Rust / cuda-oxide | planned |
+| Attention | Ragged prefill, paged decode, split-K, state merge | Rust / cuda-oxide | planned |
+| KV cache | RoPE append, gather, scatter, compaction, quantized storage | Rust / cuda-oxide | planned |
+| Decode tail | Logits processing, penalties, top-k, top-p, Min-P, logprobs, sampling | Rust / cuda-oxide | planned |
+| Speculation | Greedy, stochastic, and tree verification | Rust / cuda-oxide | planned |
+| MoE | Routing support, permutation, grouped-GEMM input, combine | Rust plus vendor GEMM | planned |
+| Quantization | Scale, pack, unpack, dequantize, layout conversion | Rust / cuda-oxide | planned |
+| Matrix work | Dense, quantized, and grouped GEMM | Qualified vendor libraries | planned |
+| Communication | Tensor-parallel and expert-parallel collectives | Qualified vendor libraries | planned |
 
 ## Attention baseline
 

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -8,18 +8,23 @@ providers.
 - [F32 RMSNorm H20 correctness](h20-rms-norm-f32-correctness-20260802.json):
   four shapes and exact buffer rejection pass on a non-default stream.
 - [F32 RMSNorm H20 command scope](h20-rms-norm-f32-command-scope-20260802.json):
-  checked bindings, queue reuse, two-launch chaining, and a partial-scope
+  checked bindings, queue reuse, two-command chaining, and a partial-scope
   rejection pass. The record contains no performance, graph, engine, or
   serving claim.
 - [FP16 and BF16 RMSNorm H20 correctness](h20-rms-norm-low-precision-20260802.json):
   scalar and packed paths, typed heterogeneous bindings, short-buffer checks,
-  signed zero, and reusable two-launch scopes pass.
+  signed zero, and reusable two-command scopes pass.
+- [BF16 cuBLASLt GEMM H20 correctness](h20-bf16-cublaslt-correctness-20260802.json):
+  fixed-plan standalone and transpose-sensitive cases, exact spans, command
+  capacity, reuse, and RMSNorm-to-GEMM chaining pass. No performance claim is
+  included.
 
 ## Claim levels
 
 | Level | Required evidence |
 | --- | --- |
 | Correctness | Declared contract, oracle, error limit, and edge cases |
+| Lifecycle | Stream order, resource retention, capacity, reuse, and completion behavior |
 | Kernel | Matched buffers, streams, provider order, and raw device timings |
 | Graph | Capture and replay behavior with fixed plans and dynamic bindings |
 | Engine | Real invocation, provider hit count, and model output |

--- a/docs/results/h20-bf16-cublaslt-correctness-20260802.json
+++ b/docs/results/h20-bf16-cublaslt-correctness-20260802.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-02",
+  "claim_level": "correctness",
+  "operator": "bf16_dense_gemm_cublaslt",
+  "status": "passed",
+  "source": {
+    "git_base_revision": "0927a405f260f42bb3f5b3460dac46ba3dbce956",
+    "worktree": "uncommitted BF16 cuBLASLt provider",
+    "projection": "sorted path and SHA-256 list for Cargo manifests, Cargo.lock, rust-toolchain.toml, and Rust source files",
+    "projection_sha256": "23c321fa8d94e32c0c9b1758116e6c250246be79fc0ac4d05d5e54748c87ce46",
+    "cargo_lock_sha256": "8c014680dac69c81c5d72980ff47a27e8a7755462ff5f4b301a63bbf78202460",
+    "local_remote_projection_match": true
+  },
+  "environment": {
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "compute_capability": "9.0",
+    "driver": "535.161.08",
+    "cuda": "13.1.115",
+    "cublaslt_reported_version": 130200,
+    "cublaslt_shared_object": "libcublasLt.so.13.2.0.9",
+    "cudarc": "0.19.8",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "llvm": "22.1.2-rust-1.96.0-nightly",
+    "clang": "20.2.0",
+    "cargo_oxide": "0.2.1",
+    "cuda_oxide_revision": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+    "compute_sanitizer": "unavailable"
+  },
+  "contract": {
+    "equation": "D[M,N] = A[M,K] * transpose(W[N,K])",
+    "a_dtype": "bf16",
+    "weight_dtype": "bf16",
+    "output_dtype": "bf16",
+    "compute": "f32 accumulation and f32 alpha/beta scaling",
+    "layouts": "A, W, and D are contiguous row-major tensors",
+    "buffer_lengths": "exactly match the fixed specification",
+    "tensor_alignment_bytes": 16,
+    "workspace_alignment_bytes": 256,
+    "workspace_search_limit_bytes": 33554432,
+    "workspace_admission": "the caller supplies at least the selected algorithm's actual requirement",
+    "algorithm_policy": "select one cuBLASLt heuristic during planning; no tuning or fallback during enqueue",
+    "stream": "one caller-owned non-default stream per command queue",
+    "bindings": "typed read and write leases retain buffers through completion",
+    "completion": "one preallocated CUDA event settles all commands in the scope",
+    "oracle": "loom_infer::bf16_gemm_reference"
+  },
+  "plan": {
+    "large": {
+      "m": 1,
+      "n": 4096,
+      "k": 4096,
+      "workspace_required_bytes": 0,
+      "heuristic_waves_count": 0.820513
+    },
+    "transpose_sensitive": {
+      "m": 2,
+      "n": 3,
+      "k": 4,
+      "workspace_required_bytes": 0,
+      "heuristic_waves_count": 0.002564
+    }
+  },
+  "correctness_cases": [
+    {
+      "name": "standalone_reuse",
+      "m": 1,
+      "n": 4096,
+      "k": 4096,
+      "scopes": 2,
+      "commands_per_scope": 1,
+      "independent_outputs": 2,
+      "queue_reused": true,
+      "bindings_reused": true,
+      "plan_reused": true,
+      "first_bit_mismatches": 0,
+      "second_bit_mismatches": 0,
+      "max_abs_error": 0.0,
+      "first_output_digest": "9c7c07b655452325",
+      "second_output_digest": "9c7c07b655452325"
+    },
+    {
+      "name": "row_major_transpose",
+      "m": 2,
+      "n": 3,
+      "k": 4,
+      "bit_mismatches": 0,
+      "max_abs_error": 0.0,
+      "output_digest": "c6b0f58fc67782b9"
+    },
+    {
+      "name": "rms_norm_gemm_chain",
+      "rms_norm_rows": 1,
+      "rms_norm_hidden_size": 4096,
+      "gemm_m": 1,
+      "gemm_n": 4096,
+      "gemm_k": 4096,
+      "commands": 2,
+      "completion_records": 1,
+      "intermediate_host_waits": 0,
+      "bit_mismatches": 0,
+      "max_abs_error": 0.0,
+      "output_digest": "9c7c07b655452325"
+    }
+  ],
+  "rejection_cases": {
+    "short_a": {"expected_elements": 8, "actual_elements": 7, "rejected_before_ffi": true},
+    "short_weight": {"expected_elements": 12, "actual_elements": 11, "rejected_before_ffi": true},
+    "short_output": {"expected_elements": 6, "actual_elements": 5, "rejected_before_ffi": true},
+    "command_capacity": {
+      "capacity": 1,
+      "first_command_submitted": true,
+      "second_command_rejected_before_ffi": true,
+      "submitted_commands": 1
+    },
+    "short_workspace": {
+      "status": "not_applicable",
+      "reason": "both selected algorithms require zero workspace bytes"
+    }
+  },
+  "commands": [
+    "cargo clippy --workspace --all-targets --features cuda -- -D warnings",
+    "cargo oxide test --arch sm_90 -- --workspace --features cuda --release",
+    "cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90",
+    "cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90"
+  ],
+  "accepted_claims": [
+    "the fixed BF16 cuBLASLt plan matches the declared CPU fixtures for (1,4096,4096) and the transpose-sensitive (2,3,4) case",
+    "two reusable standalone scopes write independent outputs that both match the CPU fixture bit for bit",
+    "short A, W, and D spans are rejected before the cuBLASLt call",
+    "command capacity rejects a second command before the cuBLASLt call and preserves the submitted count",
+    "the command scope retains and reuses the cuBLASLt plan, bindings, queue, and zero-byte workspace contract",
+    "BF16 RMSNorm feeds BF16 cuBLASLt GEMM through one stream-ordered scope and one completion without an intermediate host wait",
+    "the existing F32, FP16, and BF16 RMSNorm H20 suite still passes after external-provider lifecycle integration"
+  ],
+  "excluded_claims": [
+    "correctness for shapes or input distributions outside the declared fixtures",
+    "fault-injected cuBLASLt, CUDA driver, event, stream, or context failure behavior",
+    "Compute Sanitizer coverage because the tool is unavailable on this host",
+    "CUDA Graph support",
+    "GEMM or end-to-end performance",
+    "comparison with a named baseline",
+    "engine integration",
+    "serving performance"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ attention-kernel comparison surface.
 - keep the H20-qualified F32 path in `loom-infer-cuda`.
 - support F32, FP16, and BF16 with scalar and packed paths.
 - bind caller-owned memory and non-default streams.
-- keep one stream-ordered command scope for every provider.
+- keep one stream-ordered command scope for Rust and vendor providers.
 - replace generated argument vectors with reusable fixed argument packs.
 - pass correctness, CUDA Graph, sanitizer, and matched H20 performance gates.
 
@@ -25,7 +25,7 @@ H20 correctness and performance records.
 
 ## 2. First vendor GEMM provider
 
-**State:** next.
+**State:** active. Device correctness passed.
 
 - define contiguous BF16 `D[M,N] = A[M,K] * W[N,K]^T` with F32 accumulation.
 - plan one explicit cuBLASLt algorithm before enqueue.
@@ -35,6 +35,10 @@ H20 correctness and performance records.
 
 Exit: a fixed BF16 GEMM plan passes correctness, graph, and matched-provider
 gates without a tensor copy.
+
+The fixed BF16 cuBLASLt plan passes its H20 correctness and command-lifecycle
+gates. CUDA Graph, matched-provider performance, real-model shapes, and engine
+invocation remain open.
 
 ## 3. Attention core
 

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -10,7 +10,7 @@ export const operatorFamilies = [
   {
     name: "Normalization",
     boundary: "RMSNorm, residual fusion, and quantized output.",
-    state: "In progress",
+    state: "Device-correct",
   },
   {
     name: "Attention",
@@ -35,7 +35,7 @@ export const operatorFamilies = [
   {
     name: "Matrix work",
     boundary: "Fixed Rust plans for qualified vendor GEMM providers.",
-    state: "Vendor",
+    state: "Device-correct",
   },
 ]
 
@@ -48,7 +48,7 @@ export const milestones = [
   {
     milestone: "02",
     name: "Vendor GEMM",
-    reason: "Add one fixed BF16 cuBLASLt plan through the common command scope.",
+    reason: "The fixed BF16 cuBLASLt plan passes correctness. Graph, baseline, and engine gates remain open.",
   },
   {
     milestone: "03",

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -26,7 +26,7 @@ import { repositoryUrl } from "../../data/site";
         </div>
         <div class="doc-card">
           <h3>Roadmap</h3>
-          <p>Follow the RMSNorm, attention, decode, and vendor-provider phases.</p>
+          <p>Follow the RMSNorm, vendor GEMM, attention, and decode phases.</p>
           <a href={`${repositoryUrl}/blob/main/docs/roadmap.md`}>Roadmap</a>
         </div>
         <div class="doc-card">
@@ -49,7 +49,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-targets</code></pre>
       <p>
         The <a href={`${repositoryUrl}/blob/main/docs/results/README.md`}>evidence index</a>
-        contains the permanent F32, FP16, and BF16 RMSNorm correctness results.
+        contains the RMSNorm and fixed BF16 cuBLASLt correctness results.
       </p>
     </article>
   </div>

--- a/website/src/pages/docs/operators.astro
+++ b/website/src/pages/docs/operators.astro
@@ -12,7 +12,7 @@ import { milestones, operatorFamilies, repositoryUrl } from "../../data/site";
   <header class="page-hero">
     <p class="eyebrow">Operators</p>
     <h1>One lifecycle for every operator.</h1>
-    <p>Current work starts with a permanent Rust RMSNorm provider on H20.</p>
+    <p>Current H20 providers cover Rust RMSNorm and one fixed BF16 cuBLASLt GEMM plan.</p>
   </header>
 
   <div class="docs-layout">

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -23,7 +23,7 @@ import { repositoryUrl } from "../data/site";
         <strong>F32 RMSNorm passes its H20 correctness gate.</strong>
         <p>
           Four shapes match the CPU reference, and an invalid buffer is
-          rejected. Checked bindings chain two launches on a non-default
+          rejected. Checked bindings chain two commands on a non-default
           stream with one completion record. The chained maximum absolute
           error is <code>7.152557373e-7</code>. Performance is not measured.
         </p>
@@ -42,6 +42,18 @@ import { repositoryUrl } from "../data/site";
         </p>
         <a href={`${repositoryUrl}/blob/main/docs/results/h20-rms-norm-low-precision-20260802.json`}>
           Low-precision result
+        </a>
+      </div>
+      <div class="doc-note">
+        <strong>One fixed BF16 cuBLASLt GEMM plan passes its H20 correctness gate.</strong>
+        <p>
+          Standalone and transpose-sensitive cases match the CPU reference.
+          Short A, W, and D buffers are rejected. BF16 RMSNorm feeds GEMM under
+          one completion without an intermediate host wait. The selected H20
+          algorithm requires no workspace. Performance is not measured.
+        </p>
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-bf16-cublaslt-correctness-20260802.json`}>
+          BF16 GEMM result
         </a>
       </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -41,7 +41,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   </section>
 
   <section class="metrics-strip" aria-label="Project status">
-    <div class="metric"><strong>1</strong><span>active operator slice</span></div>
+    <div class="metric"><strong>2</strong><span>device-correct slices</span></div>
     <div class="metric"><strong>SM90</strong><span>first target</span></div>
     <div class="metric"><strong>Rust</strong><span>host and device source</span></div>
     <div class="metric"><strong>Pending</strong><span>performance evidence</span></div>
@@ -95,7 +95,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       </article>
       <article class="architecture-card">
         <span class="card-index">04</span><h3>Execution</h3>
-        <p>Rust device artifacts today; explicit vendor calls are next.</p>
+        <p>Rust device artifacts and fixed vendor calls share one checked command scope.</p>
       </article>
     </div>
   </section>
@@ -110,12 +110,17 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       <p>F32, FP16, and BF16 pass their declared correctness gates.</p>
       <small>Scalar and packed low-precision paths pass. Performance is not measured.</small>
     </article>
+    <article class="evidence-card">
+      <h3>BF16 cuBLASLt GEMM on H20</h3><span class="result">Correct</span>
+      <p>Fixed-plan standalone, transpose-sensitive, and RMSNorm-to-GEMM cases pass.</p>
+      <small>Command lifecycle and rejection gates pass. Performance is not measured.</small>
+    </article>
   </section>
 
   <section class="section">
     <header class="section-header">
-      <div><p class="eyebrow">Next</p><h2>Add the first vendor provider</h2></div>
-      <p>Plan one fixed BF16 cuBLASLt GEMM on the same checked command scope.</p>
+      <div><p class="eyebrow">Next</p><h2>Qualify the current providers</h2></div>
+      <p>Add graph and matched performance evidence, then enter the attention core.</p>
     </header>
     <div class="roadmap-grid">
       {milestones.map((item) => (


### PR DESCRIPTION
## What changed

- Add a contiguous BF16 GEMM contract and CPU reference with F32 accumulation.
- Add one fixed cuBLASLt plan with checked layouts, spans, alignment, context, stream, and workspace.
- Extend the command scope so Rust kernels and vendor calls share one completion fence.
- Add H20 correctness and lifecycle coverage, a machine-readable result, and matching documentation and website status.

## Why

Loom Infer needs one execution model for Loom-owned Rust kernels and qualified vendor GEMM. Algorithm selection now happens during planning. Enqueue does not tune, copy tensors, or fall back.

## Breaking impact

- Rename launch capacity APIs and errors to provider-neutral command terminology.
- Retain external provider plans alongside CUDA functions.
- Add the exact optional `cudarc 0.19.8` dependency to the `cuda` feature.

## Validation

Local:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo check --workspace --release`
- `cargo package -p loom-infer --allow-dirty`
- `npm run build`

NVIDIA H20 / SM90:

- `cargo clippy --workspace --all-targets --features cuda -- -D warnings`
- `cargo oxide test --arch sm_90 -- --workspace --features cuda --release`
- `cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90`
- `cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90`

The declared `(1,4096,4096)` and transpose-sensitive `(2,3,4)` GEMM fixtures are BF16 bit-exact against the CPU reference. Exact A, W, and D span rejection, command-capacity rejection, two independent reusable scopes, and one RMSNorm-to-GEMM completion pass.

## Evidence boundary

This PR establishes correctness and command lifecycle for the declared fixtures. Compute Sanitizer, CUDA Graph, matched performance, engine integration, and serving results remain open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BF16 GEMM with F32 accumulation, including CPU reference support and a CUDA-accelerated implementation.
  * Added H20 validation covering correctness, chaining, workspace handling, buffer validation, and command capacity.
  * Expanded command scopes to support reusable resources and external provider operations.

* **Bug Fixes**
  * Improved validation and error reporting for invalid operands, capacities, submissions, and resource cleanup.

* **Documentation**
  * Updated READMEs, architecture guides, roadmap, operator catalog, and website content with GEMM capabilities and H20 correctness evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->