### PR TITLE
feat(cuda): add owned fixed-address graph execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <p>
     <a href="docs/README.md">Docs</a> ·
     <a href="docs/operator-catalog.md">Operators</a> ·
+    <a href="docs/flashinfer-parity.md">Parity</a> ·
     <a href="docs/roadmap.md">Roadmap</a> ·
     <a href="docs/results/README.md">Evidence</a>
   </p>
@@ -30,8 +31,8 @@ The current device paths are:
 
 | Operator | Provider | H20 state |
 | --- | --- | --- |
-| Contiguous RMSNorm F32, FP16, BF16 | Rust device kernels compiled with cuda-oxide | Device correct |
-| Contiguous BF16 GEMM with F32 accumulation | One fixed cuBLASLt algorithm | Device correct |
+| Contiguous RMSNorm F32, FP16, BF16 | Rust device kernels compiled with cuda-oxide | Owned-binding revision device-correct and sanitizer-clean |
+| Contiguous BF16 GEMM with F32 accumulation | One fixed cuBLASLt algorithm | Device-correct with fixed-address Graph replay and sanitizer coverage |
 
 Both use the same public flow:
 
@@ -44,14 +45,20 @@ validated spec
   -> plan::enqueue_into
   -> CommandScope::finish
   -> CommandCompletion::wait
