### PR TITLE
feat(attention): add BF16 single-decode baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   workspace, context, and caller-owned stream.
 - Added H20 correctness coverage for standalone GEMM, row-major transpose,
   capacity and buffer rejection, plan reuse, and an RMSNorm-to-GEMM chain.
+- Added a BF16 NHD D128 single-decode contract, CPU reference, and Rust CUDA
+  provider for MHA, MQA, and GQA.
+- Added H20 attention correctness, exact-span rejection, duplicate-binding checks,
+  Compute Sanitizer, and SM90 artifact evidence.
 
 ### Changed
 
@@ -17,6 +21,7 @@
 - Renamed launch-specific command capacity APIs to provider-neutral command
   terminology.
 - Separated external provider submission errors from CUDA driver errors.
+- Added checked three-read, two-write resolution to the shared binding path.
 
 ## 1.0.0-alpha.1
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ The current device paths are:
 | --- | --- | --- |
 | Contiguous RMSNorm F32, FP16, BF16 | Rust device kernels compiled with cuda-oxide | Owned-binding revision device-correct and sanitizer-clean |
 | Contiguous BF16 GEMM with F32 accumulation | One fixed cuBLASLt algorithm | Device-correct with fixed-address Graph replay and sanitizer coverage |
+| BF16 single-request decode attention | Rust device kernel compiled with cuda-oxide | Narrow NHD D128 contract device-correct and sanitizer-clean |
 
-Both use the same public flow:
+All providers use the same public flow:
 
 ```text
 validated spec
@@ -55,10 +56,12 @@ The GEMM contract is `D[M,N] = A[M,K] * W[N,K]^T` over contiguous row-major
 BF16 tensors. Algorithm selection happens during planning. Enqueue does not
 tune or fall back.
 
-Attention, sampling, KV-cache, MoE, quantization, and performance qualification
-remain roadmap work. The fixed-address Graph path passed its declared H20
-correctness and sanitizer gates. See the
-[2026-08-03 result](docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json).
+Paged attention, sampling, KV-cache, MoE, quantization, and performance
+qualification remain roadmap work.
+
+The first single-decode slice covers BF16 MHA, MQA, and GQA with NHD caches and
+head dimension 128. It does not establish FlashInfer performance parity. See the
+[single-decode result](docs/results/h20-bf16-single-decode-correctness-20260803.json).
 
 ### Execution
 
@@ -97,6 +100,7 @@ cd crates/loom-infer-cuda
 cargo oxide doctor
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
 cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
+cargo oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch sm_90
 cargo oxide test --arch sm_90 -- --workspace --features cuda --release
 ```
 
@@ -109,12 +113,13 @@ Operator correctness, kernel latency, graph execution, engine integration, and
 serving performance are separate claims. A microbenchmark does not establish
 an engine or serving speedup.
 
-The current Graph record covers correctness and Compute Sanitizer results. It
-makes no performance, engine, or serving claim.
+The current attention and shared-command regression records cover correctness,
+Graph replay, and Compute Sanitizer results. They make no performance, engine,
+or serving claim.
 
 See the [architecture](docs/design/loom-infer-architecture.md),
 [operator catalog](docs/operator-catalog.md), [roadmap](docs/roadmap.md), and
-[owned-binding Graph result](docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json).
+[evidence index](docs/results/README.md).
 
 ## License
 

--- a/crates/loom-infer-cuda/Cargo.toml
+++ b/crates/loom-infer-cuda/Cargo.toml
@@ -31,3 +31,8 @@ required-features = ["cuda"]
 name = "bf16_gemm_h20"
 path = "src/bin/bf16_gemm_h20.rs"
 required-features = ["cuda"]
+
+[[bin]]
+name = "single_decode_h20"
+path = "src/bin/single_decode_h20.rs"
+required-features = ["cuda"]

--- a/crates/loom-infer-cuda/README.md
+++ b/crates/loom-infer-cuda/README.md
@@ -11,14 +11,16 @@ Enable `cuda` only inside the pinned CUDA build environment.
 ```bash
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
 cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
+cargo oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch sm_90
 ```
 
 ## Current providers
 
-The Rust provider implements contiguous F32, FP16, and BF16 RMSNorm. The first
-vendor provider freezes one contiguous BF16 cuBLASLt GEMM algorithm during
-planning. Both use typed heterogeneous bindings and one completion event.
+The Rust providers implement contiguous RMSNorm and BF16 single-request decode
+attention. The vendor provider freezes one contiguous BF16 cuBLASLt GEMM
+algorithm during planning. All use typed bindings and one completion event.
 
 The current owned-binding revision passed its H20 correctness gates. The fixed
-RMSNorm-to-GEMM Graph also passed replay and Compute Sanitizer gates. Fixed
-Rust-kernel argument packs and performance gates remain open.
+RMSNorm-to-GEMM Graph also passed replay and Compute Sanitizer gates. The
+single-decode attention slice passed its H20 correctness and sanitizer gates.
+Fixed Rust-kernel argument packs and performance gates remain open.