+  -> CheckedBindings::take_read_write
 ```
+
+The Graph path consumes a one-shot `GraphQueue` with a private stream and
+returns the same bindings through `GraphExec::into_bindings`.
 
 The GEMM contract is `D[M,N] = A[M,K] * W[N,K]^T` over contiguous row-major
 BF16 tensors. Algorithm selection happens during planning. Enqueue does not
 tune or fall back.
 
-Attention, sampling, KV-cache, MoE, quantization, graph
-replay, and performance qualification remain roadmap work.
+Attention, sampling, KV-cache, MoE, quantization, and performance qualification
+remain roadmap work. The fixed-address Graph path passed its declared H20
+correctness and sanitizer gates. See the
+[2026-08-03 result](docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json).
 
 ### Execution
 
@@ -68,8 +75,8 @@ allocates its argument vector during Rust-kernel enqueue.
   silent fallback.
 - CUDA drivers and cuBLASLt are current vendor dependencies. Other established
   GEMM and collective libraries may enter through explicit providers.
-- The caller owns streams and device buffers. Checked bindings retain borrowed
-  resources while the GPU uses them.
+- The caller owns streams. Checked bindings share read-only buffers through
+  `Arc` and take exclusive ownership of writable buffers until completion.
 
 ## Local checks
 
@@ -102,12 +109,12 @@ Operator correctness, kernel latency, graph execution, engine integration, and
 serving performance are separate claims. A microbenchmark does not establish
 an engine or serving speedup.
 
-The current GEMM record makes no performance, CUDA Graph, Compute Sanitizer,
-engine, or serving claim.
+The current Graph record covers correctness and Compute Sanitizer results. It
+makes no performance, engine, or serving claim.
 
 See the [architecture](docs/design/loom-infer-architecture.md),
 [operator catalog](docs/operator-catalog.md), [roadmap](docs/roadmap.md), and
-[BF16 cuBLASLt result](docs/results/h20-bf16-cublaslt-correctness-20260802.json).
+[owned-binding Graph result](docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json).
 
 ## License
 

--- a/crates/loom-infer-cuda/README.md
+++ b/crates/loom-infer-cuda/README.md
@@ -19,5 +19,6 @@ The Rust provider implements contiguous F32, FP16, and BF16 RMSNorm. The first
 vendor provider freezes one contiguous BF16 cuBLASLt GEMM algorithm during
 planning. Both use typed heterogeneous bindings and one completion event.
 
-Their declared H20 correctness gates pass. Fixed Rust-kernel argument packs,
-graph, sanitizer, and performance gates remain open.
+The current owned-binding revision passed its H20 correctness gates. The fixed
+RMSNorm-to-GEMM Graph also passed replay and Compute Sanitizer gates. Fixed
+Rust-kernel argument packs and performance gates remain open.

--- a/crates/loom-infer-cuda/src/bin/bf16_gemm_h20.rs
+++ b/crates/loom-infer-cuda/src/bin/bf16_gemm_h20.rs
@@ -3,6 +3,7 @@ use half::bf16;
 use loom_infer::{Bf16GemmSpec, DType, RmsNormSpec, bf16_gemm_reference, rms_norm_bf16_reference};
 use loom_infer_cuda::command::{CommandError, CommandQueue};
 use loom_infer_cuda::gemm::{Bf16GemmArgs, Bf16GemmEnqueueError, Bf16GemmPlan, CublasLtProvider};
+use loom_infer_cuda::graph::GraphQueue;
 use loom_infer_cuda::rms_norm::{RmsNormArgs, RmsNormProvider};
 use std::error::Error;
 use std::sync::Arc;
@@ -89,17 +90,17 @@ fn check_standalone(queue: &mut CommandQueue, plan: &Bf16GemmPlan) -> Result<(),
     let mut expected = vec![bf16::ZERO; spec.output_numel()];
     bf16_gemm_reference(&activation_host, &weight_host, &mut expected, spec)?;
 
-    let activation = DeviceBuffer::from_host(&stream, &activation_host)?;
-    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-    let mut first_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
-    let mut second_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let activation = Arc::new(DeviceBuffer::from_host(&stream, &activation_host)?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+    let first_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let second_output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
     let mut bindings = queue.bindings(5)?;
-    let activation_handle = bindings.bind_read(&activation)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let first_output_handle = bindings.bind_read_write(&mut first_output)?;
-    let second_output_handle = bindings.bind_read_write(&mut second_output)?;
-    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let activation_handle = bindings.bind_read(Arc::clone(&activation))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let first_output_handle = bindings.bind_read_write(first_output)?;
+    let second_output_handle = bindings.bind_read_write(second_output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
 
     for output_handle in [first_output_handle.write(), second_output_handle.write()] {
         let mut scope = queue.begin(bindings)?;
@@ -118,6 +119,8 @@ fn check_standalone(queue: &mut CommandQueue, plan: &Bf16GemmPlan) -> Result<(),
         }
         bindings = completion.wait()?;
     }
+    let first_output = bindings.take_read_write(first_output_handle)?;
+    let second_output = bindings.take_read_write(second_output_handle)?;
     drop(bindings);
 
     let first_actual = first_output.to_host_vec(&stream)?;
@@ -176,15 +179,15 @@ fn check_row_major_transpose(
     let mut expected = vec![bf16::ZERO; spec.output_numel()];
     bf16_gemm_reference(&activation_host, &weight_host, &mut expected, spec)?;
 
-    let activation = DeviceBuffer::from_host(&stream, &activation_host)?;
-    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let activation = Arc::new(DeviceBuffer::from_host(&stream, &activation_host)?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
     let mut bindings = queue.bindings(4)?;
-    let activation_handle = bindings.bind_read(&activation)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
-    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let activation_handle = bindings.bind_read(Arc::clone(&activation))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let mut scope = queue.begin(bindings)?;
     plan.enqueue_into(
         &mut scope,
@@ -199,7 +202,9 @@ fn check_row_major_transpose(
     if completion.submitted() != 1 {
         return Err("transpose-sensitive GEMM completion covered the wrong command count".into());
     }
-    drop(completion.wait()?);
+    let mut bindings = completion.wait()?;
+    let output = bindings.take_read_write(output_handle)?;
+    drop(bindings);
 
     let actual = output.to_host_vec(&stream)?;
     let comparison = compare(&actual, &expected)?;
@@ -226,15 +231,15 @@ fn expect_length_rejection(
     output_len: usize,
 ) -> Result<(), Box<dyn Error>> {
     let stream = queue.stream().clone();
-    let activation = DeviceBuffer::<bf16>::zeroed(&stream, activation_len)?;
-    let weight = DeviceBuffer::<bf16>::zeroed(&stream, weight_len)?;
-    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, output_len)?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
+    let activation = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, activation_len)?);
+    let weight = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, weight_len)?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, output_len)?;
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(plan))?;
     let mut bindings = queue.bindings(4)?;
-    let activation_handle = bindings.bind_read(&activation)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
-    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let activation_handle = bindings.bind_read(Arc::clone(&activation))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let mut scope = queue.begin(bindings)?;
     let result = plan.enqueue_into(
         &mut scope,
@@ -294,16 +299,15 @@ fn check_short_buffers(
         "not_applicable_zero_required"
     } else {
         let stream = queue.stream().clone();
-        let activation = DeviceBuffer::<bf16>::zeroed(&stream, spec.a_numel())?;
-        let weight = DeviceBuffer::<bf16>::zeroed(&stream, spec.weight_numel())?;
-        let mut output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
-        let mut workspace =
-            DeviceBuffer::<u8>::zeroed(&stream, workspace_required.saturating_sub(1))?;
+        let activation = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, spec.a_numel())?);
+        let weight = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, spec.weight_numel())?);
+        let output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+        let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_required.saturating_sub(1))?;
         let mut bindings = queue.bindings(4)?;
-        let activation_handle = bindings.bind_read(&activation)?;
-        let weight_handle = bindings.bind_read(&weight)?;
-        let output_handle = bindings.bind_read_write(&mut output)?;
-        let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+        let activation_handle = bindings.bind_read(Arc::clone(&activation))?;
+        let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+        let output_handle = bindings.bind_read_write(output)?;
+        let workspace_handle = bindings.bind_read_write(workspace)?;
         let mut scope = queue.begin(bindings)?;
         let result = plan.enqueue_into(
             &mut scope,
@@ -339,15 +343,15 @@ fn check_command_capacity(
 ) -> Result<(), Box<dyn Error>> {
     let spec = plan.spec();
     let mut queue = CommandQueue::new(stream.clone(), 1)?;
-    let activation = DeviceBuffer::<bf16>::zeroed(stream, spec.a_numel())?;
-    let weight = DeviceBuffer::<bf16>::zeroed(stream, spec.weight_numel())?;
-    let mut output = DeviceBuffer::<bf16>::zeroed(stream, spec.output_numel())?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(stream, workspace_len(plan))?;
+    let activation = Arc::new(DeviceBuffer::<bf16>::zeroed(stream, spec.a_numel())?);
+    let weight = Arc::new(DeviceBuffer::<bf16>::zeroed(stream, spec.weight_numel())?);
+    let output = DeviceBuffer::<bf16>::zeroed(stream, spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(stream, workspace_len(plan))?;
     let mut bindings = queue.bindings(4)?;
-    let activation_handle = bindings.bind_read(&activation)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
-    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let activation_handle = bindings.bind_read(Arc::clone(&activation))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let args = Bf16GemmArgs::new(
         activation_handle,
         weight_handle,
@@ -402,19 +406,19 @@ fn check_rms_norm_gemm_chain(
         gemm_spec,
     )?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let norm_weight = DeviceBuffer::from_host(&stream, &norm_weight_host)?;
-    let mut intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
-    let gemm_weight = DeviceBuffer::from_host(&stream, &gemm_weight_host)?;
-    let mut output = DeviceBuffer::<bf16>::zeroed(&stream, gemm_spec.output_numel())?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(gemm_plan))?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let norm_weight = Arc::new(DeviceBuffer::from_host(&stream, &norm_weight_host)?);
+    let intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let gemm_weight = Arc::new(DeviceBuffer::from_host(&stream, &gemm_weight_host)?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, gemm_spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(gemm_plan))?;
     let mut bindings = queue.bindings(6)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let norm_weight_handle = bindings.bind_read(&norm_weight)?;
-    let intermediate_handle = bindings.bind_read_write(&mut intermediate)?;
-    let gemm_weight_handle = bindings.bind_read(&gemm_weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
-    let workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let norm_weight_handle = bindings.bind_read(Arc::clone(&norm_weight))?;
+    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let gemm_weight_handle = bindings.bind_read(Arc::clone(&gemm_weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let mut scope = queue.begin(bindings)?;
     rms_plan.enqueue_into(
         &mut scope,
@@ -437,7 +441,9 @@ fn check_rms_norm_gemm_chain(
     if completion.submitted() != 2 {
         return Err("RMSNorm to GEMM completion covered the wrong command count".into());
     }
-    drop(completion.wait()?);
+    let mut bindings = completion.wait()?;
+    let output = bindings.take_read_write(output_handle)?;
+    drop(bindings);
 
     let actual = output.to_host_vec(&stream)?;
     let comparison = compare(&actual, &expected)?;
@@ -446,6 +452,118 @@ fn check_rms_norm_gemm_chain(
         "gate=bf16_gemm_h20 case=rms_norm_gemm_chain status=pass rows=1 hidden=4096 \
          m={} n={} k={} commands=2 completion_records=1 intermediate_waits=0 \
          gemm_plan_reused=true bit_mismatches={} max_abs={:.9e} digest={:016x}",
+        gemm_spec.m(),
+        gemm_spec.n(),
+        gemm_spec.k(),
+        comparison.bit_mismatches,
+        comparison.max_abs,
+        comparison.digest,
+    );
+    Ok(())
+}
+
+fn check_rms_norm_gemm_graph(
+    queue: &mut CommandQueue,
+    rms_provider: RmsNormProvider,
+    gemm_plan: Bf16GemmPlan,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let gemm_spec = gemm_plan.spec();
+    let rms_spec = RmsNormSpec::new(1, LARGE_K, 1.0e-5, DType::Bf16)?;
+    let rms_plan = rms_provider.plan_bf16(rms_spec)?;
+    drop(rms_provider);
+    let input_host = vec![bf16::ONE; rms_spec.numel()];
+    let norm_weight_host = vec![bf16::ONE; rms_spec.hidden_size()];
+    let (_, gemm_weight_host) = large_fixture(gemm_spec);
+    let mut intermediate_expected = vec![bf16::ZERO; rms_spec.numel()];
+    let mut expected = vec![bf16::ZERO; gemm_spec.output_numel()];
+    rms_norm_bf16_reference(
+        &input_host,
+        &norm_weight_host,
+        &mut intermediate_expected,
+        rms_spec,
+    )?;
+    bf16_gemm_reference(
+        &intermediate_expected,
+        &gemm_weight_host,
+        &mut expected,
+        gemm_spec,
+    )?;
+
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let norm_weight = Arc::new(DeviceBuffer::from_host(&stream, &norm_weight_host)?);
+    let intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let gemm_weight = Arc::new(DeviceBuffer::from_host(&stream, &gemm_weight_host)?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, gemm_spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(&gemm_plan))?;
+    let graph_queue = GraphQueue::new(stream.context(), 2)?;
+    let mut bindings = graph_queue.bindings(6)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let norm_weight_handle = bindings.bind_read(Arc::clone(&norm_weight))?;
+    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let gemm_weight_handle = bindings.bind_read(Arc::clone(&gemm_weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
+
+    let captured = graph_queue.capture(bindings, |scope| -> Result<(), Box<dyn Error>> {
+        rms_plan.enqueue_into(
+            scope,
+            RmsNormArgs::new(
+                input_handle,
+                norm_weight_handle,
+                intermediate_handle.write(),
+            ),
+        )?;
+        gemm_plan.enqueue_into(
+            scope,
+            Bf16GemmArgs::new(
+                intermediate_handle.read(),
+                gemm_weight_handle,
+                output_handle.write(),
+                workspace_handle.write(),
+            ),
+        )?;
+        Ok(())
+    })?;
+    if captured.commands() != 2 {
+        return Err("captured graph covered the wrong command count".into());
+    }
+    drop(rms_plan);
+    drop(gemm_plan);
+    drop(input);
+    drop(norm_weight);
+    drop(gemm_weight);
+
+    let mut exec = captured.instantiate()?;
+    for expected_launch in 1..=2 {
+        let mut completion = exec.launch()?;
+        if completion.launch_index() != expected_launch {
+            return Err("graph completion reported the wrong replay index".into());
+        }
+        let _ = completion.is_complete()?;
+        if expected_launch == 1 {
+            completion.wait()?;
+        } else {
+            drop(completion);
+        }
+    }
+    if exec.launches() != 2 || exec.commands() != 2 {
+        return Err("graph exec accounting changed across replay".into());
+    }
+    let mut bindings = exec.into_bindings()?;
+    let output = bindings.take_read_write(output_handle)?;
+    drop(bindings);
+
+    let actual = output.to_host_vec(&stream)?;
+    let comparison = compare(&actual, &expected)?;
+    require_bit_exact("RMSNorm to GEMM graph", comparison)?;
+    println!(
+        "gate=bf16_gemm_h20 case=rms_norm_gemm_graph status=pass rows=1 hidden=4096 \
+         m={} n={} k={} commands=2 replays=2 fixed_bindings=true cross_stream=false \
+         external_owners_dropped_before_replay=true \
+         completion_queries=2 completion_waits=1 completion_drops=1 \
+         intra_graph_host_waits=0 inter_replay_host_waits=1 \
+         bit_mismatches={} max_abs={:.9e} digest={:016x}",
         gemm_spec.m(),
         gemm_spec.n(),
         gemm_spec.k(),
@@ -483,6 +601,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     check_short_buffers(&mut queue, &small_plan)?;
     check_command_capacity(queue.stream(), &small_plan)?;
     check_rms_norm_gemm_chain(&mut queue, &rms_provider, &large_plan)?;
+    drop(small_plan);
+    drop(gemm_provider);
+    check_rms_norm_gemm_graph(&mut queue, rms_provider, large_plan)?;
     println!("gate=bf16_gemm_h20 suite=all status=pass");
     Ok(())
 }

--- a/crates/loom-infer-cuda/src/bin/rms_norm_h20.rs
+++ b/crates/loom-infer-cuda/src/bin/rms_norm_h20.rs
@@ -8,6 +8,7 @@ use loom_infer_cuda::rms_norm::{
     RmsNormArgs, RmsNormBf16Plan, RmsNormEnqueueError, RmsNormF16Plan, RmsNormKernelPath,
     RmsNormPlanError, RmsNormProvider,
 };
+use std::sync::Arc;
 
 const F32_MAX_ABS_ERROR: f32 = 5.0e-5;
 const F16_MAX_ABS_ERROR: f32 = 4.0e-3;
@@ -29,7 +30,7 @@ trait LowPrecisionPlan<T: LowPrecision> {
 
     fn enqueue(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<T>,
     ) -> Result<(), RmsNormEnqueueError>;
 }
@@ -60,7 +61,7 @@ impl LowPrecisionPlan<f16> for RmsNormF16Plan {
 
     fn enqueue(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<f16>,
     ) -> Result<(), RmsNormEnqueueError> {
         self.enqueue_into(scope, args)
@@ -107,7 +108,7 @@ impl LowPrecisionPlan<bf16> for RmsNormBf16Plan {
 
     fn enqueue(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<bf16>,
     ) -> Result<(), RmsNormEnqueueError> {
         self.enqueue_into(scope, args)
@@ -222,13 +223,13 @@ fn check_low_precision_case<T: LowPrecision>(
     let mut expected = vec![T::from_f32(0.0); spec.numel()];
     T::reference(&input_host, &weight_host, &mut expected, spec)?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-    let mut output = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+    let output = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
     let mut bindings = queue.bindings(3)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
     let mut scope = queue.begin(bindings)?;
     plan.enqueue(
         &mut scope,
@@ -238,7 +239,8 @@ fn check_low_precision_case<T: LowPrecision>(
     if completion.submitted() != 1 {
         return Err(format!("{} single scope retained the wrong command count", T::NAME).into());
     }
-    drop(completion.wait()?);
+    let mut bindings = completion.wait()?;
+    let output = bindings.take_read_write(output_handle)?;
 
     let actual = output.to_host_vec(&stream)?;
     let stats = compare_low_precision(&actual, &expected)?;
@@ -280,13 +282,13 @@ fn check_f32_case(
     let mut expected = vec![0.0_f32; spec.numel()];
     rms_norm_f32_reference(&input_host, &weight_host, &mut expected, spec)?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-    let mut output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+    let output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
     let mut bindings = queue.bindings(3)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
     let mut scope = queue.begin(bindings)?;
     plan.enqueue_into(
         &mut scope,
@@ -296,8 +298,8 @@ fn check_f32_case(
     if completion.submitted() != 1 {
         return Err("single RMSNorm scope did not retain exactly one launch".into());
     }
-    let bindings = completion.wait()?;
-    drop(bindings);
+    let mut bindings = completion.wait()?;
+    let output = bindings.take_read_write(output_handle)?;
 
     let actual = output.to_host_vec(&stream)?;
     let mut max_abs_error = 0.0_f32;
@@ -342,14 +344,14 @@ fn check_f32_rejected_input_length(
     let stream = queue.stream().clone();
     let spec = RmsNormSpec::new(1, 4, 1.0e-5, DType::F32)?;
     let plan = provider.plan_f32(spec)?;
-    let input = DeviceBuffer::from_host(&stream, &[1.0_f32; 3])?;
-    let weight = DeviceBuffer::from_host(&stream, &[1.0_f32; 4])?;
-    let mut output = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &[1.0_f32; 3])?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &[1.0_f32; 4])?);
+    let output = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
 
     let mut bindings = queue.bindings(3)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let output_handle = bindings.bind_read_write(output)?;
     let mut scope = queue.begin(bindings)?;
     if plan
         .enqueue_into(
@@ -392,18 +394,18 @@ fn check_f32_chained_scope(
         spec,
     )?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let weight_one = DeviceBuffer::from_host(&stream, &weight_one_host)?;
-    let weight_two = DeviceBuffer::from_host(&stream, &weight_two_host)?;
-    let mut intermediate = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
-    let mut output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let weight_one = Arc::new(DeviceBuffer::from_host(&stream, &weight_one_host)?);
+    let weight_two = Arc::new(DeviceBuffer::from_host(&stream, &weight_two_host)?);
+    let intermediate = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
 
     let mut bindings = queue.bindings(5)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let weight_one_handle = bindings.bind_read(&weight_one)?;
-    let intermediate_handle = bindings.bind_read_write(&mut intermediate)?;
-    let weight_two_handle = bindings.bind_read(&weight_two)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_one_handle = bindings.bind_read(Arc::clone(&weight_one))?;
+    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let weight_two_handle = bindings.bind_read(Arc::clone(&weight_two))?;
+    let output_handle = bindings.bind_read_write(output)?;
     for _ in 0..2 {
         let mut scope = queue.begin(bindings)?;
         plan.enqueue_into(
@@ -424,7 +426,7 @@ fn check_f32_chained_scope(
         }
         bindings = completion.wait()?;
     }
-    drop(bindings);
+    let output = bindings.take_read_write(output_handle)?;
 
     let actual = output.to_host_vec(&stream)?;
     let max_abs_error = actual
@@ -459,17 +461,17 @@ fn check_f32_partial_scope_rejection(
     let mut expected = [0.0_f32; 4];
     rms_norm_f32_reference(&input_host, &weight_host, &mut expected, spec)?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let short_input = DeviceBuffer::from_host(&stream, &[1.0_f32; 3])?;
-    let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-    let mut intermediate = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
-    let mut output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let short_input = Arc::new(DeviceBuffer::from_host(&stream, &[1.0_f32; 3])?);
+    let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+    let intermediate = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
     let mut bindings = queue.bindings(5)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let short_input_handle = bindings.bind_read(&short_input)?;
-    let weight_handle = bindings.bind_read(&weight)?;
-    let intermediate_handle = bindings.bind_read_write(&mut intermediate)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let short_input_handle = bindings.bind_read(Arc::clone(&short_input))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let output_handle = bindings.bind_read_write(output)?;
     let mut scope = queue.begin(bindings)?;
     plan.enqueue_into(
         &mut scope,
@@ -484,7 +486,8 @@ fn check_f32_partial_scope_rejection(
     {
         return Err("partial scope accepted a short second input".into());
     }
-    drop(scope);
+    let mut bindings = scope.finish().wait()?;
+    let intermediate = bindings.take_read_write(intermediate_handle)?;
 
     let actual = intermediate.to_host_vec(&stream)?;
     let max_abs_error = actual
@@ -499,6 +502,38 @@ fn check_f32_partial_scope_rejection(
         .into());
     }
 
+    let drop_intermediate = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let drop_output = DeviceBuffer::<f32>::zeroed(&stream, spec.numel())?;
+    let mut drop_bindings = queue.bindings(5)?;
+    let drop_input_handle = drop_bindings.bind_read(Arc::clone(&input))?;
+    let drop_short_input_handle = drop_bindings.bind_read(Arc::clone(&short_input))?;
+    let drop_weight_handle = drop_bindings.bind_read(Arc::clone(&weight))?;
+    let drop_intermediate_handle = drop_bindings.bind_read_write(drop_intermediate)?;
+    let drop_output_handle = drop_bindings.bind_read_write(drop_output)?;
+    let mut drop_scope = queue.begin(drop_bindings)?;
+    plan.enqueue_into(
+        &mut drop_scope,
+        RmsNormArgs::new(
+            drop_input_handle,
+            drop_weight_handle,
+            drop_intermediate_handle.write(),
+        ),
+    )?;
+    if plan
+        .enqueue_into(
+            &mut drop_scope,
+            RmsNormArgs::new(
+                drop_short_input_handle,
+                drop_weight_handle,
+                drop_output_handle.write(),
+            ),
+        )
+        .is_ok()
+    {
+        return Err("drop-guard scope accepted a short second input".into());
+    }
+    drop(drop_scope);
+
     println!(
         "rms_norm_f32 partial_scope submitted_before_error=1 second_launch_rejected=true \
          drop_guard_exercised=true first_launch_max_abs_error={max_abs_error:.9e}"
@@ -509,14 +544,24 @@ fn check_f32_partial_scope_rejection(
 fn expect_low_precision_rejection<T: LowPrecision>(
     queue: &mut CommandQueue,
     plan: &T::Plan,
-    input: &DeviceBuffer<T>,
-    weight: &DeviceBuffer<T>,
-    output: &mut DeviceBuffer<T>,
+    input_len: usize,
+    weight_len: usize,
+    output_len: usize,
     operand: &'static str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let stream = queue.stream().clone();
+    let input = Arc::new(DeviceBuffer::from_host(
+        &stream,
+        &vec![T::from_f32(1.0); input_len],
+    )?);
+    let weight = Arc::new(DeviceBuffer::from_host(
+        &stream,
+        &vec![T::from_f32(1.0); weight_len],
+    )?);
+    let output = DeviceBuffer::<T>::zeroed(&stream, output_len)?;
     let mut bindings = queue.bindings(3)?;
-    let input_handle = bindings.bind_read(input)?;
-    let weight_handle = bindings.bind_read(weight)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
     let output_handle = bindings.bind_read_write(output)?;
     let mut scope = queue.begin(bindings)?;
     if plan
@@ -536,40 +581,12 @@ fn check_low_precision_rejections<T: LowPrecision>(
     queue: &mut CommandQueue,
     provider: &RmsNormProvider,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let stream = queue.stream().clone();
     let spec = RmsNormSpec::new(1, 4, 1.0e-5, T::DTYPE)?;
     let plan = T::plan(provider, spec)?;
-    let valid_input = DeviceBuffer::from_host(&stream, &[T::from_f32(1.0); 4])?;
-    let short_input = DeviceBuffer::from_host(&stream, &[T::from_f32(1.0); 3])?;
-    let valid_weight = DeviceBuffer::from_host(&stream, &[T::from_f32(1.0); 4])?;
-    let short_weight = DeviceBuffer::from_host(&stream, &[T::from_f32(1.0); 3])?;
-    let mut valid_output = DeviceBuffer::<T>::zeroed(&stream, 4)?;
-    let mut short_output = DeviceBuffer::<T>::zeroed(&stream, 3)?;
 
-    expect_low_precision_rejection(
-        queue,
-        &plan,
-        &short_input,
-        &valid_weight,
-        &mut valid_output,
-        "input",
-    )?;
-    expect_low_precision_rejection(
-        queue,
-        &plan,
-        &valid_input,
-        &short_weight,
-        &mut valid_output,
-        "weight",
-    )?;
-    expect_low_precision_rejection(
-        queue,
-        &plan,
-        &valid_input,
-        &valid_weight,
-        &mut short_output,
-        "output",
-    )?;
+    expect_low_precision_rejection::<T>(queue, &plan, 3, 4, 4, "input")?;
+    expect_low_precision_rejection::<T>(queue, &plan, 4, 3, 4, "weight")?;
+    expect_low_precision_rejection::<T>(queue, &plan, 4, 4, 3, "output")?;
 
     println!(
         "rms_norm_{} short_buffers input_rejected=true weight_rejected=true \
@@ -610,22 +627,22 @@ fn check_low_precision_chained_scope<T: LowPrecision>(
         spec,
     )?;
 
-    let input = DeviceBuffer::from_host(&stream, &input_host)?;
-    let weight_one = DeviceBuffer::from_host(&stream, &weight_one_host)?;
-    let weight_two = DeviceBuffer::from_host(&stream, &weight_two_host)?;
-    let mut intermediate = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
-    let mut output = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
-    let metadata = DeviceBuffer::from_host(&stream, &[1.0_f32])?;
-    let mut workspace = DeviceBuffer::<u8>::zeroed(&stream, 256)?;
+    let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let weight_one = Arc::new(DeviceBuffer::from_host(&stream, &weight_one_host)?);
+    let weight_two = Arc::new(DeviceBuffer::from_host(&stream, &weight_two_host)?);
+    let intermediate = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
+    let output = DeviceBuffer::<T>::zeroed(&stream, spec.numel())?;
+    let metadata = Arc::new(DeviceBuffer::from_host(&stream, &[1.0_f32])?);
+    let workspace = DeviceBuffer::<u8>::zeroed(&stream, 256)?;
 
     let mut bindings = queue.bindings(7)?;
-    let input_handle = bindings.bind_read(&input)?;
-    let weight_one_handle = bindings.bind_read(&weight_one)?;
-    let intermediate_handle = bindings.bind_read_write(&mut intermediate)?;
-    let weight_two_handle = bindings.bind_read(&weight_two)?;
-    let output_handle = bindings.bind_read_write(&mut output)?;
-    let _metadata_handle = bindings.bind_read(&metadata)?;
-    let _workspace_handle = bindings.bind_read_write(&mut workspace)?;
+    let input_handle = bindings.bind_read(Arc::clone(&input))?;
+    let weight_one_handle = bindings.bind_read(Arc::clone(&weight_one))?;
+    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let weight_two_handle = bindings.bind_read(Arc::clone(&weight_two))?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let _metadata_handle = bindings.bind_read(Arc::clone(&metadata))?;
+    let _workspace_handle = bindings.bind_read_write(workspace)?;
     for _ in 0..2 {
         let mut scope = queue.begin(bindings)?;
         plan.enqueue(
@@ -648,7 +665,7 @@ fn check_low_precision_chained_scope<T: LowPrecision>(
         }
         bindings = completion.wait()?;
     }
-    drop(bindings);
+    let output = bindings.take_read_write(output_handle)?;
 
     let actual = output.to_host_vec(&stream)?;
     let stats = compare_low_precision(&actual, &expected)?;
@@ -689,19 +706,20 @@ fn check_low_precision_signed_zero<T: LowPrecision>(
         let weight_host = vec![T::from_f32(1.0); hidden_size];
         let mut expected = vec![T::from_f32(0.0); hidden_size];
         T::reference(&input_host, &weight_host, &mut expected, spec)?;
-        let input = DeviceBuffer::from_host(&stream, &input_host)?;
-        let weight = DeviceBuffer::from_host(&stream, &weight_host)?;
-        let mut output = DeviceBuffer::<T>::zeroed(&stream, hidden_size)?;
+        let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+        let weight = Arc::new(DeviceBuffer::from_host(&stream, &weight_host)?);
+        let output = DeviceBuffer::<T>::zeroed(&stream, hidden_size)?;
         let mut bindings = queue.bindings(3)?;
-        let input_handle = bindings.bind_read(&input)?;
-        let weight_handle = bindings.bind_read(&weight)?;
-        let output_handle = bindings.bind_read_write(&mut output)?;
+        let input_handle = bindings.bind_read(Arc::clone(&input))?;
+        let weight_handle = bindings.bind_read(Arc::clone(&weight))?;
+        let output_handle = bindings.bind_read_write(output)?;
         let mut scope = queue.begin(bindings)?;
         plan.enqueue(
             &mut scope,
             RmsNormArgs::new(input_handle, weight_handle, output_handle.write()),
         )?;
-        drop(scope.finish().wait()?);
+        let mut bindings = scope.finish().wait()?;
+        let output = bindings.take_read_write(output_handle)?;
         let actual = output.to_host_vec(&stream)?;
         let actual_bits = actual.iter().map(|value| value.bits()).collect::<Vec<_>>();
         let expected_bits = expected

--- a/crates/loom-infer-cuda/src/command.rs
+++ b/crates/loom-infer-cuda/src/command.rs
@@ -5,6 +5,7 @@
 use cuda_core::{CudaEvent, CudaFunction, CudaStream, DeviceBuffer, DeviceCopy, DriverError};
 use half::{bf16, f16};
 use std::any::Any;
+use std::fmt::{self, Display, Formatter};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -56,10 +57,7 @@ impl CommandQueue {
     }
 
     /// Creates reusable checked binding storage outside the enqueue path.
-    pub fn bindings<'buffer>(
-        &self,
-        capacity: usize,
-    ) -> Result<CheckedBindings<'buffer>, CommandError> {
+    pub fn bindings(&self, capacity: usize) -> Result<CheckedBindings, CommandError> {
         if capacity == 0 {
             return Err(CommandError::ZeroBindingCapacity);
         }
@@ -74,10 +72,10 @@ impl CommandQueue {
     }
 
     /// Begins one stream-ordered command scope.
-    pub fn begin<'queue, 'buffer>(
+    pub fn begin<'queue>(
         &'queue mut self,
-        bindings: CheckedBindings<'buffer>,
-    ) -> Result<CommandScope<'queue, 'buffer>, CommandError> {
+        bindings: CheckedBindings,
+    ) -> Result<CommandScope<'queue>, CommandError> {
         if self.poisoned {
             return Err(CommandError::QueuePoisoned);
         }
@@ -109,7 +107,7 @@ impl Drop for CommandQueue {
             return;
         }
 
-        let synchronize_error = synchronize_stream_or_abort(self);
+        let synchronize_error = synchronize_stream_or_abort(&self.stream);
         self.retained_resources.clear();
         if let Some(error) = synchronize_error {
             eprintln!(
@@ -122,17 +120,19 @@ impl Drop for CommandQueue {
 
 /// A reusable set of checked, heterogeneous buffer leases.
 ///
-/// Moving this value into a [`CommandScope`] keeps every buffer borrowed until
-/// the returned completion is settled.
-pub struct CheckedBindings<'buffer> {
+/// Moving this value into a [`CommandScope`] retains shared read allocations and
+/// transfers writable allocations until the returned completion is settled.
+/// Owning every writable allocation makes the asynchronous contract safe even
+/// if a scope or completion is leaked.
+pub struct CheckedBindings {
     queue_id: u64,
     set_id: u64,
     stream: Arc<CudaStream>,
-    leases: Vec<Lease<'buffer>>,
+    leases: Vec<Lease>,
     capacity: usize,
 }
 
-impl<'buffer> CheckedBindings<'buffer> {
+impl CheckedBindings {
     pub const fn capacity(&self) -> usize {
         self.capacity
     }
@@ -148,10 +148,20 @@ impl<'buffer> CheckedBindings<'buffer> {
     /// Adds a read-only buffer and returns its opaque handle.
     pub fn bind_read<T: BindingElement>(
         &mut self,
-        buffer: &'buffer DeviceBuffer<T>,
-    ) -> Result<Read<T>, CommandError> {
-        self.check_buffer(buffer)?;
-        let slot = self.reserve_slot()?;
+        buffer: Arc<DeviceBuffer<T>>,
+    ) -> Result<Read<T>, BindError<Arc<DeviceBuffer<T>>>> {
+        let slot = match self
+            .check_buffer(&buffer)
+            .and_then(|()| self.reserve_slot())
+        {
+            Ok(slot) => slot,
+            Err(error) => {
+                return Err(BindError {
+                    error,
+                    resource: buffer,
+                });
+            }
+        };
         let ErasedLease(lease) = T::__erase_read(buffer);
         self.leases.push(lease);
         Ok(Read {
@@ -161,13 +171,23 @@ impl<'buffer> CheckedBindings<'buffer> {
         })
     }
 
-    /// Adds a uniquely borrowed buffer that may be read and written.
+    /// Transfers one buffer that may be read and written.
     pub fn bind_read_write<T: BindingElement>(
         &mut self,
-        buffer: &'buffer mut DeviceBuffer<T>,
-    ) -> Result<ReadWrite<T>, CommandError> {
-        self.check_buffer(buffer)?;
-        let slot = self.reserve_slot()?;
+        buffer: DeviceBuffer<T>,
+    ) -> Result<ReadWrite<T>, BindError<DeviceBuffer<T>>> {
+        let slot = match self
+            .check_buffer(&buffer)
+            .and_then(|()| self.reserve_slot())
+        {
+            Ok(slot) => slot,
+            Err(error) => {
+                return Err(BindError {
+                    error,
+                    resource: buffer,
+                });
+            }
+        };
         let ErasedLease(lease) = T::__erase_read_write(buffer);
         self.leases.push(lease);
         Ok(ReadWrite {
@@ -175,6 +195,26 @@ impl<'buffer> CheckedBindings<'buffer> {
             slot,
             element: PhantomData,
         })
+    }
+
+    /// Removes one completed allocation from the binding arena.
+    ///
+    /// This is intended after [`CommandCompletion::wait`] or
+    /// [`crate::graph::GraphExec::into_bindings`] returns ownership.
+    pub fn take_read_write<T: BindingElement>(
+        &mut self,
+        handle: ReadWrite<T>,
+    ) -> Result<DeviceBuffer<T>, CommandError> {
+        if handle.set_id != self.set_id {
+            return Err(CommandError::BindingSetMismatch);
+        }
+        if handle.slot >= self.leases.len() {
+            return Err(CommandError::BindingSlotOutOfRange {
+                slot: handle.slot,
+                bindings: self.leases.len(),
+            });
+        }
+        T::__take_read_write(self, handle.slot)
     }
 
     fn check_buffer<T: BindingElement>(
@@ -204,16 +244,57 @@ impl<'buffer> CheckedBindings<'buffer> {
     }
 }
 
-pub(crate) enum Access<'buffer, T: DeviceCopy> {
-    Read(&'buffer DeviceBuffer<T>),
-    ReadWrite(&'buffer mut DeviceBuffer<T>),
+/// A failed ownership transfer into a checked binding arena.
+///
+/// The original allocation is returned so a recoverable capacity or context
+/// error never destroys caller data.
+pub struct BindError<R> {
+    error: CommandError,
+    resource: R,
 }
 
-pub(crate) enum Lease<'buffer> {
-    F32(Access<'buffer, f32>),
-    F16(Access<'buffer, f16>),
-    Bf16(Access<'buffer, bf16>),
-    U8(Access<'buffer, u8>),
+impl<R> BindError<R> {
+    pub const fn error(&self) -> &CommandError {
+        &self.error
+    }
+
+    pub fn into_parts(self) -> (CommandError, R) {
+        (self.error, self.resource)
+    }
+}
+
+impl<R> fmt::Debug for BindError<R> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BindError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<R> Display for BindError<R> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.error, formatter)
+    }
+}
+
+impl<R: 'static> std::error::Error for BindError<R> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+pub(crate) enum Access<T: DeviceCopy> {
+    Read(Arc<DeviceBuffer<T>>),
+    ReadWrite(DeviceBuffer<T>),
+}
+
+pub(crate) enum Lease {
+    F32(Access<f32>),
+    F16(Access<f16>),
+    Bf16(Access<bf16>),
+    U8(Access<u8>),
+    Vacant,
 }
 
 mod sealed {
@@ -224,13 +305,18 @@ mod sealed {
 ///
 /// The trait is sealed so every handle can be resolved without type erasure,
 /// downcasts, or unsafe pointer casts.
-pub trait BindingElement: DeviceCopy + sealed::Sealed + Sized {
+pub trait BindingElement: DeviceCopy + sealed::Sealed + Sized + 'static {
     #[doc(hidden)]
-    fn __erase_read<'buffer>(buffer: &'buffer DeviceBuffer<Self>) -> ErasedLease<'buffer>;
+    fn __erase_read(buffer: Arc<DeviceBuffer<Self>>) -> ErasedLease;
 
     #[doc(hidden)]
-    fn __erase_read_write<'buffer>(buffer: &'buffer mut DeviceBuffer<Self>)
-    -> ErasedLease<'buffer>;
+    fn __erase_read_write(buffer: DeviceBuffer<Self>) -> ErasedLease;
+
+    #[doc(hidden)]
+    fn __take_read_write(
+        bindings: &mut CheckedBindings,
+        slot: usize,
+    ) -> Result<DeviceBuffer<Self>, CommandError>;
 }
 
 /// Opaque erased storage for one binding.
@@ -238,19 +324,18 @@ pub trait BindingElement: DeviceCopy + sealed::Sealed + Sized {
 /// This type exists only to keep the sealed [`BindingElement`] interface
 /// visibility-correct. Its payload is private and cannot be forged downstream.
 #[doc(hidden)]
-pub struct ErasedLease<'buffer>(Lease<'buffer>);
+pub struct ErasedLease(Lease);
 
 pub(crate) trait ResolveElement: BindingElement {
-    fn read<'lease>(lease: &'lease Lease<'_>) -> Result<&'lease DeviceBuffer<Self>, LeaseError>;
+    fn read(lease: &Lease) -> Result<&DeviceBuffer<Self>, LeaseError>;
 
-    fn write<'lease>(
-        lease: &'lease mut Lease<'_>,
-    ) -> Result<&'lease mut DeviceBuffer<Self>, LeaseError>;
+    fn write(lease: &mut Lease) -> Result<&mut DeviceBuffer<Self>, LeaseError>;
 }
 
 pub(crate) enum LeaseError {
     ElementMismatch,
     ReadOnly,
+    Vacant,
 }
 
 macro_rules! impl_binding_element {
@@ -258,34 +343,53 @@ macro_rules! impl_binding_element {
         impl sealed::Sealed for $ty {}
 
         impl BindingElement for $ty {
-            fn __erase_read<'buffer>(buffer: &'buffer DeviceBuffer<Self>) -> ErasedLease<'buffer> {
+            fn __erase_read(buffer: Arc<DeviceBuffer<Self>>) -> ErasedLease {
                 ErasedLease(Lease::$variant(Access::Read(buffer)))
             }
 
-            fn __erase_read_write<'buffer>(
-                buffer: &'buffer mut DeviceBuffer<Self>,
-            ) -> ErasedLease<'buffer> {
+            fn __erase_read_write(buffer: DeviceBuffer<Self>) -> ErasedLease {
                 ErasedLease(Lease::$variant(Access::ReadWrite(buffer)))
+            }
+
+            fn __take_read_write(
+                bindings: &mut CheckedBindings,
+                slot: usize,
+            ) -> Result<DeviceBuffer<Self>, CommandError> {
+                let lease = bindings
+                    .leases
+                    .get_mut(slot)
+                    .expect("binding slot was validated before removal");
+                let owned = std::mem::replace(lease, Lease::Vacant);
+                match owned {
+                    Lease::$variant(Access::ReadWrite(buffer)) => Ok(buffer),
+                    Lease::$variant(Access::Read(buffer)) => {
+                        *lease = Lease::$variant(Access::Read(buffer));
+                        Err(CommandError::BindingIsReadOnly { slot })
+                    }
+                    Lease::Vacant => Err(CommandError::BindingSlotVacant { slot }),
+                    other => {
+                        *lease = other;
+                        Err(CommandError::BindingTypeMismatch { slot })
+                    }
+                }
             }
         }
 
         impl ResolveElement for $ty {
-            fn read<'lease>(
-                lease: &'lease Lease<'_>,
-            ) -> Result<&'lease DeviceBuffer<Self>, LeaseError> {
+            fn read(lease: &Lease) -> Result<&DeviceBuffer<Self>, LeaseError> {
                 match lease {
-                    Lease::$variant(Access::Read(buffer)) => Ok(*buffer),
-                    Lease::$variant(Access::ReadWrite(buffer)) => Ok(&**buffer),
+                    Lease::$variant(Access::Read(buffer)) => Ok(buffer.as_ref()),
+                    Lease::$variant(Access::ReadWrite(buffer)) => Ok(buffer),
+                    Lease::Vacant => Err(LeaseError::Vacant),
                     _ => Err(LeaseError::ElementMismatch),
                 }
             }
 
-            fn write<'lease>(
-                lease: &'lease mut Lease<'_>,
-            ) -> Result<&'lease mut DeviceBuffer<Self>, LeaseError> {
+            fn write(lease: &mut Lease) -> Result<&mut DeviceBuffer<Self>, LeaseError> {
                 match lease {
-                    Lease::$variant(Access::ReadWrite(buffer)) => Ok(&mut **buffer),
+                    Lease::$variant(Access::ReadWrite(buffer)) => Ok(buffer),
                     Lease::$variant(Access::Read(_)) => Err(LeaseError::ReadOnly),
+                    Lease::Vacant => Err(LeaseError::Vacant),
                     _ => Err(LeaseError::ElementMismatch),
                 }
             }
@@ -341,18 +445,18 @@ pub struct Write<T: BindingElement> {
 }
 
 /// A stream-ordered sequence of commands with one final completion fence.
-pub struct CommandScope<'queue, 'buffer> {
+pub struct CommandScope<'queue> {
     queue: Option<&'queue mut CommandQueue>,
-    bindings: Option<CheckedBindings<'buffer>>,
+    bindings: Option<CheckedBindings>,
     scope_id: u64,
     submitted: usize,
     submission_error: Option<SubmissionError>,
     finished: bool,
 }
 
-impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
-    /// Records one final fence and transfers all leases to the completion.
-    pub fn finish(mut self) -> CommandCompletion<'queue, 'buffer> {
+impl<'queue> CommandScope<'queue> {
+    /// Records one final fence and transfers all bindings to the completion.
+    pub fn finish(mut self) -> CommandCompletion<'queue> {
         let queue = self.queue.take().expect("live command scope has a queue");
         let bindings = self
             .bindings
@@ -391,6 +495,37 @@ impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
                 scope_id: self.scope_id,
                 submission_index: self.submitted,
             })
+        }
+    }
+
+    pub(crate) const fn submitted_commands(&self) -> usize {
+        self.submitted
+    }
+
+    pub(crate) fn capture_error(&self) -> Option<CommandError> {
+        self.submission_error.map(Into::into)
+    }
+
+    pub(crate) fn finish_capture(mut self) -> CapturedCommandSet {
+        assert!(
+            self.submission_error.is_none() && self.submitted > 0,
+            "only a non-empty healthy command scope may become a captured graph"
+        );
+        let queue = self.queue.take().expect("live command scope has a queue");
+        let bindings = self
+            .bindings
+            .take()
+            .expect("live command scope has bindings");
+        let resources = std::mem::replace(
+            &mut queue.retained_resources,
+            Vec::with_capacity(queue.max_commands),
+        );
+        self.finished = true;
+        CapturedCommandSet {
+            stream: queue.stream.clone(),
+            bindings,
+            resources,
+            submitted: self.submitted,
         }
     }
 
@@ -525,6 +660,10 @@ impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
                 _function: function,
             },
         );
+        self.queue
+            .as_mut()
+            .expect("live command scope has a queue")
+            .poisoned = true;
         self.submission_error = Some(SubmissionError::Driver(error));
     }
 
@@ -554,10 +693,18 @@ impl<'queue, 'buffer> CommandScope<'queue, 'buffer> {
                 _resource: resource,
             },
         );
+        self.queue
+            .as_mut()
+            .expect("live command scope has a queue")
+            .poisoned = true;
         self.submission_error = Some(SubmissionError::External(error));
     }
 
     pub(crate) fn record_preflight_driver_failure(&mut self, error: DriverError) {
+        self.queue
+            .as_mut()
+            .expect("live command scope has a queue")
+            .poisoned = true;
         self.submission_error = Some(SubmissionError::Driver(error));
     }
 
@@ -583,7 +730,7 @@ pub(crate) struct CommandPermit {
     submission_index: usize,
 }
 
-enum RetainedResource {
+pub(crate) enum RetainedResource {
     Kernel {
         _function: CudaFunction,
     },
@@ -592,7 +739,14 @@ enum RetainedResource {
     },
 }
 
-impl Drop for CommandScope<'_, '_> {
+pub(crate) struct CapturedCommandSet {
+    pub(crate) stream: Arc<CudaStream>,
+    pub(crate) bindings: CheckedBindings,
+    pub(crate) resources: Vec<RetainedResource>,
+    pub(crate) submitted: usize,
+}
+
+impl Drop for CommandScope<'_> {
     fn drop(&mut self) {
         if self.finished {
             return;
@@ -602,7 +756,7 @@ impl Drop for CommandScope<'_, '_> {
         };
 
         if self.submitted > 0 {
-            let synchronize_error = synchronize_stream_or_abort(queue);
+            let synchronize_error = synchronize_stream_or_abort(&queue.stream);
             if self.submission_error.is_some() || synchronize_error.is_some() {
                 queue.poisoned = true;
             }
@@ -649,11 +803,11 @@ pub(crate) struct ResolvedRrww<
     pub(crate) fourth: &'scope mut DeviceBuffer<D>,
 }
 
-/// The final fence and all leases retained by a completed command scope.
+/// The final fence and all bindings retained by a completed command scope.
 #[must_use = "dropping the completion waits before releasing CUDA resources"]
-pub struct CommandCompletion<'queue, 'buffer> {
+pub struct CommandCompletion<'queue> {
     queue: Option<&'queue mut CommandQueue>,
-    bindings: Option<CheckedBindings<'buffer>>,
+    bindings: Option<CheckedBindings>,
     submitted: usize,
     submission_error: Option<SubmissionError>,
     record_error: Option<DriverError>,
@@ -661,7 +815,7 @@ pub struct CommandCompletion<'queue, 'buffer> {
     complete: bool,
 }
 
-impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
+impl<'queue> CommandCompletion<'queue> {
     /// Returns whether all submitted commands have completed without blocking.
     pub fn is_complete(&mut self) -> Result<bool, CommandError> {
         if let Some(error) = self.submission_error {
@@ -687,7 +841,7 @@ impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
     }
 
     /// Waits once and returns the reusable checked bindings.
-    pub fn wait(mut self) -> Result<CheckedBindings<'buffer>, CommandError> {
+    pub fn wait(mut self) -> Result<CheckedBindings, CommandError> {
         match self.settle() {
             None => {
                 self.complete = true;
@@ -726,32 +880,32 @@ impl<'queue, 'buffer> CommandCompletion<'queue, 'buffer> {
         if let Some(submission_error) = self.submission_error {
             return Some(SettlementFailure {
                 reported: submission_error,
-                synchronize_error: synchronize_stream_or_abort(queue),
+                synchronize_error: synchronize_stream_or_abort(&queue.stream),
             });
         }
         if let Some(record_error) = self.record_error {
             return Some(SettlementFailure {
                 reported: SubmissionError::Driver(record_error),
-                synchronize_error: synchronize_stream_or_abort(queue),
+                synchronize_error: synchronize_stream_or_abort(&queue.stream),
             });
         }
         if let Some(poll_error) = self.poll_error {
             return Some(SettlementFailure {
                 reported: SubmissionError::Driver(poll_error),
-                synchronize_error: synchronize_stream_or_abort(queue),
+                synchronize_error: synchronize_stream_or_abort(&queue.stream),
             });
         }
         match queue.completion_event.synchronize() {
             Ok(()) => None,
             Err(event_error) => Some(SettlementFailure {
                 reported: SubmissionError::Driver(event_error),
-                synchronize_error: synchronize_stream_or_abort(queue),
+                synchronize_error: synchronize_stream_or_abort(&queue.stream),
             }),
         }
     }
 }
 
-impl Drop for CommandCompletion<'_, '_> {
+impl Drop for CommandCompletion<'_> {
     fn drop(&mut self) {
         if self.complete {
             return;
@@ -773,6 +927,7 @@ fn map_lease_error(error: LeaseError, slot: usize) -> CommandError {
     match error {
         LeaseError::ElementMismatch => CommandError::BindingTypeMismatch { slot },
         LeaseError::ReadOnly => CommandError::BindingIsReadOnly { slot },
+        LeaseError::Vacant => CommandError::BindingSlotVacant { slot },
     }
 }
 
@@ -782,10 +937,10 @@ fn fresh_id() -> Result<u64, CommandError> {
         .map_err(|_| CommandError::IdentifierSpaceExhausted)
 }
 
-fn synchronize_stream_or_abort(queue: &CommandQueue) -> Option<DriverError> {
-    match queue.stream.synchronize() {
+pub(crate) fn synchronize_stream_or_abort(stream: &CudaStream) -> Option<DriverError> {
+    match stream.synchronize() {
         Ok(()) => None,
-        Err(stream_error) => match queue.stream.context().synchronize() {
+        Err(stream_error) => match stream.context().synchronize() {
             Ok(()) => Some(stream_error),
             Err(context_error) => abort_after_sync_failure(stream_error, context_error),
         },
@@ -844,18 +999,15 @@ struct SettlementFailure {
 
 impl SettlementFailure {
     fn command_error(self) -> CommandError {
-        match self.synchronize_error {
-            Some(error) => CommandError::Driver(error),
-            None => self.reported.into(),
-        }
+        self.reported.into()
     }
 }
 
 fn record_settlement_errors(queue: &CommandQueue, failure: SettlementFailure) {
-    if let Some(error) = failure.reported.driver_error() {
+    if let Some(error) = failure.synchronize_error {
         queue.stream.context().record_err::<()>(Err(error));
     }
-    if let Some(error) = failure.synchronize_error {
+    if let Some(error) = failure.reported.driver_error() {
         queue.stream.context().record_err::<()>(Err(error));
     }
 }
@@ -907,6 +1059,8 @@ pub enum CommandError {
     BindingSlotOutOfRange { slot: usize, bindings: usize },
     #[error("binding slot {slot} is read-only")]
     BindingIsReadOnly { slot: usize },
+    #[error("binding slot {slot} has already been removed")]
+    BindingSlotVacant { slot: usize },
     #[error("binding slot {slot} has a different element type than its resource handle")]
     BindingTypeMismatch { slot: usize },
     #[error("one command cannot use the same binding slot for multiple operands")]

--- a/crates/loom-infer-cuda/src/driver.rs
+++ b/crates/loom-infer-cuda/src/driver.rs
@@ -1,0 +1,22 @@
+//! Shared raw-driver helpers for resource cleanup paths.
+
+use cuda_core::{CudaContext, DriverError, IntoResult, sys};
+use std::mem::MaybeUninit;
+
+/// Binds `context` without consulting cuda-oxide's sticky error state.
+///
+/// Cleanup must still release CUDA resources after an earlier asynchronous
+/// error. Normal execution paths must use `CudaContext::bind_to_thread`.
+pub(crate) fn bind_context_for_cleanup(context: &CudaContext) -> Result<(), DriverError> {
+    let mut current = MaybeUninit::uninit();
+    // SAFETY: CUDA writes one context handle to `current`. `context` remains
+    // live for this call and is the exact owner of the resources being freed.
+    unsafe {
+        sys::cuCtxGetCurrent(current.as_mut_ptr()).result()?;
+        let current = current.assume_init();
+        if current.is_null() || current != context.cu_ctx() {
+            sys::cuCtxSetCurrent(context.cu_ctx()).result()?;
+        }
+    }
+    Ok(())
+}

--- a/crates/loom-infer-cuda/src/gemm.rs
+++ b/crates/loom-infer-cuda/src/gemm.rs
@@ -1,12 +1,13 @@
 //! Fixed cuBLASLt plans for contiguous inference GEMM.
 
 use crate::command::{CommandError, CommandScope, ExternalCommandError, Read, ResolvedRrww, Write};
-use cuda_core::{CudaContext, DeviceBuffer, DriverError, IntoResult, sys as cuda_sys};
+use crate::driver::bind_context_for_cleanup;
+use cuda_core::{CudaContext, DeviceBuffer, DriverError};
 use cudarc::cublaslt::{result, sys};
 use half::bf16;
 use loom_infer::Bf16GemmSpec;
 use std::ffi::c_void;
-use std::mem::{MaybeUninit, size_of};
+use std::mem::size_of;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
 use thiserror::Error;
@@ -349,7 +350,7 @@ impl Bf16GemmPlan {
     /// Enqueues the frozen algorithm on the scope's caller-owned stream.
     pub fn enqueue_into(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: Bf16GemmArgs,
     ) -> Result<(), Bf16GemmEnqueueError> {
         let permit = scope.prepare_command()?;
@@ -562,22 +563,6 @@ fn mutable_device_ptr<T>(buffer: &mut DeviceBuffer<T>) -> *mut c_void {
 
 fn cublas_status(error: result::CublasError) -> i32 {
     error.0 as i32
-}
-
-fn bind_context_for_cleanup(context: &CudaContext) -> Result<(), DriverError> {
-    let mut current = MaybeUninit::uninit();
-    // SAFETY: CUDA writes one context handle to `current`. Setting the exact
-    // live context is required before destroying cuBLASLt resources. These raw
-    // driver calls deliberately bypass cuda-oxide's sticky-error check so a
-    // prior asynchronous error cannot prevent resource cleanup.
-    unsafe {
-        cuda_sys::cuCtxGetCurrent(current.as_mut_ptr()).result()?;
-        let current = current.assume_init();
-        if current.is_null() || current != context.cu_ctx() {
-            cuda_sys::cuCtxSetCurrent(context.cu_ctx()).result()?;
-        }
-    }
-    Ok(())
 }
 
 #[derive(Debug, Error)]

--- a/crates/loom-infer-cuda/src/graph.rs
+++ b/crates/loom-infer-cuda/src/graph.rs
@@ -1,0 +1,694 @@
+//! Fixed-address CUDA Graph capture and replay.
+//!
+//! The first graph contract deliberately excludes rebinding, node updates,
+//! cross-stream launch, concurrent replay, and default-stream capture. A graph
+//! owns its checked buffer bindings and every submitted kernel or vendor plan
+//! until the executable graph is destroyed.
+
+use crate::command::{
+    CapturedCommandSet, CheckedBindings, CommandError, CommandQueue, CommandScope,
+    RetainedResource, synchronize_stream_or_abort,
+};
+use crate::driver::bind_context_for_cleanup;
+use cuda_core::{CudaContext, CudaEvent, CudaStream, DriverError, IntoResult, sys};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::rc::Rc;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// A capture-only queue with a private CUDA stream.
+///
+/// The stream handle is intentionally not exposed. This prevents safe caller
+/// code from inserting untracked CUDA work into a capture while the closure is
+/// recording checked Loom commands.
+pub struct GraphQueue {
+    queue: CommandQueue,
+    not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl GraphQueue {
+    /// Creates a graph queue whose stream is private to Loom.
+    pub fn new(context: &Arc<CudaContext>, max_commands: usize) -> Result<Self, CommandError> {
+        let stream = context.new_stream().map_err(CommandError::from)?;
+        Ok(Self {
+            queue: CommandQueue::new(stream, max_commands)?,
+            not_send_sync: PhantomData,
+        })
+    }
+
+    /// Creates fixed binding storage for this exact graph queue.
+    pub fn bindings(&self, capacity: usize) -> Result<CheckedBindings, CommandError> {
+        self.queue.bindings(capacity)
+    }
+
+    /// Consumes this one-shot queue and captures one non-empty checked command
+    /// sequence.
+    ///
+    /// The first contract establishes input readiness with one context
+    /// synchronization before capture. Consuming the queue prevents safe code
+    /// from starting another capture on a stream retained by an earlier graph.
+    /// Replay remains asynchronous.
+    pub fn capture<E, F>(
+        mut self,
+        bindings: CheckedBindings,
+        record: F,
+    ) -> Result<CapturedGraph, CaptureError<E>>
+    where
+        F: FnOnce(&mut CommandScope<'_>) -> Result<(), E>,
+    {
+        if let Err(error) = self.queue.stream().context().synchronize() {
+            eprintln!(
+                "loom-infer-cuda cannot establish CUDA Graph input readiness: {error}; \
+                 aborting before releasing caller-supplied allocations"
+            );
+            std::process::abort();
+        }
+        self.queue.capture_checked(bindings, record)
+    }
+}
+
+impl CommandQueue {
+    /// Captures one non-empty command sequence with fixed buffer bindings.
+    ///
+    /// Planning, allocation, tuning, and host synchronization must happen
+    /// outside `record`. The closure may enqueue only commands accepted by the
+    /// ordinary checked [`CommandScope`] lifecycle.
+    fn capture_checked<E, F>(
+        &mut self,
+        bindings: CheckedBindings,
+        record: F,
+    ) -> Result<CapturedGraph, CaptureError<E>>
+    where
+        F: FnOnce(&mut CommandScope<'_>) -> Result<(), E>,
+    {
+        let stream = self.stream().clone();
+        if stream.cu_stream().is_null() {
+            return Err(CaptureError::Graph(GraphError::DefaultStreamUnsupported));
+        }
+
+        let mut commands = self.begin(bindings).map_err(CaptureError::Command)?;
+        begin_capture(&stream).map_err(CaptureError::Graph)?;
+        let guard = CaptureGuard::new(stream);
+
+        let record_result = record(&mut commands);
+        let graph_result = guard.finish();
+
+        if let Err(error) = record_result {
+            match graph_result {
+                Ok(graph) => drop(graph),
+                Err(graph_error) => return Err(CaptureError::Graph(graph_error)),
+            }
+            return Err(CaptureError::Record(error));
+        }
+
+        let graph = graph_result.map_err(CaptureError::Graph)?;
+        if let Some(error) = commands.capture_error() {
+            drop(graph);
+            return Err(CaptureError::Command(error));
+        }
+        if commands.submitted_commands() == 0 {
+            drop(graph);
+            return Err(CaptureError::Graph(GraphError::EmptyCapture));
+        }
+
+        let CapturedCommandSet {
+            stream,
+            bindings,
+            resources,
+            submitted,
+        } = commands.finish_capture();
+        Ok(CapturedGraph {
+            graph: Some(graph),
+            stream,
+            bindings: Some(bindings),
+            resources,
+            commands: submitted,
+            not_send_sync: PhantomData,
+        })
+    }
+}
+
+/// An error produced while the caller records a graph.
+#[derive(Debug)]
+pub enum CaptureError<E> {
+    /// The checked command lifecycle rejected the scope or a submission.
+    Command(CommandError),
+    /// The caller's recording closure returned an error.
+    Record(E),
+    /// CUDA Graph capture or ownership failed.
+    Graph(GraphError),
+}
+
+impl<E: Display> Display for CaptureError<E> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Command(error) => Display::fmt(error, formatter),
+            Self::Record(error) => write!(formatter, "graph recording failed: {error}"),
+            Self::Graph(error) => Display::fmt(error, formatter),
+        }
+    }
+}
+
+impl<E: fmt::Debug + Display> Error for CaptureError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Command(error) => Some(error),
+            Self::Record(_) => None,
+            Self::Graph(error) => Some(error),
+        }
+    }
+}
+
+/// A captured CUDA graph with fixed device addresses and retained resources.
+#[must_use = "instantiate or drop the captured graph"]
+pub struct CapturedGraph {
+    graph: Option<RawGraph>,
+    stream: Arc<CudaStream>,
+    bindings: Option<CheckedBindings>,
+    resources: Vec<RetainedResource>,
+    commands: usize,
+    not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl CapturedGraph {
+    /// Returns the number of commands captured into the graph.
+    pub const fn commands(&self) -> usize {
+        self.commands
+    }
+
+    /// Instantiates one executable graph while preserving fixed bindings.
+    pub fn instantiate(mut self) -> Result<GraphExec, GraphError> {
+        let graph = self.graph.take().expect("captured graph owns a raw graph");
+        let completion_event = self
+            .stream
+            .context()
+            .new_event(None)
+            .map_err(|error| GraphError::driver("completion event creation", error))?;
+        let exec = RawGraphExec::instantiate(&graph)?;
+        Ok(GraphExec {
+            exec: Some(exec),
+            graph: Some(graph),
+            stream: self.stream.clone(),
+            completion_event,
+            bindings: self.bindings.take(),
+            resources: std::mem::take(&mut self.resources),
+            commands: self.commands,
+            launches: 0,
+            in_flight: false,
+            record_error: None,
+            poll_error: None,
+            poisoned: false,
+            not_send_sync: PhantomData,
+        })
+    }
+}
+
+impl Drop for CapturedGraph {
+    fn drop(&mut self) {
+        drop(self.graph.take());
+        self.resources.clear();
+        self.bindings.take();
+    }
+}
+
+/// One executable fixed-address graph.
+///
+/// Mutable launch access prevents concurrent replay. This first version is
+/// intentionally neither `Send` nor `Sync`.
+pub struct GraphExec {
+    exec: Option<RawGraphExec>,
+    graph: Option<RawGraph>,
+    stream: Arc<CudaStream>,
+    completion_event: CudaEvent,
+    bindings: Option<CheckedBindings>,
+    resources: Vec<RetainedResource>,
+    commands: usize,
+    launches: u64,
+    in_flight: bool,
+    record_error: Option<DriverError>,
+    poll_error: Option<DriverError>,
+    poisoned: bool,
+    not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl GraphExec {
+    /// Number of commands in every replay.
+    pub const fn commands(&self) -> usize {
+        self.commands
+    }
+
+    /// Number of graph launches accepted by the CUDA driver.
+    pub const fn launches(&self) -> u64 {
+        self.launches
+    }
+
+    /// Launches the graph on the exact stream used during capture.
+    pub fn launch(&mut self) -> Result<GraphLaunchCompletion<'_>, GraphError> {
+        if self.poisoned {
+            return Err(GraphError::ExecutionPoisoned);
+        }
+        if self.in_flight {
+            return Err(GraphError::ReplayInFlight);
+        }
+        let launch_index = self
+            .launches
+            .checked_add(1)
+            .ok_or(GraphError::LaunchCountExhausted)?;
+        let exec = self.exec.as_ref().expect("live graph exec owns a raw exec");
+        self.stream
+            .context()
+            .bind_to_thread()
+            .map_err(|error| GraphError::driver("launch context binding", error))?;
+        // Treat every raw launch attempt as possibly submitted. CUDA may
+        // report an earlier asynchronous error from this call, so resources
+        // cannot be released until stream or context quiescence is proven.
+        self.in_flight = true;
+        self.record_error = None;
+        self.poll_error = None;
+        // SAFETY: `exec` is live, belongs to the stream context, and fixed
+        // bindings plus retained resources remain owned by `self`.
+        if let Err(error) =
+            unsafe { sys::cuGraphLaunch(exec.handle, self.stream.cu_stream()).result() }
+        {
+            let failure = GraphSettlementFailure {
+                reported: error,
+                synchronize_error: synchronize_stream_or_abort(&self.stream),
+            };
+            self.in_flight = false;
+            self.poisoned = true;
+            record_graph_settlement_errors(self, failure);
+            return Err(failure.into_error("launch"));
+        }
+        self.launches = launch_index;
+        self.record_error = self.completion_event.record(&self.stream).err();
+        Ok(GraphLaunchCompletion {
+            exec: Some(self),
+            launch_index,
+            settled: false,
+        })
+    }
+
+    /// Destroys graph handles and returns the original checked bindings.
+    pub fn into_bindings(mut self) -> Result<CheckedBindings, GraphError> {
+        if let Some(failure) = self.settle_in_flight() {
+            self.poisoned = true;
+            record_graph_settlement_errors(&self, failure);
+            return Err(failure.into_error("completion"));
+        }
+        drop(self.exec.take());
+        drop(self.graph.take());
+        self.resources.clear();
+        Ok(self
+            .bindings
+            .take()
+            .expect("live graph exec owns checked bindings"))
+    }
+
+    fn settle_in_flight(&mut self) -> Option<GraphSettlementFailure> {
+        if !self.in_flight {
+            return None;
+        }
+        let failure = if let Some(error) = self.record_error {
+            Some(GraphSettlementFailure {
+                reported: error,
+                synchronize_error: synchronize_stream_or_abort(&self.stream),
+            })
+        } else if let Some(error) = self.poll_error {
+            Some(GraphSettlementFailure {
+                reported: error,
+                synchronize_error: synchronize_stream_or_abort(&self.stream),
+            })
+        } else {
+            match self.completion_event.synchronize() {
+                Ok(()) => None,
+                Err(error) => Some(GraphSettlementFailure {
+                    reported: error,
+                    synchronize_error: synchronize_stream_or_abort(&self.stream),
+                }),
+            }
+        };
+        self.in_flight = false;
+        self.record_error = None;
+        self.poll_error = None;
+        failure
+    }
+}
+
+impl Drop for GraphExec {
+    fn drop(&mut self) {
+        if let Some(failure) = self.settle_in_flight() {
+            self.poisoned = true;
+            record_graph_settlement_errors(self, failure);
+        }
+        drop(self.exec.take());
+        drop(self.graph.take());
+        self.resources.clear();
+        self.bindings.take();
+    }
+}
+
+/// Completion fence for one graph replay.
+#[must_use = "wait for or drop the graph completion before replaying again"]
+pub struct GraphLaunchCompletion<'exec> {
+    exec: Option<&'exec mut GraphExec>,
+    launch_index: u64,
+    settled: bool,
+}
+
+impl GraphLaunchCompletion<'_> {
+    /// Returns the one-based replay index covered by this completion.
+    pub const fn launch_index(&self) -> u64 {
+        self.launch_index
+    }
+
+    /// Queries completion without blocking.
+    pub fn is_complete(&mut self) -> Result<bool, GraphError> {
+        let exec = self
+            .exec
+            .as_mut()
+            .expect("live completion has a graph exec");
+        if let Some(error) = exec.record_error {
+            return Err(GraphError::driver("completion event record", error));
+        }
+        if let Some(error) = exec.poll_error {
+            return Err(GraphError::driver("completion event query", error));
+        }
+        match exec.completion_event.query() {
+            Ok(complete) => Ok(complete),
+            Err(error) => {
+                exec.poll_error = Some(error);
+                Err(GraphError::driver("completion event query", error))
+            }
+        }
+    }
+
+    /// Waits for this replay to finish.
+    pub fn wait(mut self) -> Result<(), GraphError> {
+        match self.settle() {
+            None => {
+                self.settled = true;
+                Ok(())
+            }
+            Some(failure) => {
+                self.settled = true;
+                let exec = self
+                    .exec
+                    .as_mut()
+                    .expect("live completion has a graph exec");
+                exec.poisoned = true;
+                record_graph_settlement_errors(exec, failure);
+                Err(failure.into_error("completion"))
+            }
+        }
+    }
+
+    fn settle(&mut self) -> Option<GraphSettlementFailure> {
+        let exec = self
+            .exec
+            .as_mut()
+            .expect("live completion has a graph exec");
+        exec.settle_in_flight()
+    }
+}
+
+impl Drop for GraphLaunchCompletion<'_> {
+    fn drop(&mut self) {
+        if self.settled {
+            return;
+        }
+        if let Some(failure) = self.settle() {
+            let exec = self
+                .exec
+                .as_mut()
+                .expect("live completion has a graph exec");
+            exec.poisoned = true;
+            record_graph_settlement_errors(exec, failure);
+        }
+        self.settled = true;
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GraphSettlementFailure {
+    reported: DriverError,
+    synchronize_error: Option<DriverError>,
+}
+
+impl GraphSettlementFailure {
+    const fn into_error(self, operation: &'static str) -> GraphError {
+        match self.synchronize_error {
+            Some(synchronization) => GraphError::Settlement {
+                operation,
+                source: self.reported,
+                synchronization,
+            },
+            None => GraphError::Driver {
+                operation,
+                source: self.reported,
+            },
+        }
+    }
+}
+
+fn record_graph_settlement_errors(exec: &GraphExec, failure: GraphSettlementFailure) {
+    if let Some(error) = failure.synchronize_error {
+        exec.stream.context().record_err::<()>(Err(error));
+    }
+    // cuda-oxide keeps the latest sticky error. Record the primary failure
+    // last so fallback synchronization diagnostics do not overwrite it.
+    exec.stream
+        .context()
+        .record_err::<()>(Err(failure.reported));
+}
+
+struct CaptureGuard {
+    stream: Arc<CudaStream>,
+    active: bool,
+    not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl CaptureGuard {
+    fn new(stream: Arc<CudaStream>) -> Self {
+        Self {
+            stream,
+            active: true,
+            not_send_sync: PhantomData,
+        }
+    }
+
+    fn finish(mut self) -> Result<RawGraph, GraphError> {
+        let result = end_capture(&self.stream);
+        self.active = false;
+        result
+    }
+}
+
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        match end_capture(&self.stream) {
+            Ok(graph) => drop(graph),
+            Err(GraphError::Driver { source, .. }) => {
+                self.stream.context().record_err::<()>(Err(source));
+            }
+            Err(error) => {
+                eprintln!("loom-infer-cuda failed to discard CUDA Graph capture: {error}");
+            }
+        }
+        self.active = false;
+    }
+}
+
+struct RawGraph {
+    handle: sys::CUgraph,
+    context: Arc<CudaContext>,
+}
+
+impl Drop for RawGraph {
+    fn drop(&mut self) {
+        if self.handle.is_null() {
+            return;
+        }
+        match bind_context_for_cleanup(&self.context) {
+            Ok(()) => {
+                // SAFETY: this wrapper uniquely owns the graph handle and no
+                // graph exec can outlive it in the explicit owner hierarchy.
+                if let Err(error) = unsafe { sys::cuGraphDestroy(self.handle).result() } {
+                    abort_after_graph_cleanup_failure("graph", error);
+                }
+            }
+            Err(error) => abort_after_graph_cleanup_failure("graph context binding", error),
+        }
+        self.handle = std::ptr::null_mut();
+    }
+}
+
+struct RawGraphExec {
+    handle: sys::CUgraphExec,
+    context: Arc<CudaContext>,
+}
+
+impl RawGraphExec {
+    fn instantiate(graph: &RawGraph) -> Result<Self, GraphError> {
+        graph
+            .context
+            .bind_to_thread()
+            .map_err(|error| GraphError::driver("instantiate context binding", error))?;
+        let mut handle = MaybeUninit::uninit();
+        // SAFETY: `graph` is live, flags are zero, and CUDA initializes
+        // `handle` only on success.
+        unsafe {
+            sys::cuGraphInstantiateWithFlags(handle.as_mut_ptr(), graph.handle, 0)
+                .result()
+                .map_err(|error| GraphError::driver("instantiate", error))?;
+            let handle = handle.assume_init();
+            if handle.is_null() {
+                return Err(GraphError::NullExecutableHandle);
+            }
+            Ok(Self {
+                handle,
+                context: graph.context.clone(),
+            })
+        }
+    }
+}
+
+impl Drop for RawGraphExec {
+    fn drop(&mut self) {
+        if self.handle.is_null() {
+            return;
+        }
+        match bind_context_for_cleanup(&self.context) {
+            Ok(()) => {
+                // SAFETY: this wrapper uniquely owns the executable handle.
+                if let Err(error) = unsafe { sys::cuGraphExecDestroy(self.handle).result() } {
+                    abort_after_graph_cleanup_failure("executable graph", error);
+                }
+            }
+            Err(error) => {
+                abort_after_graph_cleanup_failure("executable graph context binding", error)
+            }
+        }
+        self.handle = std::ptr::null_mut();
+    }
+}
+
+fn begin_capture(stream: &CudaStream) -> Result<(), GraphError> {
+    stream
+        .context()
+        .bind_to_thread()
+        .map_err(|error| GraphError::driver("capture context binding", error))?;
+    // SAFETY: the non-default stream is live and owned by the current context.
+    unsafe {
+        sys::cuStreamBeginCapture_v2(
+            stream.cu_stream(),
+            sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+        )
+        .result()
+        .map_err(|error| GraphError::driver("capture begin", error))
+    }
+}
+
+fn end_capture(stream: &CudaStream) -> Result<RawGraph, GraphError> {
+    if let Err(error) = bind_context_for_cleanup(stream.context()) {
+        eprintln!(
+            "loom-infer-cuda cannot bind the CUDA context to end an active graph capture: \
+             {error}; aborting to preserve buffer and stream safety"
+        );
+        std::process::abort();
+    }
+    let mut handle = MaybeUninit::uninit();
+    // SAFETY: this function is called exactly once for a successfully started
+    // capture on the same thread and stream.
+    let result =
+        unsafe { sys::cuStreamEndCapture(stream.cu_stream(), handle.as_mut_ptr()).result() };
+    match result {
+        Ok(()) => {
+            // SAFETY: CUDA initialized the output handle on success.
+            let handle = unsafe { handle.assume_init() };
+            if handle.is_null() {
+                Err(GraphError::CaptureInvalidated)
+            } else {
+                Ok(RawGraph {
+                    handle,
+                    context: stream.context().clone(),
+                })
+            }
+        }
+        Err(error) => {
+            ensure_capture_ended_or_abort(stream, error);
+            Err(GraphError::driver("capture end", error))
+        }
+    }
+}
+
+fn ensure_capture_ended_or_abort(stream: &CudaStream, end_error: DriverError) {
+    let mut status = MaybeUninit::uninit();
+    // SAFETY: `status` is valid output storage and `stream` remains live.
+    let query =
+        unsafe { sys::cuStreamIsCapturing(stream.cu_stream(), status.as_mut_ptr()).result() };
+    if query.is_ok() {
+        // SAFETY: CUDA initialized `status` on success.
+        let status = unsafe { status.assume_init() };
+        if status == sys::CUstreamCaptureStatus_enum_CU_STREAM_CAPTURE_STATUS_NONE {
+            return;
+        }
+    }
+    eprintln!(
+        "loom-infer-cuda cannot prove CUDA Graph capture ended after {end_error}; aborting to preserve buffer and stream safety"
+    );
+    std::process::abort()
+}
+
+fn abort_after_graph_cleanup_failure(resource: &str, error: DriverError) -> ! {
+    eprintln!(
+        "loom-infer-cuda failed to destroy a CUDA {resource}: {error}; aborting before releasing \
+         fixed bindings or retained resources"
+    );
+    std::process::abort()
+}
+
+#[derive(Debug, Error)]
+pub enum GraphError {
+    #[error("CUDA Graph capture requires a non-default stream")]
+    DefaultStreamUnsupported,
+    #[error("CUDA Graph capture recorded no commands")]
+    EmptyCapture,
+    #[error("CUDA Graph capture was invalidated and returned no graph")]
+    CaptureInvalidated,
+    #[error("CUDA Graph instantiation returned a null executable handle")]
+    NullExecutableHandle,
+    #[error("CUDA Graph execution is poisoned by an earlier replay failure")]
+    ExecutionPoisoned,
+    #[error("a CUDA Graph replay is already in flight")]
+    ReplayInFlight,
+    #[error("CUDA Graph launch count is exhausted")]
+    LaunchCountExhausted,
+    #[error("CUDA Graph {operation} failed: {source}")]
+    Driver {
+        operation: &'static str,
+        #[source]
+        source: DriverError,
+    },
+    #[error(
+        "CUDA Graph {operation} failed: {source}; fallback stream synchronization also reported: \
+         {synchronization}"
+    )]
+    Settlement {
+        operation: &'static str,
+        #[source]
+        source: DriverError,
+        synchronization: DriverError,
+    },
+}
+
+impl GraphError {
+    const fn driver(operation: &'static str, source: DriverError) -> Self {
+        Self::Driver { operation, source }
+    }
+}

--- a/crates/loom-infer-cuda/src/lib.rs
+++ b/crates/loom-infer-cuda/src/lib.rs
@@ -5,6 +5,10 @@
 #[cfg(feature = "cuda")]
 pub mod command;
 #[cfg(feature = "cuda")]
+mod driver;
+#[cfg(feature = "cuda")]
 pub mod gemm;
+#[cfg(feature = "cuda")]
+pub mod graph;
 #[cfg(feature = "cuda")]
 pub mod rms_norm;

--- a/crates/loom-infer-cuda/src/rms_norm.rs
+++ b/crates/loom-infer-cuda/src/rms_norm.rs
@@ -489,7 +489,7 @@ impl RmsNormF32Plan {
     /// Enqueues this prepared launch into a checked command scope.
     pub fn enqueue_into(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<f32>,
     ) -> Result<(), RmsNormEnqueueError> {
         let permit = scope.prepare_command()?;
@@ -548,7 +548,7 @@ impl RmsNormF16Plan {
     /// Enqueues this prepared launch into a checked command scope.
     pub fn enqueue_into(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<f16>,
     ) -> Result<(), RmsNormEnqueueError> {
         let permit = scope.prepare_command()?;
@@ -622,7 +622,7 @@ impl RmsNormBf16Plan {
     /// Enqueues this prepared launch into a checked command scope.
     pub fn enqueue_into(
         &self,
-        scope: &mut CommandScope<'_, '_>,
+        scope: &mut CommandScope<'_>,
         args: RmsNormArgs<bf16>,
     ) -> Result<(), RmsNormEnqueueError> {
         let permit = scope.prepare_command()?;
@@ -730,7 +730,7 @@ fn require_packed_alignment(
 }
 
 fn record_launch(
-    scope: &mut CommandScope<'_, '_>,
+    scope: &mut CommandScope<'_>,
     permit: CommandPermit,
     function: CudaFunction,
     result: Result<(), LaunchContractError>,

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ Loom Infer is a Rust-native GPU operator library for LLM inference.
 - [Architecture](design/loom-infer-architecture.md) defines ownership and the
   operator lifecycle.
 - [Operator catalog](operator-catalog.md) lists current and planned work.
+- [FlashInfer parity](flashinfer-parity.md) pins the comparison surface and
+  records every upstream operator domain.
 - [Roadmap](roadmap.md) gives the implementation order and exit gates.
 - [H20 validation](development/h20-validation.md) defines the device test
   process.

--- a/docs/design/loom-infer-architecture.md
+++ b/docs/design/loom-infer-architecture.md
@@ -52,8 +52,11 @@ contract validates buffer spans before enqueue.
 
 `CommandQueue` owns one exact caller stream, one preallocated event, and fixed
 resource-retention storage. One heterogeneous binding arena holds F32, FP16,
-BF16, and byte buffers. Typed handles preserve each element type. Opaque access
-handles cannot move between binding sets.
+BF16, and byte buffers. Read-only bindings retain `Arc<DeviceBuffer<T>>`.
+Read-write bindings own `DeviceBuffer<T>` until completion returns or destroys
+the buffer after quiescence.
+
+Typed handles preserve each element type and cannot move between binding sets.
 
 One command scope submits several plans to the same stream. CUDA stream order
 makes each output available to the next launch without a host wait.
@@ -62,6 +65,32 @@ makes each output available to the next launch without a host wait.
 functions, and external provider plans until `wait()` or destruction confirms
 completion.
 
+### Graph resources
+
+Loom implements the graph path on the host. The first fixed-address contract
+passed H20 correctness and sanitizer gates on 2026-08-03. `GraphQueue` owns a
+private non-default stream and synchronizes the context once to establish input
+readiness. It then begins thread-local capture.
+
+Capture consumes the one-shot queue. The private handle and consuming API stop
+safe caller code from injecting untracked nodes. They also prevent recapture of
+a stream retained by an earlier graph.
+
+Capture transfers fixed bindings, loaded CUDA functions, and vendor plans into
+`CapturedGraph`.
+Instantiation transfers them again into one non-`Send`, non-`Sync` `GraphExec`.
+
+Each replay takes unique mutable access to `GraphExec` and records one event
+outside the graph. `GraphExec` also stores persistent in-flight state, so a
+forgotten completion cannot permit another launch or release allocations.
+
+Leaking the graph also leaks retained `Arc` reads and owned writes. The GPU does
+not lose its resources or expose writable access while work is in flight.
+
+Drop settles any replay before it destroys graph handles, provider resources,
+and bindings. The first contract rejects rebinding, graph updates, cross-stream
+launch, and default-stream capture.
+
 ### Failure handling
 
 Contract errors are recoverable. CUDA driver failures and external provider
@@ -69,7 +98,7 @@ submission failures poison the scope and queue.
 
 Cleanup tries stream
 synchronization, then context synchronization. If neither can prove
-quiescence, the process aborts before Rust releases any borrowed GPU resource.
+quiescence, the process aborts before Rust releases any retained GPU resource.
 
 ### Enqueue admission
 

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -80,6 +80,33 @@ Record the selected algorithm's actual workspace requirement. Test a short
 workspace only when that requirement is nonzero. The current H20 selection
 requires zero workspace, so that rejection case is not applicable.
 
+## Fixed-address CUDA Graph
+
+The BF16 GEMM runner also captures this exact chain:
+
+```text
+BF16 RMSNorm (1,4096)
+  -> fixed BF16 cuBLASLt GEMM (1,4096,4096)
+```
+
+The graph gate prepares buffers on the ordinary validation stream, establishes
+input readiness, then consumes a one-shot `GraphQueue` to capture on its private
+stream. It requires two accepted replays with the same device addresses and one
+retained external completion event recorded after each replay.
+
+RMSNorm and GEMM must execute without a host wait between the two graph nodes.
+The first replay waits before the second starts. The final output must match the
+CPU oracle bit for bit.
+
+One replay must settle through `wait()` and one through completion Drop.
+Capture and replay must retain the kernel module, cuBLASLt plan, workspace, and
+all bound allocations. The runner drops its external kernel-plan and read-buffer
+owners after capture and before graph instantiation.
+
+Run Compute Sanitizer over capture, both replays, and graph destruction before
+changing the graph state from open. A successful compiler check alone is not a
+device or graph result.
+
 ### Open checks
 
 The pinned compiler fails the debug-profile `DisjointSlice` MIR check but passes
@@ -108,15 +135,20 @@ identical.
 
 The correctness runner is not a benchmark. No GEMM performance gate has passed.
 
-## Current state
+## Current device state
 
-The permanent F32, FP16, and BF16 RMSNorm providers and the fixed BF16
-cuBLASLt GEMM provider pass their declared H20 correctness gates. The maximum
-F32 RMSNorm absolute error is `4.768371582e-7`.
+The [2026-08-03 record](../results/h20-owned-bindings-cuda-graph-correctness-20260803.json)
+qualifies the current owned-binding and fixed-address Graph source projection.
+The maximum F32 RMSNorm absolute error is `4.768371582e-7`.
 
 The F32 two-command chain reaches `7.152557373e-7` maximum absolute error. The
 FP16 chain reaches two ULPs, and the BF16 chain reaches one ULP. Generated PTX
 uses scalar and packed instructions, targets `sm_90`, and assembles with CUDA
 13.1. The GEMM correctness cases are BF16 bit-exact against their declared CPU
-fixtures. Compute Sanitizer, CUDA Graph, fixed Rust-kernel argument packs, and
-performance gates remain open.
+fixtures. The fixed Graph replays twice and produces a bit-exact final output.
+
+Compute Sanitizer memcheck reports no errors or leaked device allocations for
+both runners. RMSNorm racecheck and synccheck report no errors. Graph-runner
+initcheck also reports no errors.
+
+Fixed Rust-kernel argument packs and performance gates remain open.

--- a/docs/flashinfer-parity.md
+++ b/docs/flashinfer-parity.md
@@ -1,0 +1,77 @@
+# FlashInfer parity matrix
+
+Loom Infer targets the inference-operator surface of
+[FlashInfer v0.6.16](https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.6.16),
+pinned to source commit
+[`8da13a29c85f7e5b1c81878d933f84ae9fc4afa9`](https://github.com/flashinfer-ai/flashinfer/commit/8da13a29c85f7e5b1c81878d933f84ae9fc4afa9).
+
+Release candidates, nightly builds, and rolling online documentation do not
+change this acceptance baseline. They enter an upstream watch list before the
+project deliberately advances the pin.
+
+Loom measures parity by operator contract, not file or symbol count. Each
+admitted row records shapes, dtypes, layouts, architecture, and execution
+semantics.
+
+Each row also records its oracle, H20 correctness, matched performance, CUDA
+Graph, and engine integration. A domain remains incomplete until every admitted
+contract passes its declared gates.
+
+## States
+
+| State | Meaning |
+| --- | --- |
+| `partial device correct` | A narrower Loom contract passed its declared device correctness gate |
+| `planned` | The roadmap names the domain, but no permanent provider is admitted |
+| `unscoped` | The pinned upstream surface is recorded, but Loom has not admitted a contract |
+
+No complete domain-level parity is currently claimed.
+
+## Operator domains
+
+| Domain | Representative v0.6.16 surface | Loom state |
+| --- | --- | --- |
+| Dense decode attention | [`single_decode_with_kv_cache`, `BatchDecodeWithPagedKVCacheWrapper`, `xqa`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `planned`; no attention provider |
+| Prefill and append attention | [`single_prefill_with_kv_cache`, paged and ragged batch prefill](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `planned`; no attention provider |
+| Mixed-batch attention | [`BatchAttention`, attention-sink wrapper](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `unscoped` |
+| MLA attention | [`BatchMLAPagedAttentionWrapper`, XQA and TRT-LLM MLA decode](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `unscoped` |
+| Attention state and cascade | [`merge_state`, `merge_states`, `MultiLevelCascadeAttentionWrapper`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/cascade.rst) | `planned` at state-merge level |
+| Sparse and MSA attention | [`BlockSparseAttentionWrapper`, variable block sparse, MSA](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/sparse.rst) | `unscoped` |
+| POD attention | [`PODWithPagedKVCacheWrapper`, batch POD](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/pod.rst) | `unscoped` |
+| Paged KV operations | [`append_paged_kv_cache`, MLA append, index/position generation](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/page.rst) | `planned`; none implemented |
+| Dense and quantized GEMM | [`mm_bf16`, `mm_fp8`, `mm_fp4`, `tinygemm_bf16`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/gemm.rst) | `partial device correct`; one fixed contiguous BF16 cuBLASLt plan only |
+| Grouped GEMM | [`grouped_mm_bf16`, `grouped_mm_fp8`, `grouped_mm_fp4`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/grouped_mm.rst) | `planned` through vendor providers |
+| Fused MoE | [routing and fused MoE providers](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/fused_moe.rst) | `planned`; none implemented |
+| Sampling and speculation | [logits/probability sampling and chain speculative sampling](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/sampling.rst) | `planned`; none implemented |
+| Logits processing | [`LogitsPipe`, temperature, Top-K, Top-P, Min-P, sample](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/logits_processor.rst) | `planned`; no pipeline API |
+| Standalone Top-K | [`top_k` and page-table/ragged transforms](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/topk.rst) | `planned`; none implemented |
+| Normalization | [RMSNorm, fused add RMSNorm, LayerNorm, fused QK RMSNorm/RoPE](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/norm.rst) | `partial device correct`; contiguous RMSNorm F32/FP16/BF16 only |
+| RoPE | [standard and Llama 3.1 RoPE, fused FP8 KV append](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/rope.rst) | `planned`; none implemented |
+| Activation and gated MLP tail | [`silu_and_mul`, GELU tanh/exact variants](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/activation.rst) | `unscoped` |
+| Quantization | [`packbits`, FP4, NVFP4 KV, MXFP8](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/quantization.rst) | `planned`; none implemented |
+| Communication | [AllReduce fusion, quantized AllReduce, MoE and decode A2A](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/comm.rst) | `planned` only after a measured distributed workload |
+| GDN prefill/decode | [chunk GDN](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/gdn_prefill.rst), [recurrent GDN decode](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/gdn_decode.rst) | `unscoped` |
+| KDA decode | [`recurrent_kda`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/kda_decode.rst) | `unscoped` |
+| Mamba and SSM | [`selective_state_update`, checkpointing SSU](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/mamba.rst) | `unscoped` |
+| mHC | [post and pre-fusion operators](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/mhc.rst) | `unscoped` |
+| MLA packing | [`concat_mla_k`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/concat_ops.rst) | `unscoped` |
+
+## Supporting surfaces
+
+| Surface | Representative v0.6.16 surface | Loom state |
+| --- | --- | --- |
+| cuDNN attention backend | [cuDNN batch decode and prefill](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/cudnn.rst) | `unscoped`; current vendor work is cuBLASLt GEMM only |
+| CuTe DSL backend | [CuTe DSL operators and wrappers](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/cute_dsl.rst) | Outside the custom-kernel source boundary; Loom kernels use cuda-oxide |
+| CUDA green contexts | [device green-context partitioning](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/green_ctx.rst) | `unscoped` |
+| Testing and benchmarks | [FLOP, bandwidth, GPU-time, and Graph helpers](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/testing.rst) | Infrastructure partial; reusable matched benchmarks remain open |
+
+## First attention sequence
+
+The first admitted attention contract is a BF16 SM90 single-request decode
+slice: NHD layout, head dimension 128, MHA/GQA, full window, no positional
+encoding or soft cap, F32 score/softmax accumulation, BF16 output, and F32 LSE.
+It isolates head mapping, online softmax, numerical stability, and tail handling.
+
+The next contract adds BF16 paged batch decode with head dimension 128, page
+size 16, GQA, split-K state merge, and fixed-address CUDA Graph replay. Only
+that second slice begins to cover continuous-batching serving behavior.

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -1,7 +1,8 @@
 # Operator catalog
 
 This catalog defines the target Loom Infer surface. It does not claim
-FlashInfer or FlashAttention parity.
+FlashInfer or FlashAttention parity. The [FlashInfer parity matrix](flashinfer-parity.md)
+tracks the pinned upstream comparison.
 
 ## States
 
@@ -16,12 +17,12 @@ FlashInfer or FlashAttention parity.
 
 | Operator | Provider | State | Current boundary |
 | --- | --- | --- | --- |
-| RMSNorm F32 | Rust / cuda-oxide | device correct | Four shapes, checked bindings, reusable scopes, two-command chaining, and partial-scope rejection pass on H20 |
-| RMSNorm FP16 and BF16 | Rust / cuda-oxide | device correct | Scalar and packed paths, eight shapes per dtype, three short-buffer checks, signed zero, and two-command chaining pass on H20 |
-| BF16 dense GEMM | cuBLASLt | device correct | Fixed `D=A×Wᵀ` plan, two declared shapes, exact spans, capacity rejection, reuse, and RMSNorm-to-GEMM chaining pass on H20 |
+| RMSNorm F32 | Rust / cuda-oxide | device correct | Owned bindings pass H20 correctness and sanitizer gates |
+| RMSNorm FP16 and BF16 | Rust / cuda-oxide | device correct | Scalar and packed paths pass H20 correctness and sanitizer gates |
+| BF16 dense GEMM | cuBLASLt | device correct | Fixed `D=A×Wᵀ` plan and Graph chain pass H20 correctness and sanitizer gates |
 
 No permanent GPU provider has a published performance result yet. The
-[BF16 GEMM correctness record](results/h20-bf16-cublaslt-correctness-20260802.json)
+[owned-binding and Graph record](results/h20-owned-bindings-cuda-graph-correctness-20260803.json)
 contains its accepted and excluded claims.
 
 ## Target surface

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -5,6 +5,14 @@ providers.
 
 ## Results
 
+The 2026-08-03 record qualifies the current owned-binding and fixed-address
+Graph source projection. Earlier records remain immutable historical results.
+
+- [Owned bindings and CUDA Graph H20 result](h20-owned-bindings-cuda-graph-correctness-20260803.json):
+  RMSNorm and BF16 GEMM correctness pass. The final output after two fixed-address
+  Graph replays matches the CPU fixture. Compute Sanitizer reports no errors or
+  device leaks.
+
 - [F32 RMSNorm H20 correctness](h20-rms-norm-f32-correctness-20260802.json):
   four shapes and exact buffer rejection pass on a non-default stream.
 - [F32 RMSNorm H20 command scope](h20-rms-norm-f32-command-scope-20260802.json):
@@ -26,7 +34,7 @@ providers.
 | Correctness | Declared contract, oracle, error limit, and edge cases |
 | Lifecycle | Stream order, resource retention, capacity, reuse, and completion behavior |
 | Kernel | Matched buffers, streams, provider order, and raw device timings |
-| Graph | Capture and replay behavior with fixed plans and dynamic bindings |
+| Graph | Capture and replay behavior with fixed plans and declared binding policy |
 | Engine | Real invocation, provider hit count, and model output |
 | Serving | TTFT, TPOT, throughput, memory, and workload definition |
 

--- a/docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json
+++ b/docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-03",
+  "claim_level": "graph",
+  "operator": "owned_bindings_rms_norm_bf16_gemm_cuda_graph",
+  "status": "passed",
+  "source": {
+    "git_base_revision": "304dcb077a387aebb21df56eb1534e02237ef569",
+    "branch": "agent/cuda-graph-exec",
+    "worktree": "uncommitted owned-binding and fixed-address CUDA Graph cutover",
+    "projection": "SHA-256 of the sorted per-file SHA-256 list for Cargo manifests, Cargo.lock, rust-toolchain.toml, and Rust source files",
+    "projection_sha256": "0e4e1edec712fa41dffa242c7599895f46cbb13653c2862bf80a1823057931ee",
+    "cargo_lock_sha256": "8c014680dac69c81c5d72980ff47a27e8a7755462ff5f4b301a63bbf78202460",
+    "local_remote_projection_match": true
+  },
+  "environment": {
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "compute_capability": "9.0",
+    "driver": "535.161.08",
+    "cuda": "13.1.115",
+    "cublaslt_reported_version": 130200,
+    "cublaslt_shared_object": "libcublasLt.so.13.2.0.9",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "llvm_codegen": "22.1.2-rust-1.96.0-nightly",
+    "bindgen_libclang": "21.1.8",
+    "cuda_oxide_clang_resource_dir": "20.2.0",
+    "cargo_oxide": "0.2.1",
+    "cuda_oxide_revision": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+    "compute_sanitizer": "2025.4.1.0",
+    "compute_sanitizer_package": "cuda-sanitizer-13-1_13.1.118-1_amd64.deb",
+    "compute_sanitizer_package_source": "https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-sanitizer-13-1_13.1.118-1_amd64.deb",
+    "compute_sanitizer_package_sha256": "df6ae87fce601f2ac09f19a2989cd23f5f86ada6a6c6686f4c79eee8a909dd36"
+  },
+  "ownership_contract": {
+    "read_bindings": "Arc<DeviceBuffer<T>> retains shared read allocations",
+    "write_bindings": "DeviceBuffer<T> ownership remains in CheckedBindings until completion",
+    "graph_queue": "one-shot queue with one private non-default stream",
+    "capture": "one context synchronization establishes input readiness before thread-local capture",
+    "fixed_addresses": true,
+    "completion": "one retained external CUDA event recorded once per replay",
+    "destruction_order": [
+      "executable graph",
+      "source graph",
+      "kernel and vendor plan resources",
+      "checked bindings"
+    ],
+    "leaked_owner_behavior": "forgetting a scope, completion, or graph leaks owned resources instead of exposing writable or freed device memory",
+    "excluded_operations": [
+      "rebinding",
+      "graph node updates",
+      "cross-stream launch",
+      "concurrent replay",
+      "default-stream capture"
+    ]
+  },
+  "correctness": {
+    "rms_norm": {
+      "f32_single_launch_max_abs_error": 4.768371582e-7,
+      "f32_chain_max_abs_error": 7.152557373e-7,
+      "f16_single_launch_max_abs_error": 0.001953125,
+      "f16_chain_max_abs_error": 0.00390625,
+      "f16_chain_max_ulp_error": 2,
+      "bf16_single_launch_max_abs_error": 0.0,
+      "bf16_chain_max_abs_error": 0.000244140625,
+      "bf16_chain_max_ulp_error": 1,
+      "short_buffers_rejected": true,
+      "partial_scope_drop_guard": "passed"
+    },
+    "bf16_gemm": {
+      "standalone_bit_mismatches": 0,
+      "transpose_sensitive_bit_mismatches": 0,
+      "rms_norm_gemm_chain_bit_mismatches": 0,
+      "output_digest": "9c7c07b655452325",
+      "short_buffers_rejected": true,
+      "command_capacity_rejected_before_ffi": true
+    },
+    "cuda_graph": {
+      "chain": "BF16 RMSNorm (1,4096) to BF16 cuBLASLt GEMM (1,4096,4096)",
+      "commands": 2,
+      "replays": 2,
+      "fixed_bindings": true,
+      "cross_stream": false,
+      "external_kernel_plan_and_read_buffer_owners_dropped_before_replay": true,
+      "completion_queries": 2,
+      "completion_waits": 1,
+      "completion_drops": 1,
+      "intra_graph_host_waits": 0,
+      "inter_replay_host_waits": 1,
+      "final_bit_mismatches": 0,
+      "final_max_abs_error": 0.0,
+      "final_output_digest": "9c7c07b655452325"
+    },
+    "release_tests": {
+      "loom_infer": 9,
+      "loom_infer_cuda": 3,
+      "failed": 0
+    }
+  },
+  "compute_sanitizer": {
+    "bf16_gemm_graph_memcheck": {
+      "errors": 0,
+      "leaked_bytes": 0,
+      "leaked_allocations": 0
+    },
+    "rms_norm_memcheck": {
+      "errors": 0,
+      "leaked_bytes": 0,
+      "leaked_allocations": 0
+    },
+    "rms_norm_racecheck": {
+      "errors": 0,
+      "warnings": 0,
+      "hazards_displayed": 0
+    },
+    "rms_norm_synccheck_errors": 0,
+    "bf16_gemm_graph_initcheck_errors": 0
+  },
+  "device_artifact": {
+    "ptx_target": "sm_90",
+    "ptx_sha256": "226ae04f984b41c2f0b62df50d27d8230fafd08c34715a5fb8190e8d542aaf4d",
+    "cubin_sha256": "58c9db95e789564c7b4127d40494425ffae13020f5e230f68457577e6f88a652",
+    "cubin_size_bytes": 57104,
+    "ptxas": "passed with CUDA 13.1 and -arch=sm_90"
+  },
+  "commands": [
+    "cargo oxide doctor",
+    "cargo clippy --workspace --all-targets --features cuda -- -D warnings",
+    "cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90",
+    "cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90",
+    "cargo oxide test --arch sm_90 -- --workspace --features cuda --release",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/bf16_gemm_h20",
+    "compute-sanitizer --tool racecheck --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool synccheck --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool initcheck --error-exitcode 99 target/release/bf16_gemm_h20",
+    "ptxas -arch=sm_90 loom_infer_cuda.ptx -o owned_graph_sm90_20260803.cubin"
+  ],
+  "accepted_claims": [
+    "the owned-binding lifecycle passes the declared RMSNorm and BF16 GEMM H20 correctness cases",
+    "one fixed graph captures BF16 RMSNorm and BF16 cuBLASLt GEMM on a private non-default stream",
+    "each fixed-address replay executes RMSNorm and GEMM without a host wait between the two graph nodes",
+    "the first replay waits for completion before the second replay starts",
+    "the graph replays after the runner drops its external kernel-plan and read-buffer owners",
+    "the final output after two deterministic replays matches the CPU fixture bit for bit",
+    "one replay settles through wait and one replay settles through completion Drop",
+    "memcheck reports zero errors and zero leaked device allocations for both H20 runners",
+    "racecheck and synccheck report zero RMSNorm errors, and initcheck reports zero graph-runner errors",
+    "the current PTX targets sm_90 and assembles with CUDA 13.1 ptxas"
+  ],
+  "excluded_claims": [
+    "an independent output snapshot after each graph replay",
+    "rebinding, graph node updates, cross-stream launch, concurrent replay, or default-stream capture",
+    "fault-injected CUDA driver, event, stream, context, graph, or cuBLASLt failures",
+    "allocation-free Rust-kernel enqueue before capture",
+    "CUDA Graph or operator performance",
+    "comparison with a named provider baseline",
+    "attention correctness or performance",
+    "engine integration",
+    "serving performance"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,37 +10,64 @@ attention-kernel comparison surface.
 
 - keep the H20-qualified F32 path in `loom-infer-cuda`.
 - support F32, FP16, and BF16 with scalar and packed paths.
-- bind caller-owned memory and non-default streams.
+- bind caller-supplied memory and non-default streams.
+- share read-only inputs through `Arc` and transfer writable buffers until
+  completion.
 - keep one stream-ordered command scope for Rust and vendor providers.
 - replace generated argument vectors with reusable fixed argument packs.
 - pass correctness, CUDA Graph, sanitizer, and matched H20 performance gates.
 
-F32, FP16, and BF16 correctness gates pass across scalar, packed, exact-length,
-non-default-stream, and chained cases. Typed heterogeneous bindings hold mixed
-tensor and workspace types in one scope. Fixed argument packs, CUDA Graph,
-sanitizer, and matched performance gates remain open.
+The current owned-binding revision passes F32, FP16, and BF16 correctness across
+scalar, packed, exact-length, non-default-stream, and chained cases. Memcheck,
+racecheck, and synccheck report no errors. Fixed argument packs and matched
+performance gates remain open.
 
 Exit: all three dtypes use the common operator lifecycle and have reproducible
 H20 correctness and performance records.
 
 ## 2. First vendor GEMM provider
 
-**State:** active. Device correctness passed.
+**State:** active. The owned-binding and Graph revision passed its H20
+correctness and sanitizer gates.
 
 - define contiguous BF16 `D[M,N] = A[M,K] * W[N,K]^T` with F32 accumulation.
 - plan one explicit cuBLASLt algorithm before enqueue.
-- require caller-owned output and workspace with checked alignment and spans.
+- take caller-supplied output and workspace into checked ownership with validated
+  alignment and spans, then return them after completion.
 - run GEMM through the same command scope without tuning or fallback.
 - verify real model shapes before any performance or default-provider claim.
 
 Exit: a fixed BF16 GEMM plan passes correctness, graph, and matched-provider
 gates without a tensor copy.
 
-The fixed BF16 cuBLASLt plan passes its H20 correctness and command-lifecycle
-gates. CUDA Graph, matched-provider performance, real-model shapes, and engine
-invocation remain open.
+The fixed BF16 cuBLASLt plan passes H20 correctness and command-lifecycle gates.
+Its RMSNorm-to-GEMM Graph replays twice with a bit-exact final output.
+Matched-provider performance, real-model shapes, and engine invocation remain
+open.
 
-## 3. Attention core
+## 3. Fixed-address CUDA Graph execution
+
+**State:** complete for the first fixed-address contract.
+
+- consume a one-shot `GraphQueue` to capture one checked command scope on its
+  private non-default stream.
+- retain fixed buffer ownership, CUDA functions, and vendor plans across replay.
+- instantiate and launch through owned `CapturedGraph` and `GraphExec` values.
+- retain one external completion event and record it once per replay.
+- reject rebinding, node updates, cross-stream launch, and concurrent replay in
+  the first contract.
+- validate RMSNorm to BF16 GEMM capture, replay, cleanup, and sanitizer paths.
+
+Result: the final output after two fixed-address replays matches the CPU oracle.
+The runner drops its external resource owners before replay.
+
+The Loom replay path has no planning or explicit allocation. Compute Sanitizer
+reports no errors or device leaks on H20. See the
+[machine-readable record](results/h20-owned-bindings-cuda-graph-correctness-20260803.json).
+
+## 4. Attention core
+
+**State:** next.
 
 - implement ragged prefill and paged MQA/GQA decode.
 - add split-K execution and stable state merge.
@@ -51,7 +78,7 @@ invocation remain open.
 Exit: a real model invokes Loom attention without tensor copies and preserves
 tokens or declared numerical quality.
 
-## 4. Decode and KV operations
+## 5. Decode and KV operations
 
 - add logits processing, penalties, filtering, logprobs, and deterministic
   sampling.
@@ -62,7 +89,7 @@ tokens or declared numerical quality.
 Exit: decode-tail and KV operations use the same lifecycle and show value in a
 real engine workload.
 
-## 5. Quantization, MoE, and matrix work
+## 6. Quantization, MoE, and matrix work
 
 - add scale, pack, unpack, dequantize, and layout conversion.
 - add expert routing support, permutation, and weighted combine.
@@ -72,7 +99,7 @@ real engine workload.
 Exit: dense and MoE workloads record separate operator, engine, and serving
 results.
 
-## 6. Integration and hardware coverage
+## 7. Integration and hardware coverage
 
 - expose a stable Rust API after the first provider passes admission.
 - add a checked C ABI only when an external engine requires it.

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -10,7 +10,7 @@ export const operatorFamilies = [
   {
     name: "Normalization",
     boundary: "RMSNorm, residual fusion, and quantized output.",
-    state: "Device-correct",
+    state: "Device correct",
   },
   {
     name: "Attention",
@@ -35,7 +35,7 @@ export const operatorFamilies = [
   {
     name: "Matrix work",
     boundary: "Fixed Rust plans for qualified vendor GEMM providers.",
-    state: "Device-correct",
+    state: "Device correct",
   },
 ]
 
@@ -43,12 +43,12 @@ export const milestones = [
   {
     milestone: "01",
     name: "Permanent RMSNorm",
-    reason: "F32, FP16, and BF16 correctness passes. Fixed argument packs and later gates remain open.",
+    reason: "Owned bindings pass H20 correctness and sanitizer gates. Performance remains open.",
   },
   {
     milestone: "02",
     name: "Vendor GEMM",
-    reason: "The fixed BF16 cuBLASLt plan passes correctness. Graph, baseline, and engine gates remain open.",
+    reason: "The fixed plan and Graph chain pass H20 gates. Baseline and engine gates remain open.",
   },
   {
     milestone: "03",

--- a/website/src/pages/docs/operators.astro
+++ b/website/src/pages/docs/operators.astro
@@ -12,7 +12,7 @@ import { milestones, operatorFamilies, repositoryUrl } from "../../data/site";
   <header class="page-hero">
     <p class="eyebrow">Operators</p>
     <h1>One lifecycle for every operator.</h1>
-    <p>Current H20 providers cover Rust RMSNorm and one fixed BF16 cuBLASLt GEMM plan.</p>
+    <p>The current H20 record covers Rust RMSNorm, one fixed BF16 cuBLASLt plan, and their fixed-address Graph chain.</p>
   </header>
 
   <div class="docs-layout">

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -18,9 +18,27 @@ import { repositoryUrl } from "../data/site";
   <div class="docs-layout">
     <DocsNav active="Evidence" />
     <article class="prose">
-      <h2>Current state</h2>
+      <h2>Current source projection</h2>
+      <p>
+        The 2026-08-03 record qualifies the owned-binding and fixed-address
+        CUDA Graph source projection.
+      </p>
       <div class="doc-note">
-        <strong>F32 RMSNorm passes its H20 correctness gate.</strong>
+        <strong>Owned bindings and fixed-address Graph replay passed on H20.</strong>
+        <p>
+          The graph captures BF16 RMSNorm and one fixed BF16 cuBLASLt GEMM.
+          It replays twice and produces a bit-exact final output. Compute
+          Sanitizer reports no errors or device leaks. Performance is not
+          measured.
+        </p>
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json`}>
+          Current machine-readable result
+        </a>
+      </div>
+
+      <h2>Earlier operator records</h2>
+      <div class="doc-note">
+        <strong>F32 RMSNorm passed its recorded H20 correctness gate.</strong>
         <p>
           Four shapes match the CPU reference, and an invalid buffer is
           rejected. Checked bindings chain two commands on a non-default
@@ -32,7 +50,7 @@ import { repositoryUrl } from "../data/site";
         </a>
       </div>
       <div class="doc-note">
-        <strong>FP16 and BF16 RMSNorm pass their H20 correctness gates.</strong>
+        <strong>FP16 and BF16 RMSNorm passed their recorded H20 correctness gates.</strong>
         <p>
           Scalar and packed paths match the storage-rounded CPU references.
           Three short-buffer positions are rejected. Two launches share one
@@ -45,7 +63,7 @@ import { repositoryUrl } from "../data/site";
         </a>
       </div>
       <div class="doc-note">
-        <strong>One fixed BF16 cuBLASLt GEMM plan passes its H20 correctness gate.</strong>
+        <strong>One fixed BF16 cuBLASLt GEMM plan passed its recorded H20 gate.</strong>
         <p>
           Standalone and transpose-sensitive cases match the CPU reference.
           Short A, W, and D buffers are rejected. BF16 RMSNorm feeds GEMM under

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -41,7 +41,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   </section>
 
   <section class="metrics-strip" aria-label="Project status">
-    <div class="metric"><strong>2</strong><span>device-correct slices</span></div>
+    <div class="metric"><strong>2</strong><span>qualified device slices</span></div>
     <div class="metric"><strong>SM90</strong><span>first target</span></div>
     <div class="metric"><strong>Rust</strong><span>host and device source</span></div>
     <div class="metric"><strong>Pending</strong><span>performance evidence</span></div>