--- a/crates/loom-infer-cuda/src/attention.rs
+++ b/crates/loom-infer-cuda/src/attention.rs
@@ -1,0 +1,366 @@
+//! cuda-oxide provider for BF16 single-request decode attention.
+
+use crate::command::{CommandError, CommandPermit, CommandScope, Read, Write};
+use cuda_core::{CudaContext, CudaFunction, LaunchConfig1D, LaunchContractError, PreparedLaunch};
+use cuda_device::{
+    DisjointSlice, convert, cuda_module, float, kernel, launch_bounds, launch_contract, tcgen05,
+    thread, warp,
+};
+use half::bf16;
+use loom_infer::{Bf16SingleDecodeSpec, SINGLE_DECODE_HEAD_DIM};
+use std::mem::size_of;
+use std::sync::Arc;
+use thiserror::Error;
+
+const WARP_THREADS: u32 = 32;
+const BF16_PAIRS_PER_HEAD: usize = SINGLE_DECODE_HEAD_DIM / 2;
+const BF16_PAIRS_PER_LANE: usize = BF16_PAIRS_PER_HEAD / WARP_THREADS as usize;
+
+const _: () = {
+    assert!(SINGLE_DECODE_HEAD_DIM == 128);
+    assert!(BF16_PAIRS_PER_LANE == 2);
+    assert!(core::mem::size_of::<bf16>() == core::mem::size_of::<u16>());
+    assert!(core::mem::align_of::<bf16>() == core::mem::align_of::<u16>());
+};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_bounds(32)]
+    #[allow(clippy::too_many_arguments)]
+    #[launch_contract(
+        domain = 1,
+        block = (32, 1, 1),
+        min_compute_capability = (9, 0),
+        requires = (
+            kv_len >= 1,
+            num_query_heads >= 1,
+            num_kv_heads >= 1,
+            query.len() == num_query_heads * 128,
+            key.len() == kv_len * num_kv_heads * 128,
+            value.len() == kv_len * num_kv_heads * 128,
+            output.len() == num_query_heads * 128,
+            lse.len() == num_query_heads,
+        ),
+    )]
+    pub fn single_decode_bf16_nhd(
+        kv_len: usize,
+        num_query_heads: usize,
+        num_kv_heads: usize,
+        softmax_scale_log2: f32,
+        query: &[bf16],
+        key: &[bf16],
+        value: &[bf16],
+        mut output: DisjointSlice<bf16>,
+        mut lse: DisjointSlice<f32>,
+    ) {
+        let query_head = thread::blockIdx_x() as usize;
+        let lane = thread::threadIdx_x() as usize;
+        if query_head >= num_query_heads || lane >= WARP_THREADS as usize {
+            return;
+        }
+
+        let group_size = num_query_heads / num_kv_heads;
+        let kv_head = query_head / group_size;
+        let query_pairs = query.as_ptr().cast::<u32>();
+        let key_pairs = key.as_ptr().cast::<u32>();
+        let value_pairs = value.as_ptr().cast::<u32>();
+        let output_pairs = output.as_mut_ptr().cast::<u32>();
+        let first_pair = query_head * BF16_PAIRS_PER_HEAD + lane;
+        let second_pair = first_pair + WARP_THREADS as usize;
+
+        // SAFETY: the host plan validates four-byte alignment. The launch
+        // contract proves both packed query reads are inside the exact span.
+        let (query_0, query_1, query_2, query_3) = unsafe {
+            let (query_0, query_1) = convert::cvt_f32x2_bf16x2(query_pairs.add(first_pair).read());
+            let (query_2, query_3) = convert::cvt_f32x2_bf16x2(query_pairs.add(second_pair).read());
+            (query_0, query_1, query_2, query_3)
+        };
+
+        let mut output_0 = 0.0_f32;
+        let mut output_1 = 0.0_f32;
+        let mut output_2 = 0.0_f32;
+        let mut output_3 = 0.0_f32;
+        let mut max_score_log2 = 0.0_f32;
+        let mut normalizer = 0.0_f32;
+        let mut token = 0_usize;
+
+        while token < kv_len {
+            let kv_pair_offset = (token * num_kv_heads + kv_head) * BF16_PAIRS_PER_HEAD + lane;
+            // SAFETY: packed NHD offsets cover two disjoint pairs per lane.
+            // Exact spans and four-byte base alignment were checked on host.
+            let (key_0, key_1, key_2, key_3, value_0, value_1, value_2, value_3) = unsafe {
+                let (key_0, key_1) =
+                    convert::cvt_f32x2_bf16x2(key_pairs.add(kv_pair_offset).read());
+                let (key_2, key_3) = convert::cvt_f32x2_bf16x2(
+                    key_pairs.add(kv_pair_offset + WARP_THREADS as usize).read(),
+                );
+                let (value_0, value_1) =
+                    convert::cvt_f32x2_bf16x2(value_pairs.add(kv_pair_offset).read());
+                let (value_2, value_3) = convert::cvt_f32x2_bf16x2(
+                    value_pairs
+                        .add(kv_pair_offset + WARP_THREADS as usize)
+                        .read(),
+                );
+                (
+                    key_0, key_1, key_2, key_3, value_0, value_1, value_2, value_3,
+                )
+            };
+
+            let mut dot = 0.0_f32;
+            dot = float::fma_rn_f32(query_0, key_0, dot);
+            dot = float::fma_rn_f32(query_1, key_1, dot);
+            dot = float::fma_rn_f32(query_2, key_2, dot);
+            dot = float::fma_rn_f32(query_3, key_3, dot);
+            let score_log2 = warp::reduce_sum_f32(dot) * softmax_scale_log2;
+
+            let mut previous_weight = 0.0_f32;
+            let mut current_weight = 0.0_f32;
+            if lane == 0 {
+                if token == 0 {
+                    max_score_log2 = score_log2;
+                    normalizer = 1.0;
+                    current_weight = 1.0;
+                } else {
+                    let next_max = f32::max(max_score_log2, score_log2);
+                    previous_weight = float::ex2_approx_f32(max_score_log2 - next_max);
+                    current_weight = float::ex2_approx_f32(score_log2 - next_max);
+                    normalizer = normalizer * previous_weight + current_weight;
+                    max_score_log2 = next_max;
+                }
+            }
+            previous_weight = warp::shuffle_f32(previous_weight, 0);
+            current_weight = warp::shuffle_f32(current_weight, 0);
+
+            output_0 = float::fma_rn_f32(value_0, current_weight, output_0 * previous_weight);
+            output_1 = float::fma_rn_f32(value_1, current_weight, output_1 * previous_weight);
+            output_2 = float::fma_rn_f32(value_2, current_weight, output_2 * previous_weight);
+            output_3 = float::fma_rn_f32(value_3, current_weight, output_3 * previous_weight);
+            token += 1;
+        }
+
+        let mut inverse_normalizer = 0.0_f32;
+        if lane == 0 {
+            inverse_normalizer = float::div_rn_f32(1.0, normalizer);
+            // SAFETY: only lane zero writes this query-head slot.
+            unsafe {
+                *lse.get_unchecked_mut(query_head) =
+                    max_score_log2 + float::lg2_approx_f32(normalizer);
+            }
+        }
+        inverse_normalizer = warp::shuffle_f32(inverse_normalizer, 0);
+
+        // SAFETY: each lane owns two packed output pairs. The output base is
+        // four-byte aligned and the launch contract proves the exact span.
+        unsafe {
+            output_pairs
+                .add(first_pair)
+                .write(tcgen05::cvt_f32x2_bf16x2(
+                    output_0 * inverse_normalizer,
+                    output_1 * inverse_normalizer,
+                ));
+            output_pairs
+                .add(second_pair)
+                .write(tcgen05::cvt_f32x2_bf16x2(
+                    output_2 * inverse_normalizer,
+                    output_3 * inverse_normalizer,
+                ));
+        }
+    }
+}
+
+/// Loaded cuda-oxide module for attention kernels.
+#[derive(Clone, Debug)]
+pub struct AttentionProvider {
+    module: kernels::LoadedModule,
+}
+
+impl AttentionProvider {
+    /// Loads the embedded attention artifact into one CUDA context.
+    pub fn load(context: &Arc<CudaContext>) -> Result<Self, cuda_host::EmbeddedModuleError> {
+        // SAFETY: this crate owns the package-named device bundle and the
+        // inline module defines the admitted attention entry point.
+        let module = unsafe { kernels::load(context)? };
+        Ok(Self { module })
+    }
+
+    /// Creates one immutable BF16 NHD single-decode launch plan.
+    pub fn plan_bf16(
+        &self,
+        spec: Bf16SingleDecodeSpec,
+    ) -> Result<Bf16SingleDecodePlan, SingleDecodePlanError> {
+        let query_heads = u32::try_from(spec.num_query_heads())
+            .map_err(|_| SingleDecodePlanError::QueryHeadCountOutOfRange(spec.num_query_heads()))?;
+        let launch = self
+            .module
+            .prepare_single_decode_bf16_nhd(LaunchConfig1D::new(query_heads, WARP_THREADS, 0))?;
+        Ok(Bf16SingleDecodePlan {
+            spec,
+            module: self.module.clone(),
+            launch,
+        })
+    }
+}
+
+/// Immutable launch plan for the first single-decode contract.
+#[derive(Clone)]
+pub struct Bf16SingleDecodePlan {
+    spec: Bf16SingleDecodeSpec,
+    module: kernels::LoadedModule,
+    launch: PreparedLaunch<kernels::__single_decode_bf16_nhd_CudaKernel>,
+}
+
+impl Bf16SingleDecodePlan {
+    pub const fn spec(&self) -> Bf16SingleDecodeSpec {
+        self.spec
+    }
+
+    /// Enqueues the fixed plan into a checked command scope.
+    pub fn enqueue_into(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: Bf16SingleDecodeArgs,
+    ) -> Result<(), SingleDecodeEnqueueError> {
+        let permit = scope.prepare_command()?;
+        let (function, launch_result) = {
+            let resolved =
+                scope.resolve_rrrww(args.query, args.key, args.value, args.output, args.lse)?;
+            for (operand, address) in [
+                ("Q", resolved.first.cu_deviceptr()),
+                ("K", resolved.second.cu_deviceptr()),
+                ("V", resolved.third.cu_deviceptr()),
+                ("O", resolved.fourth.cu_deviceptr()),
+            ] {
+                require_packed_alignment(operand, address)?;
+            }
+            let result = self.module.single_decode_bf16_nhd(
+                resolved.stream,
+                &self.launch,
+                self.spec.kv_len(),
+                self.spec.num_query_heads(),
+                self.spec.num_kv_heads(),
+                self.spec.softmax_scale() * core::f32::consts::LOG2_E,
+                resolved.first,
+                resolved.second,
+                resolved.third,
+                resolved.fourth,
+                resolved.fifth,
+            );
+            (self.launch.function().clone(), result)
+        };
+        record_launch(scope, permit, function, launch_result)
+    }
+}
+
+/// Checked handles for one single-decode launch.
+#[derive(Clone, Copy, Debug)]
+pub struct Bf16SingleDecodeArgs {
+    query: Read<bf16>,
+    key: Read<bf16>,
+    value: Read<bf16>,
+    output: Write<bf16>,
+    lse: Write<f32>,
+}
+
+impl Bf16SingleDecodeArgs {
+    pub const fn new(
+        query: Read<bf16>,
+        key: Read<bf16>,
+        value: Read<bf16>,
+        output: Write<bf16>,
+        lse: Write<f32>,
+    ) -> Self {
+        Self {
+            query,
+            key,
+            value,
+            output,
+            lse,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SingleDecodePlanError {
+    #[error("single-decode query-head count {0} exceeds the CUDA grid range")]
+    QueryHeadCountOutOfRange(usize),
+    #[error(transparent)]
+    Launch(#[from] LaunchContractError),
+}
+
+#[derive(Debug, Error)]
+pub enum SingleDecodeEnqueueError {
+    #[error(transparent)]
+    Command(#[from] CommandError),
+    #[error(transparent)]
+    Launch(#[from] LaunchContractError),
+    #[error(
+        "packed single decode requires {operand} to be {alignment}-byte aligned, got {address:#x}"
+    )]
+    MisalignedBuffer {
+        operand: &'static str,
+        address: u64,
+        alignment: u64,
+    },
+}
+
+fn require_packed_alignment(
+    operand: &'static str,
+    address: u64,
+) -> Result<(), SingleDecodeEnqueueError> {
+    const ALIGNMENT: u64 = size_of::<u32>() as u64;
+    if address.is_multiple_of(ALIGNMENT) {
+        Ok(())
+    } else {
+        Err(SingleDecodeEnqueueError::MisalignedBuffer {
+            operand,
+            address,
+            alignment: ALIGNMENT,
+        })
+    }
+}
+
+fn record_launch(
+    scope: &mut CommandScope<'_>,
+    permit: CommandPermit,
+    function: CudaFunction,
+    result: Result<(), LaunchContractError>,
+) -> Result<(), SingleDecodeEnqueueError> {
+    match result {
+        Ok(()) => {
+            scope.record_cuda_submission(permit, function);
+            Ok(())
+        }
+        Err(error) => {
+            if let LaunchContractError::Driver(driver_error) = &error {
+                scope.record_failed_cuda_submission(permit, function, *driver_error);
+            }
+            Err(error.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packed_alignment_gate_accepts_four_byte_boundaries() {
+        assert!(require_packed_alignment("Q", 0x1000).is_ok());
+    }
+
+    #[test]
+    fn packed_alignment_gate_rejects_two_byte_offsets() {
+        let error = require_packed_alignment("K", 0x1002).unwrap_err();
+        assert!(matches!(
+            error,
+            SingleDecodeEnqueueError::MisalignedBuffer {
+                operand: "K",
+                address: 0x1002,
+                alignment: 4,
+            }
+        ));
+    }
+}

--- a/crates/loom-infer-cuda/src/bin/single_decode_h20.rs
+++ b/crates/loom-infer-cuda/src/bin/single_decode_h20.rs
@@ -1,0 +1,419 @@
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchContractError};
+use half::bf16;
+use loom_infer::{Bf16SingleDecodeSpec, SINGLE_DECODE_HEAD_DIM, single_decode_bf16_reference};
+use loom_infer_cuda::attention::{
+    AttentionProvider, Bf16SingleDecodeArgs, Bf16SingleDecodePlan, SingleDecodeEnqueueError,
+};
+use loom_infer_cuda::command::{CommandError, CommandQueue};
+use std::error::Error;
+use std::sync::Arc;
+
+const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
+const LSE_MAX_ABS_LIMIT: f32 = 0.01;
+
+#[derive(Clone, Copy, Debug)]
+struct Comparison {
+    max_abs: f32,
+    mismatches: usize,
+    digest: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ShortBuffer {
+    Query,
+    Key,
+    Value,
+    Output,
+    Lse,
+}
+
+fn deterministic_bf16(len: usize, salt: u64) -> Vec<bf16> {
+    let mut state = 0x9e37_79b9_7f4a_7c15_u64 ^ salt;
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let signed = (state % 2001) as i32 - 1000;
+        values.push(bf16::from_f32(signed as f32 / 2048.0));
+    }
+    values
+}
+
+fn compare_bf16(actual: &[bf16], expected: &[bf16]) -> Result<Comparison, Box<dyn Error>> {
+    if actual.len() != expected.len() {
+        return Err(format!(
+            "BF16 comparison length mismatch: actual={}, expected={}",
+            actual.len(),
+            expected.len()
+        )
+        .into());
+    }
+    let mut max_abs = 0.0_f32;
+    let mut mismatches = 0_usize;
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        let actual_f32 = actual.to_f32();
+        if !actual_f32.is_finite() {
+            return Err(format!("non-finite BF16 output at index {index}").into());
+        }
+        max_abs = max_abs.max((actual_f32 - expected.to_f32()).abs());
+        mismatches += usize::from(actual.to_bits() != expected.to_bits());
+        digest ^= u64::from(actual.to_bits());
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    Ok(Comparison {
+        max_abs,
+        mismatches,
+        digest,
+    })
+}
+
+fn compare_f32(actual: &[f32], expected: &[f32]) -> Result<Comparison, Box<dyn Error>> {
+    if actual.len() != expected.len() {
+        return Err(format!(
+            "F32 comparison length mismatch: actual={}, expected={}",
+            actual.len(),
+            expected.len()
+        )
+        .into());
+    }
+    let mut max_abs = 0.0_f32;
+    let mut mismatches = 0_usize;
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if !actual.is_finite() {
+            return Err(format!("non-finite F32 LSE at index {index}").into());
+        }
+        max_abs = max_abs.max((actual - expected).abs());
+        mismatches += usize::from(actual.to_bits() != expected.to_bits());
+        digest ^= u64::from(actual.to_bits());
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    Ok(Comparison {
+        max_abs,
+        mismatches,
+        digest,
+    })
+}
+
+fn run_case(
+    queue: &mut CommandQueue,
+    provider: &AttentionProvider,
+    name: &str,
+    spec: Bf16SingleDecodeSpec,
+    salt: u64,
+) -> Result<(), Box<dyn Error>> {
+    let query_host = deterministic_bf16(spec.query_numel(), salt);
+    let key_host = deterministic_bf16(spec.kv_numel(), salt ^ 0x4b45_5900);
+    let value_host = deterministic_bf16(spec.kv_numel(), salt ^ 0x5641_4c55_4500);
+    run_case_with_inputs(
+        queue,
+        provider,
+        name,
+        spec,
+        &query_host,
+        &key_host,
+        &value_host,
+    )
+}
+
+fn run_case_with_inputs(
+    queue: &mut CommandQueue,
+    provider: &AttentionProvider,
+    name: &str,
+    spec: Bf16SingleDecodeSpec,
+    query_host: &[bf16],
+    key_host: &[bf16],
+    value_host: &[bf16],
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let plan = provider.plan_bf16(spec)?;
+    let mut expected_output = vec![bf16::ZERO; spec.output_numel()];
+    let mut expected_lse = vec![0.0_f32; spec.lse_numel()];
+    single_decode_bf16_reference(
+        query_host,
+        key_host,
+        value_host,
+        &mut expected_output,
+        &mut expected_lse,
+        spec,
+    )?;
+
+    let query = Arc::new(DeviceBuffer::from_host(&stream, query_host)?);
+    let key = Arc::new(DeviceBuffer::from_host(&stream, key_host)?);
+    let value = Arc::new(DeviceBuffer::from_host(&stream, value_host)?);
+    let output_sentinel = vec![bf16::NAN; spec.output_numel()];
+    let lse_sentinel = vec![f32::NAN; spec.lse_numel()];
+    let output = DeviceBuffer::from_host(&stream, &output_sentinel)?;
+    let lse = DeviceBuffer::from_host(&stream, &lse_sentinel)?;
+    let mut bindings = queue.bindings(5)?;
+    let query_handle = bindings.bind_read(query)?;
+    let key_handle = bindings.bind_read(key)?;
+    let value_handle = bindings.bind_read(value)?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let lse_handle = bindings.bind_read_write(lse)?;
+
+    let mut scope = queue.begin(bindings)?;
+    plan.enqueue_into(
+        &mut scope,
+        Bf16SingleDecodeArgs::new(
+            query_handle,
+            key_handle,
+            value_handle,
+            output_handle.write(),
+            lse_handle.write(),
+        ),
+    )?;
+    let completion = scope.finish();
+    if completion.submitted() != 1 {
+        return Err("single decode completion covered the wrong command count".into());
+    }
+    bindings = completion.wait()?;
+    let output = bindings.take_read_write(output_handle)?;
+    let lse = bindings.take_read_write(lse_handle)?;
+    drop(bindings);
+
+    let actual_output = output.to_host_vec(&stream)?;
+    let actual_lse = lse.to_host_vec(&stream)?;
+    let output_comparison = compare_bf16(&actual_output, &expected_output)?;
+    let lse_comparison = compare_f32(&actual_lse, &expected_lse)?;
+    if output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT {
+        return Err(format!(
+            "{name} output max abs {:.9e} exceeds {:.9e}",
+            output_comparison.max_abs, OUTPUT_MAX_ABS_LIMIT
+        )
+        .into());
+    }
+    if lse_comparison.max_abs > LSE_MAX_ABS_LIMIT {
+        return Err(format!(
+            "{name} LSE max abs {:.9e} exceeds {:.9e}",
+            lse_comparison.max_abs, LSE_MAX_ABS_LIMIT
+        )
+        .into());
+    }
+
+    println!(
+        "gate=single_decode_h20 case={} status=pass kv_len={} query_heads={} kv_heads={} \
+         group_size={} head_dim={} layout=NHD dtype=BF16 accumulation=F32 lse_domain=log2 \
+         output_max_abs={:.9e} output_bit_mismatches={} output_digest={:016x} \
+         lse_max_abs={:.9e} lse_bit_mismatches={} lse_digest={:016x}",
+        name,
+        spec.kv_len(),
+        spec.num_query_heads(),
+        spec.num_kv_heads(),
+        spec.gqa_group_size(),
+        spec.head_dim(),
+        output_comparison.max_abs,
+        output_comparison.mismatches,
+        output_comparison.digest,
+        lse_comparison.max_abs,
+        lse_comparison.mismatches,
+        lse_comparison.digest,
+    );
+    Ok(())
+}
+
+fn run_large_logit_case(
+    queue: &mut CommandQueue,
+    provider: &AttentionProvider,
+) -> Result<(), Box<dyn Error>> {
+    let spec = Bf16SingleDecodeSpec::new(3, 1, 1, SINGLE_DECODE_HEAD_DIM)?;
+    let query = vec![bf16::from_f32(64.0); spec.query_numel()];
+    let mut key = Vec::with_capacity(spec.kv_numel());
+    let mut value = Vec::with_capacity(spec.kv_numel());
+    for (key_value, value_value) in [(-64.0, -1.0), (0.0, 0.5), (64.0, 2.0)] {
+        key.extend(std::iter::repeat_n(
+            bf16::from_f32(key_value),
+            SINGLE_DECODE_HEAD_DIM,
+        ));
+        value.extend(std::iter::repeat_n(
+            bf16::from_f32(value_value),
+            SINGLE_DECODE_HEAD_DIM,
+        ));
+    }
+    run_case_with_inputs(
+        queue,
+        provider,
+        "large_logits_l3",
+        spec,
+        &query,
+        &key,
+        &value,
+    )
+}
+
+fn run_short_buffer_case(
+    queue: &mut CommandQueue,
+    plan: &Bf16SingleDecodePlan,
+    short: ShortBuffer,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let spec = plan.spec();
+    let query_len = spec.query_numel() - usize::from(matches!(short, ShortBuffer::Query));
+    let key_len = spec.kv_numel() - usize::from(matches!(short, ShortBuffer::Key));
+    let value_len = spec.kv_numel() - usize::from(matches!(short, ShortBuffer::Value));
+    let output_len = spec.output_numel() - usize::from(matches!(short, ShortBuffer::Output));
+    let lse_len = spec.lse_numel() - usize::from(matches!(short, ShortBuffer::Lse));
+    let query = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, query_len)?);
+    let key = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, key_len)?);
+    let value = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, value_len)?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, output_len)?;
+    let lse = DeviceBuffer::<f32>::zeroed(&stream, lse_len)?;
+    let mut bindings = queue.bindings(5)?;
+    let query_handle = bindings.bind_read(query)?;
+    let key_handle = bindings.bind_read(key)?;
+    let value_handle = bindings.bind_read(value)?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let lse_handle = bindings.bind_read_write(lse)?;
+
+    let mut scope = queue.begin(bindings)?;
+    let error = plan
+        .enqueue_into(
+            &mut scope,
+            Bf16SingleDecodeArgs::new(
+                query_handle,
+                key_handle,
+                value_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            ),
+        )
+        .expect_err("short single-decode buffer must be rejected");
+    let expected_relation = match short {
+        ShortBuffer::Query => "query.len() == num_query_heads * 128",
+        ShortBuffer::Key => "key.len() == kv_len * num_kv_heads * 128",
+        ShortBuffer::Value => "value.len() == kv_len * num_kv_heads * 128",
+        ShortBuffer::Output => "output.len() == num_query_heads * 128",
+        ShortBuffer::Lse => "lse.len() == num_query_heads",
+    };
+    if !matches!(
+        &error,
+        SingleDecodeEnqueueError::Launch(LaunchContractError::SizeRequirementViolated {
+            relation,
+            ..
+        }) if *relation == expected_relation
+    ) {
+        return Err(
+            format!("short {short:?} buffer did not violate {expected_relation}: {error}").into(),
+        );
+    }
+    let completion = scope.finish();
+    if completion.submitted() != 0 {
+        return Err("short buffer reached CUDA submission".into());
+    }
+    drop(completion.wait()?);
+    Ok(())
+}
+
+fn check_short_buffers(
+    queue: &mut CommandQueue,
+    provider: &AttentionProvider,
+) -> Result<(), Box<dyn Error>> {
+    let spec = Bf16SingleDecodeSpec::new(2, 4, 2, SINGLE_DECODE_HEAD_DIM)?;
+    let plan = provider.plan_bf16(spec)?;
+    for short in [
+        ShortBuffer::Query,
+        ShortBuffer::Key,
+        ShortBuffer::Value,
+        ShortBuffer::Output,
+        ShortBuffer::Lse,
+    ] {
+        run_short_buffer_case(queue, &plan, short)?;
+    }
+    println!(
+        "gate=single_decode_h20 case=short_buffers status=pass \
+         query=rejected key=rejected value=rejected output=rejected lse=rejected before_ffi=true"
+    );
+    Ok(())
+}
+
+fn check_duplicate_binding(
+    queue: &mut CommandQueue,
+    provider: &AttentionProvider,
+) -> Result<(), Box<dyn Error>> {
+    let stream = queue.stream().clone();
+    let spec = Bf16SingleDecodeSpec::new(1, 1, 1, SINGLE_DECODE_HEAD_DIM)?;
+    let plan = provider.plan_bf16(spec)?;
+    let query_and_key = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, spec.query_numel())?);
+    let value = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, spec.kv_numel())?);
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let lse = DeviceBuffer::<f32>::zeroed(&stream, spec.lse_numel())?;
+    let mut bindings = queue.bindings(4)?;
+    let query_and_key_handle = bindings.bind_read(query_and_key)?;
+    let value_handle = bindings.bind_read(value)?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let lse_handle = bindings.bind_read_write(lse)?;
+
+    let mut scope = queue.begin(bindings)?;
+    let error = plan
+        .enqueue_into(
+            &mut scope,
+            Bf16SingleDecodeArgs::new(
+                query_and_key_handle,
+                query_and_key_handle,
+                value_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            ),
+        )
+        .expect_err("one binding slot cannot serve two single-decode operands");
+    if !matches!(
+        error,
+        SingleDecodeEnqueueError::Command(CommandError::DuplicateBindingSlot)
+    ) {
+        return Err(format!("duplicate binding returned the wrong error: {error}").into());
+    }
+    let completion = scope.finish();
+    if completion.submitted() != 0 {
+        return Err("duplicate binding reached CUDA submission".into());
+    }
+    drop(completion.wait()?);
+    println!("gate=single_decode_h20 case=duplicate_binding status=pass rejected_before_ffi=true");
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let context = CudaContext::new(0)?;
+    let provider = AttentionProvider::load(&context)?;
+    let stream: Arc<CudaStream> = context.new_stream()?;
+    let mut queue = CommandQueue::new(stream, 1)?;
+
+    run_case(
+        &mut queue,
+        &provider,
+        "mha_l1",
+        Bf16SingleDecodeSpec::new(1, 8, 8, SINGLE_DECODE_HEAD_DIM)?,
+        0x1001,
+    )?;
+    run_case(
+        &mut queue,
+        &provider,
+        "mqa_l33",
+        Bf16SingleDecodeSpec::new(33, 8, 1, SINGLE_DECODE_HEAD_DIM)?,
+        0x2001,
+    )?;
+    run_case(
+        &mut queue,
+        &provider,
+        "gqa4_l127",
+        Bf16SingleDecodeSpec::new(127, 16, 4, SINGLE_DECODE_HEAD_DIM)?,
+        0x4001,
+    )?;
+    run_case(
+        &mut queue,
+        &provider,
+        "gqa8_l4096",
+        Bf16SingleDecodeSpec::new(4096, 32, 4, SINGLE_DECODE_HEAD_DIM)?,
+        0x8001,
+    )?;
+    run_large_logit_case(&mut queue, &provider)?;
+    check_short_buffers(&mut queue, &provider)?;
+    check_duplicate_binding(&mut queue, &provider)?;
+    println!(
+        "gate=single_decode_h20 suite=all status=pass output_max_abs_limit={:.9e} \
+         lse_max_abs_limit={:.9e}",
+        OUTPUT_MAX_ABS_LIMIT, LSE_MAX_ABS_LIMIT
+    );
+    Ok(())
+}