@@ -77,7 +77,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       </div>
       <p>
         CPU references define behavior. Plans fix algorithms and launch
-        configurations. Command scopes retain borrowed resources.
+        configurations. Bindings share reads and own writable buffers.
       </p>
     </header>
     <div class="architecture-grid">
@@ -106,21 +106,21 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       <p>Every claim identifies its source, hardware, boundary, and artifact.</p>
     </header>
     <article class="evidence-card">
-      <h3>RMSNorm on H20</h3><span class="result">Correct</span>
-      <p>F32, FP16, and BF16 pass their declared correctness gates.</p>
-      <small>Scalar and packed low-precision paths pass. Performance is not measured.</small>
+      <h3>RMSNorm on H20</h3><span class="result">Qualified</span>
+      <p>The owned-binding F32, FP16, and BF16 paths pass correctness.</p>
+      <small>Memcheck, racecheck, and synccheck report no errors.</small>
     </article>
     <article class="evidence-card">
-      <h3>BF16 cuBLASLt GEMM on H20</h3><span class="result">Correct</span>
-      <p>Fixed-plan standalone, transpose-sensitive, and RMSNorm-to-GEMM cases pass.</p>
-      <small>Command lifecycle and rejection gates pass. Performance is not measured.</small>
+      <h3>BF16 cuBLASLt GEMM on H20</h3><span class="result">Qualified</span>
+      <p>The fixed plan and RMSNorm-to-GEMM Graph pass correctness.</p>
+      <small>The final output after two replays is bit-exact. Memcheck reports no errors or leaks.</small>
     </article>
   </section>
 
   <section class="section">
     <header class="section-header">
-      <div><p class="eyebrow">Next</p><h2>Qualify the current providers</h2></div>
-      <p>Add graph and matched performance evidence, then enter the attention core.</p>
+      <div><p class="eyebrow">Next</p><h2>Build the attention core</h2></div>
+      <p>Use the qualified lifecycle for single decode, then add paged batch decode.</p>
     </header>
     <div class="roadmap-grid">
       {milestones.map((item) => (


### PR DESCRIPTION
Adds a fixed-address `GraphQueue` → `CapturedGraph` → `GraphExec` lifecycle. It retains buffers, Rust kernel modules, and cuBLASLt plans through replay completion.

Validated on H20 with two RMSNorm-to-BF16-GEMM replays, bit-exact final output, PTX assembly, and Compute Sanitizer. This PR makes no performance, engine, or serving claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixed-address CUDA Graph capture, replay, completion tracking, and resource management.
  * Added Graph replay coverage for RMSNorm followed by BF16 GEMM, including repeated execution and output validation.
  * Improved buffer ownership and output retrieval for CUDA command bindings.

* **Bug Fixes**
  * Improved cleanup and error handling for failed bindings, submissions, synchronization, and resource release.

* **Documentation**
  * Updated H20 validation, roadmap, architecture, operator status, and evidence documentation.
  * Added FlashInfer parity documentation and recorded successful correctness and sanitizer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->