--- a/crates/loom-infer-cuda/src/command.rs
+++ b/crates/loom-infer-cuda/src/command.rs
@@ -540,27 +540,14 @@ impl<'queue> CommandScope<'queue> {
         B: ResolveElement,
         C: ResolveElement,
     {
+        self.validate_resolve_request(
+            &[first.set_id, second.set_id, third.set_id],
+            &[first.slot, second.slot, third.slot],
+        )?;
         let bindings = self
             .bindings
             .as_mut()
             .expect("live command scope has bindings");
-        for handle in [first.set_id, second.set_id, third.set_id] {
-            if handle != bindings.set_id {
-                return Err(CommandError::BindingSetMismatch);
-            }
-        }
-        if first.slot == second.slot || first.slot == third.slot || second.slot == third.slot {
-            return Err(CommandError::DuplicateBindingSlot);
-        }
-        for slot in [first.slot, second.slot, third.slot] {
-            if slot >= bindings.leases.len() {
-                return Err(CommandError::BindingSlotOutOfRange {
-                    slot,
-                    bindings: bindings.leases.len(),
-                });
-            }
-        }
-
         let [first_lease, second_lease, third_lease] = bindings
             .leases
             .get_disjoint_mut([first.slot, second.slot, third.slot])
@@ -594,28 +581,15 @@ impl<'queue> CommandScope<'queue> {
         C: ResolveElement,
         D: ResolveElement,
     {
+        let slots = [first.slot, second.slot, third.slot, fourth.slot];
+        self.validate_resolve_request(
+            &[first.set_id, second.set_id, third.set_id, fourth.set_id],
+            &slots,
+        )?;
         let bindings = self
             .bindings
             .as_mut()
             .expect("live command scope has bindings");
-        for handle in [first.set_id, second.set_id, third.set_id, fourth.set_id] {
-            if handle != bindings.set_id {
-                return Err(CommandError::BindingSetMismatch);
-            }
-        }
-        let slots = [first.slot, second.slot, third.slot, fourth.slot];
-        for (index, slot) in slots.iter().enumerate() {
-            if slots[..index].contains(slot) {
-                return Err(CommandError::DuplicateBindingSlot);
-            }
-            if *slot >= bindings.leases.len() {
-                return Err(CommandError::BindingSlotOutOfRange {
-                    slot: *slot,
-                    bindings: bindings.leases.len(),
-                });
-            }
-        }
-
         let [first_lease, second_lease, third_lease, fourth_lease] = bindings
             .leases
             .get_disjoint_mut(slots)
@@ -637,6 +611,94 @@ impl<'queue> CommandScope<'queue> {
             third: third_buffer,
             fourth: fourth_buffer,
         })
+    }
+
+    pub(crate) fn resolve_rrrww<A, B, C, D, E>(
+        &mut self,
+        first: Read<A>,
+        second: Read<B>,
+        third: Read<C>,
+        fourth: Write<D>,
+        fifth: Write<E>,
+    ) -> Result<ResolvedRrrww<'_, A, B, C, D, E>, CommandError>
+    where
+        A: ResolveElement,
+        B: ResolveElement,
+        C: ResolveElement,
+        D: ResolveElement,
+        E: ResolveElement,
+    {
+        let slots = [first.slot, second.slot, third.slot, fourth.slot, fifth.slot];
+        self.validate_resolve_request(
+            &[
+                first.set_id,
+                second.set_id,
+                third.set_id,
+                fourth.set_id,
+                fifth.set_id,
+            ],
+            &slots,
+        )?;
+        let bindings = self
+            .bindings
+            .as_mut()
+            .expect("live command scope has bindings");
+        let [
+            first_lease,
+            second_lease,
+            third_lease,
+            fourth_lease,
+            fifth_lease,
+        ] = bindings
+            .leases
+            .get_disjoint_mut(slots)
+            .expect("validated binding slots are pairwise disjoint");
+        let first_buffer =
+            A::read(first_lease).map_err(|error| map_lease_error(error, first.slot))?;
+        let second_buffer =
+            B::read(second_lease).map_err(|error| map_lease_error(error, second.slot))?;
+        let third_buffer =
+            C::read(third_lease).map_err(|error| map_lease_error(error, third.slot))?;
+        let fourth_buffer =
+            D::write(fourth_lease).map_err(|error| map_lease_error(error, fourth.slot))?;
+        let fifth_buffer =
+            E::write(fifth_lease).map_err(|error| map_lease_error(error, fifth.slot))?;
+        let queue = self.queue.as_ref().expect("live command scope has a queue");
+
+        Ok(ResolvedRrrww {
+            stream: &queue.stream,
+            first: first_buffer,
+            second: second_buffer,
+            third: third_buffer,
+            fourth: fourth_buffer,
+            fifth: fifth_buffer,
+        })
+    }
+
+    fn validate_resolve_request(
+        &self,
+        set_ids: &[u64],
+        slots: &[usize],
+    ) -> Result<(), CommandError> {
+        let bindings = self
+            .bindings
+            .as_ref()
+            .expect("live command scope has bindings");
+        if set_ids.iter().any(|&set_id| set_id != bindings.set_id) {
+            return Err(CommandError::BindingSetMismatch);
+        }
+        for (index, &slot) in slots.iter().enumerate() {
+            if slots[..index].contains(&slot) {
+                return Err(CommandError::DuplicateBindingSlot);
+            }
+            if slot >= bindings.leases.len() {
+                return Err(CommandError::BindingSlotOutOfRange {
+                    slot,
+                    bindings: bindings.leases.len(),
+                });
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn record_cuda_submission(&mut self, permit: CommandPermit, function: CudaFunction) {
@@ -801,6 +863,22 @@ pub(crate) struct ResolvedRrww<
     pub(crate) second: &'scope DeviceBuffer<B>,
     pub(crate) third: &'scope mut DeviceBuffer<C>,
     pub(crate) fourth: &'scope mut DeviceBuffer<D>,
+}
+
+pub(crate) struct ResolvedRrrww<
+    'scope,
+    A: BindingElement,
+    B: BindingElement,
+    C: BindingElement,
+    D: BindingElement,
+    E: BindingElement,
+> {
+    pub(crate) stream: &'scope CudaStream,
+    pub(crate) first: &'scope DeviceBuffer<A>,
+    pub(crate) second: &'scope DeviceBuffer<B>,
+    pub(crate) third: &'scope DeviceBuffer<C>,
+    pub(crate) fourth: &'scope mut DeviceBuffer<D>,
+    pub(crate) fifth: &'scope mut DeviceBuffer<E>,
 }
 
 /// The final fence and all bindings retained by a completed command scope.

--- a/crates/loom-infer-cuda/src/lib.rs
+++ b/crates/loom-infer-cuda/src/lib.rs
@@ -3,6 +3,8 @@
 //! Enable the `cuda` feature inside the pinned cuda-oxide toolchain.
 
 #[cfg(feature = "cuda")]
+pub mod attention;
+#[cfg(feature = "cuda")]
 pub mod command;
 #[cfg(feature = "cuda")]
 mod driver;

--- a/crates/loom-infer/README.md
+++ b/crates/loom-infer/README.md
@@ -3,6 +3,6 @@
 `loom-infer` defines backend-independent operator contracts and CPU reference
 implementations. The crate has no CUDA, FFI, runtime, or framework dependency.
 
-The current contracts cover RMSNorm for F32, FP16, and BF16, plus contiguous
-BF16 GEMM with F32 accumulation. Loom Infer adds another contract only when a
-permanent device provider starts.
+The current contracts cover RMSNorm for F32, FP16, and BF16, contiguous BF16
+GEMM, and BF16 single-request decode attention. The attention contract fixes
+NHD caches, head dimension 128, F32 accumulation, BF16 output, and F32 log2-LSE.

--- a/crates/loom-infer/src/attention.rs
+++ b/crates/loom-infer/src/attention.rs
@@ -1,0 +1,183 @@
+//! Single-request decode-attention contracts and CPU references.
+
+use crate::ContractError;
+use crate::error::require_len;
+use half::bf16;
+
+/// Head dimension admitted by the first single-decode contract.
+pub const SINGLE_DECODE_HEAD_DIM: usize = 128;
+
+/// BF16 single-request decode over contiguous NHD key and value caches.
+///
+/// Query and output use `[query_heads, 128]`. Key and value use
+/// `[kv_len, kv_heads, 128]`. Scores and online-softmax state use F32. LSE is
+/// `log2(sum(exp(scaled_logit)))` to match FlashInfer's returned state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Bf16SingleDecodeSpec {
+    kv_len: usize,
+    num_query_heads: usize,
+    num_kv_heads: usize,
+    softmax_scale: f32,
+}
+
+impl Bf16SingleDecodeSpec {
+    /// Creates the first fixed BF16, NHD, full-window decode contract.
+    pub fn new(
+        kv_len: usize,
+        num_query_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+    ) -> Result<Self, ContractError> {
+        if kv_len == 0 || num_query_heads == 0 || num_kv_heads == 0 || head_dim == 0 {
+            return Err(ContractError::ZeroDimension);
+        }
+        if head_dim != SINGLE_DECODE_HEAD_DIM {
+            return Err(ContractError::UnsupportedHeadDimension {
+                expected: SINGLE_DECODE_HEAD_DIM,
+                actual: head_dim,
+            });
+        }
+        if !num_query_heads.is_multiple_of(num_kv_heads) {
+            return Err(ContractError::InvalidHeadMapping {
+                query_heads: num_query_heads,
+                kv_heads: num_kv_heads,
+            });
+        }
+
+        num_query_heads
+            .checked_mul(head_dim)
+            .ok_or(ContractError::ElementCountOverflow)?;
+        let elements_per_token = num_kv_heads
+            .checked_mul(head_dim)
+            .ok_or(ContractError::ElementCountOverflow)?;
+        kv_len
+            .checked_mul(elements_per_token)
+            .ok_or(ContractError::ElementCountOverflow)?;
+
+        Ok(Self {
+            kv_len,
+            num_query_heads,
+            num_kv_heads,
+            softmax_scale: 1.0 / (head_dim as f32).sqrt(),
+        })
+    }
+
+    pub const fn kv_len(self) -> usize {
+        self.kv_len
+    }
+
+    pub const fn num_query_heads(self) -> usize {
+        self.num_query_heads
+    }
+
+    pub const fn num_kv_heads(self) -> usize {
+        self.num_kv_heads
+    }
+
+    pub const fn head_dim(self) -> usize {
+        SINGLE_DECODE_HEAD_DIM
+    }
+
+    pub const fn softmax_scale(self) -> f32 {
+        self.softmax_scale
+    }
+
+    pub const fn gqa_group_size(self) -> usize {
+        self.num_query_heads / self.num_kv_heads
+    }
+
+    pub const fn query_numel(self) -> usize {
+        self.num_query_heads * SINGLE_DECODE_HEAD_DIM
+    }
+
+    pub const fn kv_numel(self) -> usize {
+        self.kv_len * self.num_kv_heads * SINGLE_DECODE_HEAD_DIM
+    }
+
+    pub const fn output_numel(self) -> usize {
+        self.query_numel()
+    }
+
+    pub const fn lse_numel(self) -> usize {
+        self.num_query_heads
+    }
+
+    pub const fn kv_head_for_query_head(self, query_head: usize) -> Option<usize> {
+        if query_head < self.num_query_heads {
+            Some(query_head / self.gqa_group_size())
+        } else {
+            None
+        }
+    }
+}
+
+/// Computes BF16 single-request decode with F32 online softmax.
+///
+/// Dot products visit head components in ascending order. Softmax visits KV
+/// tokens in ascending order. Output rounds once after normalization.
+pub fn single_decode_bf16_reference(
+    query: &[bf16],
+    key: &[bf16],
+    value: &[bf16],
+    output: &mut [bf16],
+    lse: &mut [f32],
+    spec: Bf16SingleDecodeSpec,
+) -> Result<(), ContractError> {
+    require_len("Q", query.len(), spec.query_numel())?;
+    require_len("K", key.len(), spec.kv_numel())?;
+    require_len("V", value.len(), spec.kv_numel())?;
+    require_len("O", output.len(), spec.output_numel())?;
+    require_len("LSE", lse.len(), spec.lse_numel())?;
+
+    for (query_head, lse_slot) in lse.iter_mut().enumerate() {
+        let query_offset = query_head * spec.head_dim();
+        let kv_head = spec
+            .kv_head_for_query_head(query_head)
+            .expect("enumerated query head is inside the validated specification");
+        let mut output_state = [0.0_f32; SINGLE_DECODE_HEAD_DIM];
+        let mut max_score = 0.0_f32;
+        let mut normalizer = 0.0_f32;
+
+        for token in 0..spec.kv_len() {
+            let kv_offset = (token * spec.num_kv_heads() + kv_head) * SINGLE_DECODE_HEAD_DIM;
+            let dot = (0..SINGLE_DECODE_HEAD_DIM).fold(0.0_f32, |sum, component| {
+                query[query_offset + component]
+                    .to_f32()
+                    .mul_add(key[kv_offset + component].to_f32(), sum)
+            });
+            let score = dot * spec.softmax_scale();
+
+            if token == 0 {
+                max_score = score;
+                normalizer = 1.0;
+                for component in 0..SINGLE_DECODE_HEAD_DIM {
+                    output_state[component] = value[kv_offset + component].to_f32();
+                }
+                continue;
+            }
+
+            let next_max = max_score.max(score);
+            let previous_weight = (max_score - next_max).exp();
+            let current_weight = (score - next_max).exp();
+            normalizer = normalizer * previous_weight + current_weight;
+            for component in 0..SINGLE_DECODE_HEAD_DIM {
+                output_state[component] = output_state[component] * previous_weight
+                    + value[kv_offset + component].to_f32() * current_weight;
+            }
+            max_score = next_max;
+        }
+
+        let output_offset = query_head * SINGLE_DECODE_HEAD_DIM;
+        for component in 0..SINGLE_DECODE_HEAD_DIM {
+            output[output_offset + component] =
+                bf16::from_f32(output_state[component] / normalizer);
+        }
+        *lse_slot = (max_score + normalizer.ln()) * core::f32::consts::LOG2_E;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "attention/tests.rs"]
+mod tests;

--- a/crates/loom-infer/src/attention/tests.rs
+++ b/crates/loom-infer/src/attention/tests.rs
@@ -1,0 +1,213 @@
+use super::*;
+
+fn bf16_slice(values: &[f32]) -> Vec<bf16> {
+    values.iter().copied().map(bf16::from_f32).collect()
+}
+
+#[test]
+fn reference_matches_two_token_softmax() {
+    let spec = Bf16SingleDecodeSpec::new(2, 1, 1, SINGLE_DECODE_HEAD_DIM).unwrap();
+    let mut query = vec![bf16::ZERO; spec.query_numel()];
+    let mut key = vec![bf16::ZERO; spec.kv_numel()];
+    let mut value = vec![bf16::ZERO; spec.kv_numel()];
+    query[0] = bf16::from_f32((SINGLE_DECODE_HEAD_DIM as f32).sqrt());
+    key[SINGLE_DECODE_HEAD_DIM] = bf16::ONE;
+    value[SINGLE_DECODE_HEAD_DIM..].fill(bf16::from_f32(2.0));
+    let mut output = vec![bf16::ZERO; spec.output_numel()];
+    let mut lse = vec![0.0_f32; spec.lse_numel()];
+
+    single_decode_bf16_reference(&query, &key, &value, &mut output, &mut lse, spec).unwrap();
+
+    let second_score = query[0].to_f32() * spec.softmax_scale();
+    let second_probability = second_score.exp() / (1.0 + second_score.exp());
+    let expected_output = bf16::from_f32(2.0 * second_probability);
+    assert!(output.iter().all(|&value| value == expected_output));
+    let expected_lse_log2 = (1.0 + second_score.exp()).ln() * core::f32::consts::LOG2_E;
+    assert!((lse[0] - expected_lse_log2).abs() < 1.0e-6);
+}
+
+#[test]
+fn reference_maps_gqa_heads_to_their_kv_head() {
+    let spec = Bf16SingleDecodeSpec::new(1, 4, 2, SINGLE_DECODE_HEAD_DIM).unwrap();
+    let query = vec![bf16::ZERO; spec.query_numel()];
+    let key = vec![bf16::ZERO; spec.kv_numel()];
+    let mut value = vec![bf16::ZERO; spec.kv_numel()];
+    value[..SINGLE_DECODE_HEAD_DIM].fill(bf16::from_f32(1.5));
+    value[SINGLE_DECODE_HEAD_DIM..].fill(bf16::from_f32(-2.0));
+    let mut output = vec![bf16::ZERO; spec.output_numel()];
+    let mut lse = vec![f32::NAN; spec.lse_numel()];
+
+    single_decode_bf16_reference(&query, &key, &value, &mut output, &mut lse, spec).unwrap();
+
+    let expected = bf16_slice(
+        &std::iter::repeat_n(1.5, 2 * SINGLE_DECODE_HEAD_DIM)
+            .chain(std::iter::repeat_n(-2.0, 2 * SINGLE_DECODE_HEAD_DIM))
+            .collect::<Vec<_>>(),
+    );
+    assert_eq!(output, expected);
+    assert_eq!(lse, [0.0; 4]);
+}
+
+#[test]
+fn reference_keeps_large_logits_finite() {
+    let spec = Bf16SingleDecodeSpec::new(3, 1, 1, SINGLE_DECODE_HEAD_DIM).unwrap();
+    let query = vec![bf16::from_f32(64.0); spec.query_numel()];
+    let key = bf16_slice(
+        &std::iter::repeat_n(-64.0, SINGLE_DECODE_HEAD_DIM)
+            .chain(std::iter::repeat_n(0.0, SINGLE_DECODE_HEAD_DIM))
+            .chain(std::iter::repeat_n(64.0, SINGLE_DECODE_HEAD_DIM))
+            .collect::<Vec<_>>(),
+    );
+    let value = vec![bf16::ONE; spec.kv_numel()];
+    let mut output = vec![bf16::ZERO; spec.output_numel()];
+    let mut lse = vec![0.0; spec.lse_numel()];
+
+    single_decode_bf16_reference(&query, &key, &value, &mut output, &mut lse, spec).unwrap();
+
+    assert!(output.iter().all(|value| value.to_f32().is_finite()));
+    assert!(lse[0].is_finite());
+}
+
+#[test]
+fn reference_requires_all_exact_buffer_lengths() {
+    let spec = Bf16SingleDecodeSpec::new(2, 2, 1, SINGLE_DECODE_HEAD_DIM).unwrap();
+    let q = vec![bf16::ZERO; spec.query_numel()];
+    let k = vec![bf16::ZERO; spec.kv_numel()];
+    let v = vec![bf16::ZERO; spec.kv_numel()];
+    let o = vec![bf16::ZERO; spec.output_numel()];
+    let lse = vec![0.0; spec.lse_numel()];
+
+    let cases = [
+        (
+            single_decode_bf16_reference(
+                &q[..q.len() - 1],
+                &k,
+                &v,
+                &mut o.clone(),
+                &mut lse.clone(),
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "Q",
+                expected: q.len(),
+                actual: q.len() - 1,
+            },
+        ),
+        (
+            single_decode_bf16_reference(
+                &q,
+                &k[..k.len() - 1],
+                &v,
+                &mut o.clone(),
+                &mut lse.clone(),
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "K",
+                expected: k.len(),
+                actual: k.len() - 1,
+            },
+        ),
+        (
+            single_decode_bf16_reference(
+                &q,
+                &k,
+                &v[..v.len() - 1],
+                &mut o.clone(),
+                &mut lse.clone(),
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "V",
+                expected: v.len(),
+                actual: v.len() - 1,
+            },
+        ),
+        (
+            single_decode_bf16_reference(
+                &q,
+                &k,
+                &v,
+                &mut o[..o.len() - 1].to_vec(),
+                &mut lse.clone(),
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "O",
+                expected: o.len(),
+                actual: o.len() - 1,
+            },
+        ),
+        (
+            single_decode_bf16_reference(
+                &q,
+                &k,
+                &v,
+                &mut o.clone(),
+                &mut lse[..lse.len() - 1].to_vec(),
+                spec,
+            ),
+            ContractError::LengthMismatch {
+                buffer: "LSE",
+                expected: lse.len(),
+                actual: lse.len() - 1,
+            },
+        ),
+    ];
+
+    for (actual, expected) in cases {
+        assert_eq!(actual, Err(expected));
+    }
+}
+
+#[test]
+fn spec_rejects_unsupported_shapes_and_overflow() {
+    for dimensions in [(0, 1, 1, 128), (1, 0, 1, 128), (1, 1, 0, 128), (1, 1, 1, 0)] {
+        assert_eq!(
+            Bf16SingleDecodeSpec::new(dimensions.0, dimensions.1, dimensions.2, dimensions.3),
+            Err(ContractError::ZeroDimension)
+        );
+    }
+    assert_eq!(
+        Bf16SingleDecodeSpec::new(1, 1, 1, 64),
+        Err(ContractError::UnsupportedHeadDimension {
+            expected: SINGLE_DECODE_HEAD_DIM,
+            actual: 64,
+        })
+    );
+    assert_eq!(
+        Bf16SingleDecodeSpec::new(1, 6, 4, SINGLE_DECODE_HEAD_DIM),
+        Err(ContractError::InvalidHeadMapping {
+            query_heads: 6,
+            kv_heads: 4,
+        })
+    );
+    assert_eq!(
+        Bf16SingleDecodeSpec::new(usize::MAX, 1, 1, SINGLE_DECODE_HEAD_DIM),
+        Err(ContractError::ElementCountOverflow)
+    );
+    assert_eq!(
+        Bf16SingleDecodeSpec::new(1, usize::MAX, 1, SINGLE_DECODE_HEAD_DIM),
+        Err(ContractError::ElementCountOverflow)
+    );
+}
+
+#[test]
+fn spec_reports_fixed_shapes_and_mapping() {
+    let spec = Bf16SingleDecodeSpec::new(7, 8, 2, SINGLE_DECODE_HEAD_DIM).unwrap();
+
+    assert_eq!(spec.kv_len(), 7);
+    assert_eq!(spec.num_query_heads(), 8);
+    assert_eq!(spec.num_kv_heads(), 2);
+    assert_eq!(spec.head_dim(), 128);
+    assert_eq!(spec.gqa_group_size(), 4);
+    assert_eq!(spec.kv_head_for_query_head(0), Some(0));
+    assert_eq!(spec.kv_head_for_query_head(3), Some(0));
+    assert_eq!(spec.kv_head_for_query_head(4), Some(1));
+    assert_eq!(spec.kv_head_for_query_head(7), Some(1));
+    assert_eq!(spec.kv_head_for_query_head(8), None);
+    assert_eq!(spec.query_numel(), 8 * 128);
+    assert_eq!(spec.kv_numel(), 7 * 2 * 128);
+    assert_eq!(spec.output_numel(), 8 * 128);
+    assert_eq!(spec.lse_numel(), 8);
+}

--- a/crates/loom-infer/src/error.rs
+++ b/crates/loom-infer/src/error.rs
@@ -7,6 +7,14 @@ pub enum ContractError {
     ZeroDimension,
     ElementCountOverflow,
     InvalidEpsilon(f32),
+    UnsupportedHeadDimension {
+        expected: usize,
+        actual: usize,
+    },
+    InvalidHeadMapping {
+        query_heads: usize,
+        kv_heads: usize,
+    },
     UnsupportedDType(DType),
     LengthMismatch {
         buffer: &'static str,
@@ -26,6 +34,17 @@ impl fmt::Display for ContractError {
                     "RMSNorm epsilon must be finite and positive, got {value}"
                 )
             }
+            Self::UnsupportedHeadDimension { expected, actual } => write!(
+                formatter,
+                "unsupported attention head dimension: expected {expected}, got {actual}"
+            ),
+            Self::InvalidHeadMapping {
+                query_heads,
+                kv_heads,
+            } => write!(
+                formatter,
+                "query heads must be divisible by KV heads: query={query_heads}, KV={kv_heads}"
+            ),
             Self::UnsupportedDType(dtype) => write!(formatter, "unsupported dtype {dtype:?}"),
             Self::LengthMismatch {
                 buffer,

--- a/crates/loom-infer/src/lib.rs
+++ b/crates/loom-infer/src/lib.rs
@@ -5,9 +5,11 @@
 mod dtype;
 mod error;
 
+pub mod attention;
 pub mod gemm;
 pub mod rms_norm;
 
+pub use attention::{Bf16SingleDecodeSpec, SINGLE_DECODE_HEAD_DIM, single_decode_bf16_reference};
 pub use dtype::DType;
 pub use error::ContractError;
 pub use gemm::{Bf16GemmSpec, bf16_gemm_reference};

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ Loom Infer is a Rust-native GPU operator library for LLM inference.
 - [Evidence](results/README.md) indexes results from permanent providers.
 
 The root [README](../README.md) gives the short project overview. Current
-correctness evidence covers Rust RMSNorm kernels and one fixed BF16 cuBLASLt
-GEMM plan on H20.
+correctness evidence covers Rust RMSNorm and single-decode attention kernels,
+plus one fixed BF16 cuBLASLt GEMM plan on H20.
 
 ## Documentation rules
 

--- a/docs/design/loom-infer-architecture.md
+++ b/docs/design/loom-infer-architecture.md
@@ -32,7 +32,8 @@ separate ownership or safety boundary.
 
 ## Operator lifecycle
 
-The current RMSNorm and BF16 GEMM slices implement this lifecycle:
+The current RMSNorm, BF16 GEMM, and single-decode attention slices implement
+this lifecycle:
 
 ```text
 validated specification
@@ -120,6 +121,12 @@ device access.
 The FP16 and BF16 RMSNorm plans select scalar access for odd widths. Even widths
 use two-element loads and stores after a four-byte alignment check. Both paths
 use F32 arithmetic and round the stored result to nearest-even.
+
+The first attention plan fixes BF16, NHD caches, head dimension 128, and one
+warp per query head. It computes scores and online softmax state in F32. The
+kernel writes BF16 output and F32 log2-LSE.
+
+This is a correctness baseline. Matched performance remains open.
 
 ## Vendor providers
 

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -27,6 +27,7 @@ cd <loom-infer-checkout>/crates/loom-infer-cuda
 cargo oxide doctor
 cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90
 cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90
+cargo oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch sm_90
 cargo oxide test --arch sm_90 -- --workspace --features cuda --release
 ```
 
@@ -79,6 +80,29 @@ second command when queue capacity is one. It also chains BF16 RMSNorm
 Record the selected algorithm's actual workspace requirement. Test a short
 workspace only when that requirement is nonzero. The current H20 selection
 requires zero workspace, so that rejection case is not applicable.
+
+## BF16 single-decode correctness
+
+Validate the first fixed attention contract:
+
+```text
+Q, O: [query_heads, 128] BF16
+K, V: [kv_len, kv_heads, 128] BF16 NHD
+LSE:   [query_heads] F32 log2-domain
+scale: 1 / sqrt(128)
+```
+
+The gate covers MHA `(1,8,8)`, MQA `(33,8,1)`, GQA `(127,16,4)` and
+`(4096,32,4)`, plus one large-logit stability case. Tuples use
+`(kv_len, query_heads, kv_heads)`.
+
+Compare against the `loom-infer` CPU reference. BF16 output maximum absolute
+error must not exceed `0.015625`. Log2-LSE maximum absolute error must not
+exceed `0.01`. Initialize output buffers with NaN sentinels.
+
+Reject Q, K, V, O, or LSE that is one element short. Reject duplicate operand
+bindings before CUDA submission. Run memcheck, racecheck, synccheck, and
+initcheck over the complete runner.
 
 ## Fixed-address CUDA Graph
 
@@ -137,9 +161,10 @@ The correctness runner is not a benchmark. No GEMM performance gate has passed.
 
 ## Current device state
 
-The [2026-08-03 record](../results/h20-owned-bindings-cuda-graph-correctness-20260803.json)
-qualifies the current owned-binding and fixed-address Graph source projection.
-The maximum F32 RMSNorm absolute error is `4.768371582e-7`.
+The [shared-command regression](../results/h20-shared-command-regression-20260803.json)
+qualifies the current source projection. It reruns RMSNorm, BF16 GEMM, the
+fixed-address Graph, and BF16 single decode. The maximum F32 RMSNorm absolute
+error is `4.768371582e-7`.
 
 The F32 two-command chain reaches `7.152557373e-7` maximum absolute error. The
 FP16 chain reaches two ULPs, and the BF16 chain reaches one ULP. Generated PTX
@@ -148,7 +173,12 @@ uses scalar and packed instructions, targets `sm_90`, and assembles with CUDA
 fixtures. The fixed Graph replays twice and produces a bit-exact final output.
 
 Compute Sanitizer memcheck reports no errors or leaked device allocations for
-both runners. RMSNorm racecheck and synccheck report no errors. Graph-runner
-initcheck also reports no errors.
+the RMSNorm and Graph runners. RMSNorm racecheck and synccheck report no errors.
+Graph-runner initcheck also reports no errors.
+
+The [single-decode record](../results/h20-bf16-single-decode-correctness-20260803.json)
+qualifies the narrow attention slice. Its largest output absolute error is
+`7.629394531e-6`; its largest log2-LSE error is `1.907348633e-6`. All four
+Compute Sanitizer tools report zero errors.
 
 Fixed Rust-kernel argument packs and performance gates remain open.

--- a/docs/flashinfer-parity.md
+++ b/docs/flashinfer-parity.md
@@ -31,7 +31,7 @@ No complete domain-level parity is currently claimed.
 
 | Domain | Representative v0.6.16 surface | Loom state |
 | --- | --- | --- |
-| Dense decode attention | [`single_decode_with_kv_cache`, `BatchDecodeWithPagedKVCacheWrapper`, `xqa`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `planned`; no attention provider |
+| Dense decode attention | [`single_decode_with_kv_cache`, `BatchDecodeWithPagedKVCacheWrapper`, `xqa`](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `partial device correct`; BF16 single-request NHD D128 MHA/MQA/GQA only |
 | Prefill and append attention | [`single_prefill_with_kv_cache`, paged and ragged batch prefill](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `planned`; no attention provider |
 | Mixed-batch attention | [`BatchAttention`, attention-sink wrapper](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `unscoped` |
 | MLA attention | [`BatchMLAPagedAttentionWrapper`, XQA and TRT-LLM MLA decode](https://github.com/flashinfer-ai/flashinfer/blob/v0.6.16/docs/api/attention.rst) | `unscoped` |
@@ -69,8 +69,13 @@ No complete domain-level parity is currently claimed.
 
 The first admitted attention contract is a BF16 SM90 single-request decode
 slice: NHD layout, head dimension 128, MHA/GQA, full window, no positional
-encoding or soft cap, F32 score/softmax accumulation, BF16 output, and F32 LSE.
-It isolates head mapping, online softmax, numerical stability, and tail handling.
+encoding or soft cap, F32 score/softmax accumulation, BF16 output, and F32
+log2-LSE. It covers head mapping, online softmax, numerical stability, and
+non-power-of-two KV lengths.
+
+The
+[H20 result](results/h20-bf16-single-decode-correctness-20260803.json) is a
+Loom GPU versus CPU-oracle gate. It contains no matched FlashInfer run.
 
 The next contract adds BF16 paged batch decode with head dimension 128, page
 size 16, GQA, split-K state merge, and fixed-address CUDA Graph replay. Only

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -20,17 +20,18 @@ tracks the pinned upstream comparison.
 | RMSNorm F32 | Rust / cuda-oxide | device correct | Owned bindings pass H20 correctness and sanitizer gates |
 | RMSNorm FP16 and BF16 | Rust / cuda-oxide | device correct | Scalar and packed paths pass H20 correctness and sanitizer gates |
 | BF16 dense GEMM | cuBLASLt | device correct | Fixed `D=A×Wᵀ` plan and Graph chain pass H20 correctness and sanitizer gates |
+| BF16 single decode | Rust / cuda-oxide | device correct | NHD D128 MHA/MQA/GQA slice passes H20 correctness and sanitizer gates |
 
 No permanent GPU provider has a published performance result yet. The
-[owned-binding and Graph record](results/h20-owned-bindings-cuda-graph-correctness-20260803.json)
-contains its accepted and excluded claims.
+[attention record](results/h20-bf16-single-decode-correctness-20260803.json)
+contains the latest accepted and excluded claims.
 
 ## Target surface
 
 | Family | Operators | Provider | State |
 | --- | --- | --- | --- |
 | Normalization | RMSNorm, Add+RMSNorm, quantized output | Rust / cuda-oxide | planned |
-| Attention | Ragged prefill, paged decode, split-K, state merge | Rust / cuda-oxide | planned |
+| Attention | Single decode, ragged prefill, paged decode, split-K, state merge | Rust / cuda-oxide | in progress |
 | KV cache | RoPE append, gather, scatter, compaction, quantized storage | Rust / cuda-oxide | planned |
 | Decode tail | Logits processing, penalties, top-k, top-p, Min-P, logprobs, sampling | Rust / cuda-oxide | planned |
 | Speculation | Greedy, stochastic, and tree verification | Rust / cuda-oxide | planned |
@@ -44,6 +45,9 @@ contains its accepted and excluded claims.
 Attention implementations compare against pinned FlashAttention, FlashInfer,
 and engine providers when contracts match. The comparison must keep shapes,
 dtypes, layouts, masks, workspaces, streams, and graph mode equal.
+
+The current single-decode record is a Loom GPU versus CPU-oracle correctness
+gate. It contains no matched FlashInfer performance result.
 
 ## Admission
 

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -5,8 +5,20 @@ providers.
 
 ## Results
 
-The 2026-08-03 record qualifies the current owned-binding and fixed-address
-Graph source projection. Earlier records remain immutable historical results.
+Two 2026-08-03 records qualify the current source projection. One records the
+new attention contract. The other reruns every provider affected by the shared
+command resolver change. Earlier records remain immutable historical results.
+
+- [Shared command-resolution H20 regression](h20-shared-command-regression-20260803.json):
+  RMSNorm, BF16 GEMM, the fixed-address Graph, and BF16 single decode pass on
+  one source projection. The declared Compute Sanitizer matrix reports no
+  errors or device leaks.
+
+- [BF16 single-decode attention H20 correctness](h20-bf16-single-decode-correctness-20260803.json):
+  BF16 NHD D128 MHA, MQA, and GQA cases pass against the CPU reference.
+  Exact-span and duplicate-binding checks reject invalid launches. Compute
+  Sanitizer reports no errors or device leaks. The record contains no
+  performance measurement.
 
 - [Owned bindings and CUDA Graph H20 result](h20-owned-bindings-cuda-graph-correctness-20260803.json):
   RMSNorm and BF16 GEMM correctness pass. The final output after two fixed-address

--- a/docs/results/h20-bf16-single-decode-correctness-20260803.json
+++ b/docs/results/h20-bf16-single-decode-correctness-20260803.json
@@ -1,0 +1,208 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-03",
+  "claim_level": "correctness",
+  "operator": "bf16_single_decode_attention",
+  "status": "passed",
+  "source": {
+    "git_base_revision": "9f59a3f2bebcdab518e9906c135b649023068c84",
+    "branch": "agent/single-decode-attention",
+    "worktree": "uncommitted BF16 single-decode attention slice",
+    "projection": "SHA-256 of the sorted per-file SHA-256 list for Cargo manifests, Cargo.lock, rust-toolchain.toml, and Rust source files",
+    "projection_sha256": "97feead67a0dbb9a934997827017f69531cf4fc3dc7288234eeab023d94eeddd",
+    "cargo_lock_sha256": "8c014680dac69c81c5d72980ff47a27e8a7755462ff5f4b301a63bbf78202460",
+    "local_remote_projection_match": true
+  },
+  "environment": {
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "compute_capability": "9.0",
+    "driver": "535.161.08",
+    "cuda": "13.1.115",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "llvm_codegen": "22.1.2-rust-1.96.0-nightly",
+    "bindgen_libclang": "21.1.8",
+    "cargo_oxide": "0.2.1",
+    "cuda_oxide_revision": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+    "compute_sanitizer": "2025.4.1.0",
+    "compute_sanitizer_package": "cuda-sanitizer-13-1_13.1.118-1_amd64.deb",
+    "compute_sanitizer_package_source": "https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-sanitizer-13-1_13.1.118-1_amd64.deb",
+    "compute_sanitizer_package_sha256": "df6ae87fce601f2ac09f19a2989cd23f5f86ada6a6c6686f4c79eee8a909dd36"
+  },
+  "contract": {
+    "query": "contiguous BF16 [query_heads, 128]",
+    "key": "contiguous BF16 [kv_len, kv_heads, 128] in NHD order",
+    "value": "contiguous BF16 [kv_len, kv_heads, 128] in NHD order",
+    "output": "contiguous BF16 [query_heads, 128]",
+    "lse": "contiguous F32 [query_heads] in log2 domain",
+    "head_mapping": "query_heads is divisible by kv_heads; kv_head = query_head / (query_heads / kv_heads)",
+    "softmax_scale": "1 / sqrt(128)",
+    "window": "full KV sequence",
+    "position_encoding": "none",
+    "soft_cap": "none",
+    "arithmetic": "F32 dot product, online softmax state, normalization, and output accumulation; BF16 nearest-even output conversion",
+    "kernel": "one 32-thread warp per query head with packed BF16x2 Q/K/V/O access",
+    "launch_target": "minimum compute capability 9.0; qualified only on H20 SM90"
+  },
+  "flashinfer_reference": {
+    "version": "v0.6.16",
+    "commit": "8da13a29c85f7e5b1c81878d933f84ae9fc4afa9",
+    "api": "single_decode_with_kv_cache",
+    "contract_source": "https://raw.githubusercontent.com/flashinfer-ai/flashinfer/v0.6.16/flashinfer/decode.py",
+    "kernel_source": "https://raw.githubusercontent.com/flashinfer-ai/flashinfer/v0.6.16/include/flashinfer/attention/decode.cuh",
+    "state_source": "https://raw.githubusercontent.com/flashinfer-ai/flashinfer/v0.6.16/include/flashinfer/attention/state.cuh",
+    "differential_executed": false
+  },
+  "correctness": {
+    "oracle": "loom-infer CPU reference with natural exp and ln, converted to FlashInfer-compatible log2 LSE",
+    "output_max_abs_limit": 0.015625,
+    "lse_max_abs_limit": 0.01,
+    "output_initialized_with_nan_sentinel": true,
+    "lse_initialized_with_nan_sentinel": true,
+    "cases": [
+      {
+        "name": "mha_l1",
+        "kv_len": 1,
+        "query_heads": 8,
+        "kv_heads": 8,
+        "group_size": 1,
+        "output_max_abs": 0.0,
+        "output_bit_mismatches": 0,
+        "output_digest": "7e223f2cc0d3c4d0",
+        "lse_max_abs": 1.490116119e-8,
+        "lse_bit_mismatches": 5,
+        "lse_digest": "b1c9c541604317f6"
+      },
+      {
+        "name": "mqa_l33",
+        "kv_len": 33,
+        "query_heads": 8,
+        "kv_heads": 1,
+        "group_size": 8,
+        "output_max_abs": 0.0,
+        "output_bit_mismatches": 0,
+        "output_digest": "fb25c494a5dcb812",
+        "lse_max_abs": 9.536743164e-7,
+        "lse_bit_mismatches": 2,
+        "lse_digest": "86d5e4150fc67cff"
+      },
+      {
+        "name": "gqa4_l127",
+        "kv_len": 127,
+        "query_heads": 16,
+        "kv_heads": 4,
+        "group_size": 4,
+        "output_max_abs": 0.0,
+        "output_bit_mismatches": 0,
+        "output_digest": "de07b51473f43abb",
+        "lse_max_abs": 4.768371582e-7,
+        "lse_bit_mismatches": 9,
+        "lse_digest": "49c508de7f28053a"
+      },
+      {
+        "name": "gqa8_l4096",
+        "kv_len": 4096,
+        "query_heads": 32,
+        "kv_heads": 4,
+        "group_size": 8,
+        "output_max_abs": 7.629394531e-6,
+        "output_bit_mismatches": 4,
+        "output_digest": "59def3b740db6e9d",
+        "lse_max_abs": 1.907348633e-6,
+        "lse_bit_mismatches": 19,
+        "lse_digest": "b2065261cd306708"
+      },
+      {
+        "name": "large_logits_l3",
+        "kv_len": 3,
+        "query_heads": 1,
+        "kv_heads": 1,
+        "group_size": 1,
+        "output_max_abs": 0.0,
+        "output_bit_mismatches": 0,
+        "output_digest": "8b4299097885ed25",
+        "lse_max_abs": 0.0,
+        "lse_bit_mismatches": 0,
+        "lse_digest": "2df163b86a0c68f1"
+      }
+    ],
+    "short_buffers_rejected_before_cuda_submission": [
+      "query",
+      "key",
+      "value",
+      "output",
+      "lse"
+    ],
+    "duplicate_binding_rejected_before_cuda_submission": true,
+    "release_tests": {
+      "loom_infer": 15,
+      "loom_infer_cuda": 5,
+      "failed": 0
+    }
+  },
+  "compute_sanitizer": {
+    "memcheck": {
+      "errors": 0,
+      "leaked_bytes": 0,
+      "leaked_allocations": 0
+    },
+    "racecheck": {
+      "errors": 0,
+      "warnings": 0,
+      "hazards_displayed": 0
+    },
+    "synccheck_errors": 0,
+    "initcheck_errors": 0
+  },
+  "device_artifact": {
+    "ptx_target": "sm_90",
+    "ptx_sha256": "161760b9bccbd17d8b173f23be21d3258978fe47466ae8131d10e38bd8539c14",
+    "ptx_size_bytes": 33172,
+    "cubin_sha256": "98c192bd10711f7f8b440b1f4f92d0d4de5f97b0ca7913168b0480489b3bf54f",
+    "cubin_size_bytes": 65808,
+    "single_decode_registers": 37,
+    "single_decode_spill_stores_bytes": 0,
+    "single_decode_spill_loads_bytes": 0,
+    "single_decode_barriers": 0,
+    "ptx_features_checked": [
+      ".reqntid 32, 1, 1",
+      "packed 32-bit global loads and stores",
+      "warp shuffle reduction",
+      "ex2.approx.f32",
+      "lg2.approx.f32",
+      "cvt.rn.bf16x2.f32"
+    ],
+    "ptxas": "passed with CUDA 13.1 and -arch=sm_90"
+  },
+  "commands": [
+    "cargo fmt --all -- --check",
+    "cargo clippy --workspace --all-targets --features cuda -- -D warnings",
+    "cargo oxide test --arch sm_90 -- --workspace --features cuda --release",
+    "cargo oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch sm_90",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool racecheck --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool synccheck --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool initcheck --error-exitcode 99 target/release/single_decode_h20",
+    "ptxas -v -arch=sm_90 loom_infer_cuda.ptx -o single_decode_sm90_20260803.cubin"
+  ],
+  "accepted_claims": [
+    "the permanent Rust BF16 single-request NHD decode provider passes the declared H20 correctness cases against the Loom CPU reference",
+    "the declared cases cover MHA, MQA, GQA, non-power-of-two KV lengths, a 4096-token KV sequence, and large finite logits",
+    "NaN output sentinels confirm that each declared case writes finite output and log2-LSE values",
+    "all five exact-span failures and one duplicate binding fail before CUDA submission",
+    "memcheck, racecheck, synccheck, and initcheck report no errors for the declared runner",
+    "the generated PTX targets sm_90 and assembles without spills through CUDA 13.1 ptxas"
+  ],
+  "excluded_claims": [
+    "complete FlashInfer or FlashAttention parity",
+    "a matched FlashInfer differential result",
+    "attention performance or a speedup over any provider",
+    "paged or batched decode, prefill, split-K, state merge, or attention cascade",
+    "HND layout, variable head dimensions, FP16 attention, FP8 attention, RoPE, ALiBi, sliding windows, soft caps, or custom scales",
+    "attention CUDA Graph capture or replay",
+    "SM80, Blackwell, or any GPU other than the validated H20",
+    "real-model, engine, distributed, or serving integration",
+    "bit-exact output or LSE across the complete admitted contract"
+  ]
+}

--- a/docs/results/h20-shared-command-regression-20260803.json
+++ b/docs/results/h20-shared-command-regression-20260803.json
@@ -1,0 +1,168 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-03",
+  "claim_level": "graph",
+  "operator": "shared_command_resolution_regression",
+  "status": "passed",
+  "source": {
+    "git_base_revision": "9f59a3f2bebcdab518e9906c135b649023068c84",
+    "branch": "agent/single-decode-attention",
+    "worktree": "uncommitted BF16 single-decode attention and shared resolver revision",
+    "projection": "SHA-256 of the sorted per-file SHA-256 list for Cargo manifests, Cargo.lock, rust-toolchain.toml, and Rust source files",
+    "projection_sha256": "97feead67a0dbb9a934997827017f69531cf4fc3dc7288234eeab023d94eeddd",
+    "cargo_lock_sha256": "8c014680dac69c81c5d72980ff47a27e8a7755462ff5f4b301a63bbf78202460",
+    "local_remote_projection_match": true
+  },
+  "environment": {
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "compute_capability": "9.0",
+    "driver": "535.161.08",
+    "cuda": "13.1.115",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "llvm_codegen": "22.1.2-rust-1.96.0-nightly",
+    "bindgen_libclang": "21.1.8",
+    "cargo_oxide": "0.2.1",
+    "cuda_oxide_revision": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+    "compute_sanitizer": "2025.4.1.0"
+  },
+  "change_scope": {
+    "shared_validation": "binding-set, duplicate-slot, and slot-range checks now use one internal validator",
+    "resolved_patterns": [
+      "two reads and one write",
+      "two reads and two writes",
+      "three reads and two writes"
+    ],
+    "execution_policy": "typed bindings, one caller-owned stream, one command scope, and one final completion event",
+    "fallback": "none"
+  },
+  "regression": {
+    "release_tests": {
+      "loom_infer": 15,
+      "loom_infer_cuda": 5,
+      "failed": 0
+    },
+    "rms_norm": {
+      "runner": "rms_norm_h20",
+      "status": "passed",
+      "f32_single_launch_max_abs": 4.768371582e-7,
+      "f32_chain_max_abs": 7.152557373e-7,
+      "f16_single_launch_max_abs": 0.001953125,
+      "f16_chain_max_abs": 0.00390625,
+      "f16_chain_max_ulp": 2,
+      "bf16_single_launch_max_abs": 0.0,
+      "bf16_chain_max_abs": 0.000244140625,
+      "bf16_chain_max_ulp": 1,
+      "short_buffers_rejected": true,
+      "queue_reuse_passed": true,
+      "chained_commands_passed": true
+    },
+    "bf16_gemm": {
+      "runner": "bf16_gemm_h20",
+      "status": "passed",
+      "standalone_bit_mismatches": 0,
+      "transpose_sensitive_bit_mismatches": 0,
+      "rms_norm_gemm_chain_bit_mismatches": 0,
+      "short_buffers_rejected": true,
+      "command_capacity_rejected_before_ffi": true
+    },
+    "fixed_address_cuda_graph": {
+      "runner": "bf16_gemm_h20",
+      "status": "passed",
+      "chain": "BF16 RMSNorm (1,4096) to BF16 cuBLASLt GEMM (1,4096,4096)",
+      "commands": 2,
+      "replays": 2,
+      "fixed_bindings": true,
+      "external_owners_dropped_before_replay": true,
+      "completion_queries": 2,
+      "completion_waits": 1,
+      "completion_drops": 1,
+      "intra_graph_host_waits": 0,
+      "inter_replay_host_waits": 1,
+      "final_bit_mismatches": 0,
+      "final_max_abs": 0.0,
+      "final_output_digest": "9c7c07b655452325"
+    },
+    "bf16_single_decode_attention": {
+      "runner": "single_decode_h20",
+      "status": "passed",
+      "cases": [
+        "mha_l1",
+        "mqa_l33",
+        "gqa4_l127",
+        "gqa8_l4096",
+        "large_logits_l3"
+      ],
+      "max_output_abs": 7.629394531e-6,
+      "max_log2_lse_abs": 1.907348633e-6,
+      "short_buffers_rejected_before_cuda_submission": true,
+      "duplicate_binding_rejected_before_cuda_submission": true
+    }
+  },
+  "compute_sanitizer": {
+    "rms_norm": {
+      "memcheck_errors": 0,
+      "memcheck_leaked_bytes": 0,
+      "memcheck_leaked_allocations": 0,
+      "racecheck_errors": 0,
+      "racecheck_warnings": 0,
+      "synccheck_errors": 0
+    },
+    "bf16_gemm_and_graph": {
+      "memcheck_errors": 0,
+      "memcheck_leaked_bytes": 0,
+      "memcheck_leaked_allocations": 0,
+      "initcheck_errors": 0
+    },
+    "bf16_single_decode_attention": {
+      "memcheck_errors": 0,
+      "memcheck_leaked_bytes": 0,
+      "memcheck_leaked_allocations": 0,
+      "racecheck_errors": 0,
+      "racecheck_warnings": 0,
+      "synccheck_errors": 0,
+      "initcheck_errors": 0
+    }
+  },
+  "device_artifact": {
+    "ptx_target": "sm_90",
+    "ptx_sha256": "161760b9bccbd17d8b173f23be21d3258978fe47466ae8131d10e38bd8539c14",
+    "cubin_sha256": "98c192bd10711f7f8b440b1f4f92d0d4de5f97b0ca7913168b0480489b3bf54f",
+    "cubin_size_bytes": 65808,
+    "ptxas": "passed with CUDA 13.1 and -arch=sm_90"
+  },
+  "commands": [
+    "cargo fmt --all -- --check",
+    "cargo clippy --workspace --all-targets --features cuda -- -D warnings",
+    "cargo oxide test --arch sm_90 -- --workspace --features cuda --release",
+    "cargo oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch sm_90",
+    "cargo oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch sm_90",
+    "cargo oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch sm_90",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool racecheck --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool synccheck --error-exitcode 99 target/release/rms_norm_h20",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/bf16_gemm_h20",
+    "compute-sanitizer --tool initcheck --error-exitcode 99 target/release/bf16_gemm_h20",
+    "compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool racecheck --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool synccheck --error-exitcode 99 target/release/single_decode_h20",
+    "compute-sanitizer --tool initcheck --error-exitcode 99 target/release/single_decode_h20",
+    "ptxas -v -arch=sm_90 loom_infer_cuda.ptx -o single_decode_sm90_20260803.cubin"
+  ],
+  "accepted_claims": [
+    "the shared two-read and one-write resolver passes the declared RMSNorm H20 regression",
+    "the shared two-read and two-write resolver passes the declared BF16 GEMM and fixed-address Graph H20 regression",
+    "the new three-read and two-write resolver passes the declared BF16 single-decode attention H20 regression",
+    "the three H20 runners preserve their recorded correctness, lifecycle, and fixed-address Graph results on this source projection",
+    "the declared Compute Sanitizer matrix reports no errors or device leaks on this source projection"
+  ],
+  "excluded_claims": [
+    "operator or CUDA Graph performance",
+    "comparison with a named performance baseline",
+    "complete FlashInfer or FlashAttention parity",
+    "attention CUDA Graph capture or replay",
+    "fault-injected CUDA driver, stream, event, context, graph, or cuBLASLt failures",
+    "real-model, engine, distributed, or serving integration"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,8 +67,11 @@ reports no errors or device leaks on H20. See the
 
 ## 4. Attention core
 
-**State:** next.
+**State:** active. The first narrow single-decode contract passed its H20
+correctness and sanitizer gates.
 
+- retain the BF16 NHD D128 single-request MHA/MQA/GQA correctness baseline.
+- measure the baseline against the pinned FlashInfer contract.
 - implement ragged prefill and paged MQA/GQA decode.
 - add split-K execution and stable state merge.
 - support common causal and sliding-window contracts.
@@ -77,6 +80,10 @@ reports no errors or device leaks on H20. See the
 
 Exit: a real model invokes Loom attention without tensor copies and preserves
 tokens or declared numerical quality.
+
+The first slice also rejects five short buffers and duplicate bindings before
+CUDA submission. Performance, Graph replay, paged batching, split-K, and real
+model invocation remain open.
 
 ## 5. Decode and KV operations
 

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -14,8 +14,8 @@ export const operatorFamilies = [
   },
   {
     name: "Attention",
-    boundary: "Ragged prefill, paged decode, split-K, and state merge.",
-    state: "Planned",
+    boundary: "Single decode baseline, then paged decode, split-K, and state merge.",
+    state: "Partial device correct",
   },
   {
     name: "Decode tail",
@@ -53,6 +53,6 @@ export const milestones = [
   {
     milestone: "03",
     name: "Attention core",
-    reason: "Implement ragged prefill and paged decode against matched providers.",
+    reason: "Single decode passes H20 correctness. Matched performance and paged decode remain open.",
   },
 ]

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -49,7 +49,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-targets</code></pre>
       <p>
         The <a href={`${repositoryUrl}/blob/main/docs/results/README.md`}>evidence index</a>
-        contains the RMSNorm and fixed BF16 cuBLASLt correctness results.
+        contains the RMSNorm, BF16 GEMM, CUDA Graph, and single-decode results.
       </p>
     </article>
   </div>

--- a/website/src/pages/docs/operators.astro
+++ b/website/src/pages/docs/operators.astro
@@ -12,7 +12,7 @@ import { milestones, operatorFamilies, repositoryUrl } from "../../data/site";
   <header class="page-hero">
     <p class="eyebrow">Operators</p>
     <h1>One lifecycle for every operator.</h1>
-    <p>The current H20 record covers Rust RMSNorm, one fixed BF16 cuBLASLt plan, and their fixed-address Graph chain.</p>
+    <p>The current H20 records also cover a narrow BF16 single-decode attention contract.</p>
   </header>
 
   <div class="docs-layout">

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -20,9 +20,30 @@ import { repositoryUrl } from "../data/site";
     <article class="prose">
       <h2>Current source projection</h2>
       <p>
-        The 2026-08-03 record qualifies the owned-binding and fixed-address
-        CUDA Graph source projection.
+        The latest 2026-08-03 record qualifies the BF16 single-decode
+        attention source projection.
       </p>
+      <div class="doc-note">
+        <strong>BF16 single decode passed its declared H20 correctness gate.</strong>
+        <p>
+          NHD D128 MHA, MQA, and GQA cases match the CPU reference within the
+          declared limits. Invalid spans and duplicate bindings fail before
+          submission. Four sanitizer tools report no errors. Performance is
+          not measured.
+        </p>
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-bf16-single-decode-correctness-20260803.json`}>
+          Attention machine-readable result
+        </a>
+        <p>
+          The shared command regression reruns RMSNorm, BF16 GEMM, their
+          fixed-address Graph, and single decode on the same source projection.
+        </p>
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-shared-command-regression-20260803.json`}>
+          Shared command regression
+        </a>
+      </div>
+
+      <h2>Earlier operator records</h2>
       <div class="doc-note">
         <strong>Owned bindings and fixed-address Graph replay passed on H20.</strong>
         <p>
@@ -32,11 +53,9 @@ import { repositoryUrl } from "../data/site";
           measured.
         </p>
         <a href={`${repositoryUrl}/blob/main/docs/results/h20-owned-bindings-cuda-graph-correctness-20260803.json`}>
-          Current machine-readable result
+          Graph machine-readable result
         </a>
       </div>
-
-      <h2>Earlier operator records</h2>
       <div class="doc-note">
         <strong>F32 RMSNorm passed its recorded H20 correctness gate.</strong>
         <p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -41,7 +41,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   </section>
 
   <section class="metrics-strip" aria-label="Project status">
-    <div class="metric"><strong>2</strong><span>qualified device slices</span></div>
+    <div class="metric"><strong>3</strong><span>qualified device slices</span></div>
     <div class="metric"><strong>SM90</strong><span>first target</span></div>
     <div class="metric"><strong>Rust</strong><span>host and device source</span></div>
     <div class="metric"><strong>Pending</strong><span>performance evidence</span></div>
@@ -115,12 +115,17 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       <p>The fixed plan and RMSNorm-to-GEMM Graph pass correctness.</p>
       <small>The final output after two replays is bit-exact. Memcheck reports no errors or leaks.</small>
     </article>
+    <article class="evidence-card">
+      <h3>BF16 single decode on H20</h3><span class="result">Qualified</span>
+      <p>The NHD D128 MHA, MQA, and GQA cases pass the CPU-oracle gate.</p>
+      <small>Four sanitizer tools report no errors. Performance is not measured.</small>
+    </article>
   </section>
 
   <section class="section">
     <header class="section-header">
-      <div><p class="eyebrow">Next</p><h2>Build the attention core</h2></div>
-      <p>Use the qualified lifecycle for single decode, then add paged batch decode.</p>
+      <div><p class="eyebrow">Next</p><h2>Measure and extend attention</h2></div>
+      <p>Compare single decode with FlashInfer, then add paged batch decode.</p>
     </header>
     <div class="roadmap-grid">
       {milestones.map((item) => (


### PR DESCRIPTION
Adds the first BF16 single-request decode contract, CPU reference, and cuda-oxide provider. The fixed slice uses NHD caches, head dimension 128, MHA/MQA/GQA mapping, F32 online softmax, BF16 output, and F32 log2-LSE.

The H20 gate covers MHA, MQA, GQA, long KV, large logits, exact spans, duplicate binding slots, PTX assembly, and Compute Sanitizer. The shared command resolver regression also reruns RMSNorm, BF16 GEMM, and fixed-address Graph replay. This PR makes no attention performance, paged-batch, engine, or serving claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BF16 single-request decode attention for NHD head dimension 128, supporting MHA, MQA, and GQA.
  * Added CPU reference computation and CUDA execution with BF16 outputs and F32 log-sum-exp results.
  * Added H20 validation covering correctness, numerical stability, buffer validation, and sanitizer checks.

* **Documentation**
  * Updated operator documentation, roadmap, parity status, and website evidence to reflect the new attention capability and its current scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->