### PR TITLE
Prepare H20 requalification and restore site identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,27 @@ SHELL := /bin/bash
 CUDA_CRATE := crates/oxide-infer-cuda
 VALIDATION_CRATE := crates/oxide-infer-lab
 CUDA_ARCH ?= sm_90
+override H20_ARCH := sm_90a
+H20_RUNNER ?=
+H20_RUNNER_SHA256 ?=
+H20_RUNNERS := rms_norm_h20 bf16_gemm_h20 oxide_sm90_simt_gemv_h20 \
+	single_decode_h20 paged_batch_decode_h20 ragged_prefill_h20 \
+	paged_prefill_h20 rope_h20 engine_interop_h20
+override H20_TARGET_DIR := $(CURDIR)/target
+override H20_BINARY = $(H20_TARGET_DIR)/release/$(H20_RUNNER)
+override COMPUTE_SANITIZER := compute-sanitizer
+override SHA256SUM := sha256sum
 PACKAGE_FLAGS ?= --allow-dirty
 OXIDE_SOURCE_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
+USE_MISE ?= 0
+ifeq ($(USE_MISE),1)
 MISE := $(shell command -v mise 2>/dev/null)
-ifneq ($(MISE),)
+ifeq ($(MISE),)
+$(error USE_MISE=1 requires mise on PATH)
+endif
 RUN := $(MISE) exec --
+else ifneq ($(USE_MISE),0)
+$(error USE_MISE must be 0 or 1)
 endif
 ifneq ($(OXIDE_CARGO_HOME),)
 CARGO_ENV := CARGO_HOME=$(OXIDE_CARGO_HOME)
@@ -19,6 +35,7 @@ NPM := $(RUN) npm --prefix website
 .PHONY: help check check-rust check-tools check-website install-website cuda-doctor \
 	cuda-check cuda-test h20-rms-norm h20-gemm h20-oxide-gemm h20-attention h20-paged-attention \
 	h20-ragged-prefill h20-paged-prefill h20-rope h20-engine-interop h20 \
+	h20-runner-preflight h20-build-runner h20-sanitize-runner \
 	bench-oxide bench-paged-oxide bench-ragged-oxide \
 	bench-paged-prefill-oxide bench-paged-prefill-graph-oxide bench-ragged-graph-oxide \
 	bench-rope-oxide bench-rope-append-oxide \
@@ -30,8 +47,10 @@ help:
 		'make check-tools    Check Python evidence tools' \
 		'make cuda-doctor    Check the pinned cuda-oxide environment' \
 		'make cuda-check     Run CUDA-feature Clippy' \
-		'make cuda-test      Run release tests through cuda-oxide' \
-		'make h20            Run all H20 correctness programs sequentially' \
+		'make cuda-test      Run generic release tests; CUDA_ARCH selects the target' \
+		'make h20            Run all H20 correctness programs for fixed sm_90a' \
+		'make h20-build-runner H20_RUNNER=<name>  Build and hash one permanent runner' \
+		'make h20-sanitize-runner H20_RUNNER=<name> H20_RUNNER_SHA256=<sha256>  Sanitize the exact built binary' \
 		'make h20-oxide-gemm  Validate the experimental Oxide SM90a M=1 GEMV' \
 		'make h20-engine-interop  Validate single and paged external-stream interop' \
 		'make h20-paged-attention  Run paged batch-decode H20 correctness' \
@@ -48,7 +67,8 @@ help:
 		'make bench-rope-append-oxide  Run Oxide fused RoPE paged append case' \
 		'make bench-rope-append-tokens-oxide  Run Oxide explicit multi-token RoPE append case' \
 		'make bench-rope-append-tokens-graph-oxide  Run Oxide multi-token RoPE append Graph case' \
-		'make bench-split-k  Sweep Oxide split-K choices on H20'
+		'make bench-split-k  Sweep Oxide split-K choices on H20' \
+		'USE_MISE=1 make <target>  Run a target through the trusted mise environment'
 
 check: check-rust check-tools check-website
 
@@ -83,63 +103,101 @@ cuda-test:
 	cd $(VALIDATION_CRATE) && CARGO_BUILD_JOBS=1 $(CARGO) +nightly-2026-04-03 oxide test --arch $(CUDA_ARCH) -- --workspace --features cuda --release
 
 h20-rms-norm:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run rms_norm_h20 --bin rms_norm_h20 --features cuda --arch $(H20_ARCH)
 
 h20-gemm:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run bf16_gemm_h20 --bin bf16_gemm_h20 --features cuda --arch $(H20_ARCH)
 
 h20-oxide-gemm:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run oxide_sm90_simt_gemv_h20 --bin oxide_sm90_simt_gemv_h20 --features cuda --arch sm_90a
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run oxide_sm90_simt_gemv_h20 --bin oxide_sm90_simt_gemv_h20 --features cuda --arch $(H20_ARCH)
 
 h20-attention:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run single_decode_h20 --bin single_decode_h20 --features cuda --arch $(H20_ARCH)
 
 h20-paged-attention:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run paged_batch_decode_h20 --bin paged_batch_decode_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run paged_batch_decode_h20 --bin paged_batch_decode_h20 --features cuda --arch $(H20_ARCH)
 
 h20-ragged-prefill:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run ragged_prefill_h20 --bin ragged_prefill_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run ragged_prefill_h20 --bin ragged_prefill_h20 --features cuda --arch $(H20_ARCH)
 
 h20-paged-prefill:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run paged_prefill_h20 --bin paged_prefill_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run paged_prefill_h20 --bin paged_prefill_h20 --features cuda --arch $(H20_ARCH)
 
 h20-rope:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run rope_h20 --bin rope_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run rope_h20 --bin rope_h20 --features cuda --arch $(H20_ARCH)
 
 h20-engine-interop:
-	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run engine_interop_h20 --bin engine_interop_h20 --features cuda --arch $(CUDA_ARCH)
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide run engine_interop_h20 --bin engine_interop_h20 --features cuda --arch $(H20_ARCH)
 
 h20: h20-rms-norm h20-gemm h20-oxide-gemm h20-attention h20-paged-attention h20-ragged-prefill h20-paged-prefill h20-rope h20-engine-interop
 
+h20-runner-preflight:
+	@case " $(H20_RUNNERS) " in \
+		*" $(H20_RUNNER) "*) ;; \
+		*) printf 'H20_RUNNER must be one of: %s\n' "$(H20_RUNNERS)" >&2; exit 2 ;; \
+	esac
+
+h20-build-runner: h20-runner-preflight
+	cd $(VALIDATION_CRATE) && $(CARGO) +nightly-2026-04-03 oxide build --lineinfo --arch $(H20_ARCH) --cargo-target-dir "$(H20_TARGET_DIR)" -- --package oxide-infer-lab --bin $(H20_RUNNER) --features cuda --release
+	@set -eu; \
+		command -v "$(SHA256SUM)" >/dev/null || { echo 'sha256sum is required' >&2; exit 2; }; \
+		artifact_hash="$$($(SHA256SUM) "$(H20_BINARY)" | awk '{print $$1}')"; \
+		printf 'runner_binary=%s sha256=%s arch=%s\n' "$(H20_BINARY)" "$$artifact_hash" "$(H20_ARCH)"
+
+h20-sanitize-runner: h20-runner-preflight
+	@set -eu; \
+		expected_hash="$(H20_RUNNER_SHA256)"; \
+		[[ "$$expected_hash" =~ ^[0-9a-f]{64}$$ ]] || { echo 'H20_RUNNER_SHA256 must be the 64-character lowercase SHA-256 printed by h20-build-runner' >&2; exit 2; }; \
+		command -v "$(COMPUTE_SANITIZER)" >/dev/null || { echo 'compute-sanitizer is required' >&2; exit 2; }; \
+		command -v "$(SHA256SUM)" >/dev/null || { echo 'sha256sum is required' >&2; exit 2; }; \
+		binary="$(H20_BINARY)"; \
+		test -x "$$binary" || { printf 'missing runner binary: %s; run make h20-build-runner H20_RUNNER=%s first\n' "$$binary" "$(H20_RUNNER)" >&2; exit 2; }; \
+		read_hash() { "$(SHA256SUM)" "$$binary" | awk '{print $$1}'; }; \
+		artifact_hash="$$(read_hash)"; \
+		test "$$artifact_hash" = "$$expected_hash" || { printf 'runner hash does not match build output: expected=%s actual=%s\n' "$$expected_hash" "$$artifact_hash" >&2; exit 2; }; \
+		printf 'sanitizer_binary=%s sha256=%s arch=%s\n' "$$binary" "$$artifact_hash" "$(H20_ARCH)"; \
+		for tool in memcheck racecheck synccheck initcheck; do \
+			current_hash="$$(read_hash)"; \
+			test "$$current_hash" = "$$artifact_hash" || { printf 'runner hash changed before %s: expected=%s actual=%s\n' "$$tool" "$$artifact_hash" "$$current_hash" >&2; exit 2; }; \
+			if test "$$tool" = memcheck; then \
+				"$(COMPUTE_SANITIZER)" --tool "$$tool" --leak-check full --error-exitcode 99 "$$binary"; \
+			else \
+				"$(COMPUTE_SANITIZER)" --tool "$$tool" --error-exitcode 99 "$$binary"; \
+			fi; \
+			current_hash="$$(read_hash)"; \
+			test "$$current_hash" = "$$artifact_hash" || { printf 'runner hash changed after %s: expected=%s actual=%s\n' "$$tool" "$$artifact_hash" "$$current_hash" >&2; exit 2; }; \
+		done; \
+		printf 'sanitizer_status=pass binary=%s sha256=%s tools=memcheck,racecheck,synccheck,initcheck\n' "$$binary" "$$artifact_hash"
+
 bench-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-paged-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=paged_batch_decode OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=paged_batch_decode OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-ragged-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=ragged_prefill OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=ragged_prefill OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-paged-prefill-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=paged_prefill OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=paged_prefill OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-paged-prefill-graph-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run paged_prefill_graph_bench_h20 --bin paged_prefill_graph_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run paged_prefill_graph_bench_h20 --bin paged_prefill_graph_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-ragged-graph-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run ragged_graph_bench_h20 --bin ragged_graph_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run ragged_graph_bench_h20 --bin ragged_graph_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-rope-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-rope-append-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope_paged_kv_append OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope_paged_kv_append OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-rope-append-tokens-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope_paged_kv_append_tokens OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=rope_paged_kv_append_tokens OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-rope-append-tokens-graph-oxide:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run rope_append_graph_bench_h20 --bin rope_append_graph_bench_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run rope_append_graph_bench_h20 --bin rope_append_graph_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-split-k:
-	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" OXIDE_SOURCE_STATE=working_tree $(CARGO) +nightly-2026-04-03 oxide run split_k_sweep_h20 --bin split_k_sweep_h20 --features cuda --arch $(CUDA_ARCH) | sed -n '/^{/p'
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" OXIDE_SOURCE_STATE=working_tree $(CARGO) +nightly-2026-04-03 oxide run split_k_sweep_h20 --bin split_k_sweep_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'

--- a/README.md
+++ b/README.md
@@ -161,17 +161,17 @@ cd oxide-infer
 
 mise trust
 mise install
-make install-website
-make check
+USE_MISE=1 make install-website
+USE_MISE=1 make check
 ```
 
 Run CUDA gates inside the pinned Linux environment:
 
 ```bash
-make cuda-doctor
-make cuda-check
-make cuda-test
-make h20
+USE_MISE=1 make cuda-doctor
+USE_MISE=1 make cuda-check
+USE_MISE=1 make cuda-test
+USE_MISE=1 make h20
 ```
 
 The [environment guide](docs/development/environment.md) lists the pinned Rust,

--- a/crates/oxide-infer-lab/src/gates/bf16_gemm.rs
+++ b/crates/oxide-infer-lab/src/gates/bf16_gemm.rs
@@ -1,3 +1,4 @@
+use super::{VALID_GRAPH_REPLAYS, valid_graph_commands};
 use crate::comparison::{Comparison, compare_bf16};
 use crate::reporting::GateCase;
 use cuda_core::{CudaContext, CudaStream, DeviceBuffer};
@@ -18,6 +19,7 @@ use std::sync::Arc;
 const LARGE_M: usize = 1;
 const LARGE_N: usize = 4096;
 const LARGE_K: usize = 4096;
+const RMS_GEMM_GRAPH_COMMANDS_PER_STAGE: usize = 2;
 
 fn require_bit_exact(case: &str, comparison: Comparison) -> Result<(), Box<dyn Error>> {
     if comparison.bit_mismatches == 0 {
@@ -451,10 +453,25 @@ fn check_rms_norm_gemm_graph(
     let rms_plan = rms_provider.plan_bf16(rms_spec)?;
     drop(rms_provider);
     let input_host = vec![bf16::ONE; rms_spec.numel()];
+    let poison_input_host = vec![bf16::ZERO; rms_spec.numel()];
     let norm_weight_host = vec![bf16::ONE; rms_spec.hidden_size()];
     let (_, gemm_weight_host) = large_fixture(gemm_spec);
+    let mut poison_intermediate_expected = vec![bf16::NAN; rms_spec.numel()];
+    let mut poison_expected = vec![bf16::NAN; gemm_spec.output_numel()];
     let mut intermediate_expected = vec![bf16::ZERO; rms_spec.numel()];
     let mut expected = vec![bf16::ZERO; gemm_spec.output_numel()];
+    rms_norm_bf16_reference(
+        &poison_input_host,
+        &norm_weight_host,
+        &mut poison_intermediate_expected,
+        rms_spec,
+    )?;
+    bf16_dense_gemm_reference(
+        &poison_intermediate_expected,
+        &gemm_weight_host,
+        &mut poison_expected,
+        gemm_spec,
+    )?;
     rms_norm_bf16_reference(
         &input_host,
         &norm_weight_host,
@@ -467,53 +484,110 @@ fn check_rms_norm_gemm_graph(
         &mut expected,
         gemm_spec,
     )?;
+    if poison_expected
+        .iter()
+        .zip(&expected)
+        .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+    {
+        return Err("RMSNorm to GEMM graph poison does not differ from the real output".into());
+    }
 
     let input = Arc::new(DeviceBuffer::from_host(&stream, &input_host)?);
+    let poison_input = Arc::new(DeviceBuffer::from_host(&stream, &poison_input_host)?);
     let norm_weight = Arc::new(DeviceBuffer::from_host(&stream, &norm_weight_host)?);
-    let intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let poison_observer_intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let target_poison_intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
+    let real_intermediate = DeviceBuffer::<bf16>::zeroed(&stream, rms_spec.numel())?;
     let gemm_weight = Arc::new(DeviceBuffer::from_host(&stream, &gemm_weight_host)?);
-    let output = DeviceBuffer::<bf16>::zeroed(&stream, gemm_spec.output_numel())?;
-    let workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(&gemm_plan))?;
-    let graph_queue = GraphQueue::new(stream.context(), 2)?;
-    let mut bindings = graph_queue.bindings(6)?;
+    let initial_output = vec![bf16::NAN; gemm_spec.output_numel()];
+    let poison_observer_output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let poison_observer_workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(&gemm_plan))?;
+    let target_poison_workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(&gemm_plan))?;
+    let real_workspace = DeviceBuffer::<u8>::zeroed(&stream, workspace_len(&gemm_plan))?;
+    let graph_commands = valid_graph_commands(RMS_GEMM_GRAPH_COMMANDS_PER_STAGE);
+    let graph_queue = GraphQueue::new(stream.context(), graph_commands)?;
+    let mut bindings = graph_queue.bindings(12)?;
+    let poison_input_handle = bindings.bind_read(Arc::clone(&poison_input))?;
     let input_handle = bindings.bind_read(Arc::clone(&input))?;
     let norm_weight_handle = bindings.bind_read(Arc::clone(&norm_weight))?;
-    let intermediate_handle = bindings.bind_read_write(intermediate)?;
+    let poison_observer_intermediate_handle =
+        bindings.bind_read_write(poison_observer_intermediate)?;
+    let target_poison_intermediate_handle = bindings.bind_read_write(target_poison_intermediate)?;
+    let real_intermediate_handle = bindings.bind_read_write(real_intermediate)?;
     let gemm_weight_handle = bindings.bind_read(Arc::clone(&gemm_weight))?;
+    let poison_observer_output_handle = bindings.bind_read_write(poison_observer_output)?;
     let output_handle = bindings.bind_read_write(output)?;
-    let workspace_handle = bindings.bind_read_write(workspace)?;
+    let poison_observer_workspace_handle = bindings.bind_read_write(poison_observer_workspace)?;
+    let target_poison_workspace_handle = bindings.bind_read_write(target_poison_workspace)?;
+    let real_workspace_handle = bindings.bind_read_write(real_workspace)?;
 
     let captured = graph_queue.capture(bindings, |scope| -> Result<(), Box<dyn Error>> {
         rms_plan.enqueue_into(
             scope,
             RmsNormArgs::new(
-                input_handle,
+                poison_input_handle,
                 norm_weight_handle,
-                intermediate_handle.write(),
+                poison_observer_intermediate_handle.write(),
             ),
         )?;
         gemm_plan.enqueue_into(
             scope,
             Bf16DenseGemmOperands::new(
-                intermediate_handle.read(),
+                poison_observer_intermediate_handle.read(),
+                gemm_weight_handle,
+                poison_observer_output_handle.write(),
+                poison_observer_workspace_handle.write(),
+            ),
+        )?;
+        rms_plan.enqueue_into(
+            scope,
+            RmsNormArgs::new(
+                poison_input_handle,
+                norm_weight_handle,
+                target_poison_intermediate_handle.write(),
+            ),
+        )?;
+        gemm_plan.enqueue_into(
+            scope,
+            Bf16DenseGemmOperands::new(
+                target_poison_intermediate_handle.read(),
                 gemm_weight_handle,
                 output_handle.write(),
-                workspace_handle.write(),
+                target_poison_workspace_handle.write(),
+            ),
+        )?;
+        rms_plan.enqueue_into(
+            scope,
+            RmsNormArgs::new(
+                input_handle,
+                norm_weight_handle,
+                real_intermediate_handle.write(),
+            ),
+        )?;
+        gemm_plan.enqueue_into(
+            scope,
+            Bf16DenseGemmOperands::new(
+                real_intermediate_handle.read(),
+                gemm_weight_handle,
+                output_handle.write(),
+                real_workspace_handle.write(),
             ),
         )?;
         Ok(())
     })?;
-    if captured.commands() != 2 {
+    if captured.commands() != graph_commands {
         return Err("captured graph covered the wrong command count".into());
     }
     drop(rms_plan);
     drop(gemm_plan);
+    drop(poison_input);
     drop(input);
     drop(norm_weight);
     drop(gemm_weight);
 
     let mut exec = captured.instantiate()?;
-    for expected_launch in 1..=2 {
+    for expected_launch in 1..=VALID_GRAPH_REPLAYS {
         let mut completion = exec.launch()?;
         if completion.launch_index() != expected_launch {
             return Err("graph completion reported the wrong replay index".into());
@@ -525,27 +599,40 @@ fn check_rms_norm_gemm_graph(
             drop(completion);
         }
     }
-    if exec.launches() != 2 || exec.commands() != 2 {
+    if exec.launches() != VALID_GRAPH_REPLAYS || exec.commands() != graph_commands {
         return Err("graph exec accounting changed across replay".into());
     }
     let mut bindings = exec.into_bindings()?;
+    let poison_observer_output = bindings.take_read_write(poison_observer_output_handle)?;
     let output = bindings.take_read_write(output_handle)?;
     drop(bindings);
 
+    let poison_actual = poison_observer_output.to_host_vec(&stream)?;
     let actual = output.to_host_vec(&stream)?;
+    let poison_comparison = compare_bf16(&poison_actual, &poison_expected, "BF16 poison")?;
     let comparison = compare_bf16(&actual, &expected, "BF16")?;
+    require_bit_exact("RMSNorm to GEMM graph poison observer", poison_comparison)?;
     require_bit_exact("RMSNorm to GEMM graph", comparison)?;
     println!(
         "{} rows=1 hidden=4096 \
-         m={} n={} k={} commands=2 replays=2 fixed_bindings=true cross_stream=false \
+         m={} n={} k={} commands={} commands_per_stage=2 replays={} \
+         replay_stages=independent_poison_then_target_poison_then_real \
+         independent_poison_observable=true output_poisoned_each_replay=true \
+         independent_intermediates=true independent_workspaces=true \
+         initial_outputs=poisoned fixed_bindings=true cross_stream=false \
          external_owners_dropped_before_replay=true \
          completion_queries=2 completion_waits=1 completion_drops=1 \
          intra_graph_host_waits=0 inter_replay_host_waits=1 \
+         poison_bit_mismatches={} poison_digest={:016x} \
          bit_mismatches={} max_abs={:.9e} digest={:016x}",
         GateCase::new("bf16_gemm_h20", "rms_norm_gemm_graph"),
         gemm_spec.m(),
         gemm_spec.n(),
         gemm_spec.k(),
+        graph_commands,
+        VALID_GRAPH_REPLAYS,
+        poison_comparison.bit_mismatches,
+        poison_comparison.digest,
         comparison.bit_mismatches,
         comparison.max_abs,
         comparison.digest,

--- a/crates/oxide-infer-lab/src/gates/mod.rs
+++ b/crates/oxide-infer-lab/src/gates/mod.rs
@@ -6,3 +6,24 @@ pub mod ragged_prefill;
 pub mod rms_norm;
 pub mod rope;
 pub mod single_decode;
+
+pub(super) const VALID_GRAPH_REPLAYS: u64 = 2;
+pub(super) const VALID_GRAPH_STAGES: usize = 3;
+
+pub(super) const fn valid_graph_commands(commands_per_stage: usize) -> usize {
+    commands_per_stage * VALID_GRAPH_STAGES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VALID_GRAPH_REPLAYS, VALID_GRAPH_STAGES, valid_graph_commands};
+
+    #[test]
+    fn valid_graph_accounting_covers_observer_poison_and_real_stages() {
+        assert_eq!(VALID_GRAPH_REPLAYS, 2);
+        assert_eq!(VALID_GRAPH_STAGES, 3);
+        assert_eq!(valid_graph_commands(1), 3);
+        assert_eq!(valid_graph_commands(2), 6);
+        assert_eq!(valid_graph_commands(3), 9);
+    }
+}

--- a/crates/oxide-infer-lab/src/gates/paged_prefill.rs
+++ b/crates/oxide-infer-lab/src/gates/paged_prefill.rs
@@ -1,3 +1,4 @@
+use super::{VALID_GRAPH_REPLAYS, valid_graph_commands};
 use crate::comparison::{compare_bf16, compare_f32};
 use crate::fixture::deterministic_bf16;
 use crate::reporting::GateCase;
@@ -15,6 +16,8 @@ use std::sync::Arc;
 
 const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
 const LSE_MAX_ABS_LIMIT: f32 = 0.01;
+const PAGED_GRAPH_COMMANDS_PER_STAGE: usize = 3;
+const STATUS_POISON: i32 = i32::MIN;
 
 #[derive(Clone, Copy)]
 struct MetadataInput<'a> {
@@ -446,8 +449,25 @@ fn run_graph_case(
     let query_host = deterministic_bf16(spec.query_numel(), 0x4001);
     let key_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x4b45_5900);
     let value_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x5641_4c55_4500);
+    let poison_query_host = vec![bf16::ZERO; spec.query_numel()];
+    let poison_key_host = vec![bf16::ZERO; spec.kv_pages_numel()];
+    let poison_value_host = vec![bf16::ZERO; spec.kv_pages_numel()];
+    let mut poison_expected_output = vec![bf16::NAN; spec.output_numel()];
+    let mut poison_expected_lse = vec![f32::NAN; spec.lse_numel()];
     let mut expected_output = vec![bf16::NAN; spec.output_numel()];
     let mut expected_lse = vec![f32::NAN; spec.lse_numel()];
+    paged_prefill_bf16_reference(
+        &poison_query_host,
+        &poison_key_host,
+        &poison_value_host,
+        &qo_indptr_host,
+        &page_indptr_host,
+        &page_indices_host,
+        &last_page_len_host,
+        &mut poison_expected_output,
+        &mut poison_expected_lse,
+        spec,
+    )?;
     paged_prefill_bf16_reference(
         &query_host,
         &key_host,
@@ -460,7 +480,21 @@ fn run_graph_case(
         &mut expected_lse,
         spec,
     )?;
+    if poison_expected_output
+        .iter()
+        .zip(&expected_output)
+        .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+        || poison_expected_lse
+            .iter()
+            .zip(&expected_lse)
+            .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+    {
+        return Err("paged-prefill graph poison does not distinguish every checked output".into());
+    }
 
+    let poison_query = Arc::new(DeviceBuffer::from_host(&stream, &poison_query_host)?);
+    let poison_key_pages = Arc::new(DeviceBuffer::from_host(&stream, &poison_key_host)?);
+    let poison_value_pages = Arc::new(DeviceBuffer::from_host(&stream, &poison_value_host)?);
     let query = Arc::new(DeviceBuffer::from_host(&stream, &query_host)?);
     let key_pages = Arc::new(DeviceBuffer::from_host(&stream, &key_host)?);
     let value_pages = Arc::new(DeviceBuffer::from_host(&stream, &value_host)?);
@@ -468,13 +502,23 @@ fn run_graph_case(
     let page_indptr = Arc::new(DeviceBuffer::from_host(&stream, &page_indptr_host)?);
     let page_indices = Arc::new(DeviceBuffer::from_host(&stream, &page_indices_host)?);
     let last_page_len = Arc::new(DeviceBuffer::from_host(&stream, &last_page_len_host)?);
-    let metadata_status =
-        DeviceBuffer::<i32>::zeroed(&stream, plan.metadata_status_required_numel())?;
-    let output = DeviceBuffer::from_host(&stream, &vec![bf16::NAN; spec.output_numel()])?;
-    let lse = DeviceBuffer::from_host(&stream, &vec![f32::NAN; spec.lse_numel()])?;
+    let initial_status = vec![STATUS_POISON; plan.metadata_status_required_numel()];
+    let poison_observer_status = DeviceBuffer::from_host(&stream, &initial_status)?;
+    let target_poison_status = DeviceBuffer::from_host(&stream, &initial_status)?;
+    let real_status = DeviceBuffer::from_host(&stream, &initial_status)?;
+    let initial_output = vec![bf16::NAN; spec.output_numel()];
+    let initial_lse = vec![f32::NAN; spec.lse_numel()];
+    let poison_observer_output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let poison_observer_lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
+    let output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
 
-    let graph_queue = GraphQueue::new(stream.context(), 3)?;
-    let mut bindings = graph_queue.bindings(10)?;
+    let graph_commands = valid_graph_commands(PAGED_GRAPH_COMMANDS_PER_STAGE);
+    let graph_queue = GraphQueue::new(stream.context(), graph_commands)?;
+    let mut bindings = graph_queue.bindings(17)?;
+    let poison_query_handle = bindings.bind_read(Arc::clone(&poison_query))?;
+    let poison_key_handle = bindings.bind_read(Arc::clone(&poison_key_pages))?;
+    let poison_value_handle = bindings.bind_read(Arc::clone(&poison_value_pages))?;
     let query_handle = bindings.bind_read(Arc::clone(&query))?;
     let key_handle = bindings.bind_read(Arc::clone(&key_pages))?;
     let value_handle = bindings.bind_read(Arc::clone(&value_pages))?;
@@ -482,11 +526,45 @@ fn run_graph_case(
     let page_indptr_handle = bindings.bind_read(Arc::clone(&page_indptr))?;
     let page_indices_handle = bindings.bind_read(Arc::clone(&page_indices))?;
     let last_page_len_handle = bindings.bind_read(Arc::clone(&last_page_len))?;
-    let metadata_status_handle = bindings.bind_read_write(metadata_status)?;
+    let poison_observer_status_handle = bindings.bind_read_write(poison_observer_status)?;
+    let target_poison_status_handle = bindings.bind_read_write(target_poison_status)?;
+    let real_status_handle = bindings.bind_read_write(real_status)?;
+    let poison_observer_output_handle = bindings.bind_read_write(poison_observer_output)?;
+    let poison_observer_lse_handle = bindings.bind_read_write(poison_observer_lse)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
 
     let captured = graph_queue.capture(bindings, |scope| {
+        plan.enqueue_into(
+            scope,
+            Bf16PagedPrefillArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                qo_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                poison_observer_status_handle,
+                poison_observer_output_handle.write(),
+                poison_observer_lse_handle.write(),
+            ),
+        )?;
+        plan.enqueue_into(
+            scope,
+            Bf16PagedPrefillArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                qo_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                target_poison_status_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            ),
+        )?;
         plan.enqueue_into(
             scope,
             Bf16PagedPrefillArgs::new(
@@ -497,17 +575,20 @@ fn run_graph_case(
                 page_indptr_handle,
                 page_indices_handle,
                 last_page_len_handle,
-                metadata_status_handle,
+                real_status_handle,
                 output_handle.write(),
                 lse_handle.write(),
             ),
         )
     })?;
-    if captured.commands() != 3 {
+    if captured.commands() != graph_commands {
         return Err("paged-prefill graph captured the wrong command count".into());
     }
 
     drop(plan);
+    drop(poison_query);
+    drop(poison_key_pages);
+    drop(poison_value_pages);
     drop(query);
     drop(key_pages);
     drop(value_pages);
@@ -517,7 +598,7 @@ fn run_graph_case(
     drop(last_page_len);
 
     let mut exec = captured.instantiate()?;
-    for expected_launch in 1..=2 {
+    for expected_launch in 1..=VALID_GRAPH_REPLAYS {
         let mut completion = exec.launch()?;
         if completion.launch_index() != expected_launch {
             return Err("paged-prefill graph reported the wrong replay index".into());
@@ -529,43 +610,91 @@ fn run_graph_case(
             drop(completion);
         }
     }
-    if exec.launches() != 2 || exec.commands() != 3 {
+    if exec.launches() != VALID_GRAPH_REPLAYS || exec.commands() != graph_commands {
         return Err("paged-prefill graph accounting changed across replay".into());
     }
 
     let mut bindings = exec.into_bindings()?;
+    let poison_observer_status = bindings.take_read_write(poison_observer_status_handle)?;
+    let target_poison_status = bindings.take_read_write(target_poison_status_handle)?;
+    let real_status = bindings.take_read_write(real_status_handle)?;
+    let poison_observer_output = bindings.take_read_write(poison_observer_output_handle)?;
+    let poison_observer_lse = bindings.take_read_write(poison_observer_lse_handle)?;
     let output = bindings.take_read_write(output_handle)?;
     let lse = bindings.take_read_write(lse_handle)?;
     drop(bindings);
     let actual_output = output.to_host_vec(&stream)?;
     let actual_lse = lse.to_host_vec(&stream)?;
+    for (label, status) in [
+        (
+            "independent poison",
+            poison_observer_status.to_host_vec(&stream)?,
+        ),
+        ("target poison", target_poison_status.to_host_vec(&stream)?),
+        ("real", real_status.to_host_vec(&stream)?),
+    ] {
+        if status.iter().any(|&word| word != 0) {
+            return Err(format!("paged-prefill graph {label} status was not rewritten").into());
+        }
+    }
+    let poison_output_comparison = compare_bf16(
+        &poison_observer_output.to_host_vec(&stream)?,
+        &poison_expected_output,
+        "graph paged prefill poison BF16",
+    )?;
+    let poison_lse_comparison = compare_f32(
+        &poison_observer_lse.to_host_vec(&stream)?,
+        &poison_expected_lse,
+        "graph paged prefill poison F32 LSE",
+    )?;
     let output_comparison =
         compare_bf16(&actual_output, &expected_output, "graph paged prefill BF16")?;
     let lse_comparison = compare_f32(&actual_lse, &expected_lse, "graph paged prefill F32 LSE")?;
-    if output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT {
+    if poison_output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+        || output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+    {
         return Err(format!(
             "paged-prefill graph output max abs {:.9e} exceeds {:.9e}",
-            output_comparison.max_abs, OUTPUT_MAX_ABS_LIMIT
+            poison_output_comparison
+                .max_abs
+                .max(output_comparison.max_abs),
+            OUTPUT_MAX_ABS_LIMIT
         )
         .into());
     }
-    if lse_comparison.max_abs > LSE_MAX_ABS_LIMIT {
+    if poison_lse_comparison.max_abs > LSE_MAX_ABS_LIMIT
+        || lse_comparison.max_abs > LSE_MAX_ABS_LIMIT
+    {
         return Err(format!(
             "paged-prefill graph LSE max abs {:.9e} exceeds {:.9e}",
-            lse_comparison.max_abs, LSE_MAX_ABS_LIMIT
+            poison_lse_comparison.max_abs.max(lse_comparison.max_abs),
+            LSE_MAX_ABS_LIMIT
         )
         .into());
     }
 
     println!(
         "{} batch_size=2 nnz_qo=6 query_heads=16 kv_heads=4 page_size=16 \
-         algorithm=direct_one_warp_per_query_row_head commands=3 validator_kernels=1 \
-         attention_kernels=1 status_readbacks=1 replays=2 \
+         algorithm=direct_one_warp_per_query_row_head commands={} commands_per_stage=3 \
+         validator_kernels_per_stage=1 attention_kernels_per_stage=1 \
+         status_readbacks_per_stage=1 replays={} \
+         replay_stages=independent_poison_then_target_poison_then_real \
+         independent_poison_observable=true output_lse_poisoned_each_replay=true \
+         independent_status_packets=true status_packets_rewritten=true \
+         initial_outputs=poisoned \
          fixed_bindings=true cross_stream=false external_owners_dropped_before_replay=true \
          completion_queries=2 completion_waits=1 completion_drops=1 \
+         poison_output_max_abs={:.9e} poison_output_digest={:016x} \
+         poison_lse_max_abs={:.9e} poison_lse_digest={:016x} \
          output_max_abs={:.9e} output_bit_mismatches={} output_digest={:016x} \
          lse_max_abs={:.9e} lse_bit_mismatches={} lse_digest={:016x}",
         GateCase::new("paged_prefill_h20", "gqa4_graph"),
+        graph_commands,
+        VALID_GRAPH_REPLAYS,
+        poison_output_comparison.max_abs,
+        poison_output_comparison.digest,
+        poison_lse_comparison.max_abs,
+        poison_lse_comparison.digest,
         output_comparison.max_abs,
         output_comparison.bit_mismatches,
         output_comparison.digest,

--- a/crates/oxide-infer-lab/src/gates/ragged_prefill.rs
+++ b/crates/oxide-infer-lab/src/gates/ragged_prefill.rs
@@ -1,3 +1,4 @@
+use super::{VALID_GRAPH_REPLAYS, valid_graph_commands};
 use crate::comparison::{compare_bf16, compare_f32};
 use crate::fixture::deterministic_bf16;
 use crate::reporting::GateCase;
@@ -14,6 +15,7 @@ use std::sync::Arc;
 
 const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
 const LSE_MAX_ABS_LIMIT: f32 = 0.01;
+const TILED_GRAPH_COMMANDS_PER_STAGE: usize = 2;
 
 fn run_case(
     queue: &mut CommandQueue,
@@ -333,8 +335,23 @@ fn run_tiled_graph_case(
     let query_host = deterministic_bf16(spec.query_numel(), 0x4001);
     let key_host = deterministic_bf16(spec.kv_numel(), 0x4001 ^ 0x4b45_5900);
     let value_host = deterministic_bf16(spec.kv_numel(), 0x4001 ^ 0x5641_4c55_4500);
+    let poison_query_host = vec![bf16::ZERO; spec.query_numel()];
+    let poison_key_host = vec![bf16::ZERO; spec.kv_numel()];
+    let poison_value_host = vec![bf16::ZERO; spec.kv_numel()];
+    let mut poison_expected_output = vec![bf16::NAN; spec.output_numel()];
+    let mut poison_expected_lse = vec![f32::NAN; spec.lse_numel()];
     let mut expected_output = vec![bf16::NAN; spec.output_numel()];
     let mut expected_lse = vec![f32::NAN; spec.lse_numel()];
+    ragged_prefill_bf16_reference(
+        &poison_query_host,
+        &poison_key_host,
+        &poison_value_host,
+        &qo_indptr_host,
+        &kv_indptr_host,
+        &mut poison_expected_output,
+        &mut poison_expected_lse,
+        spec,
+    )?;
     ragged_prefill_bf16_reference(
         &query_host,
         &key_host,
@@ -345,28 +362,84 @@ fn run_tiled_graph_case(
         &mut expected_lse,
         spec,
     )?;
+    if poison_expected_output
+        .iter()
+        .zip(&expected_output)
+        .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+        || poison_expected_lse
+            .iter()
+            .zip(&expected_lse)
+            .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+    {
+        return Err("ragged graph poison does not distinguish every checked output".into());
+    }
 
+    let poison_query = Arc::new(DeviceBuffer::from_host(&stream, &poison_query_host)?);
+    let poison_key = Arc::new(DeviceBuffer::from_host(&stream, &poison_key_host)?);
+    let poison_value = Arc::new(DeviceBuffer::from_host(&stream, &poison_value_host)?);
     let query = Arc::new(DeviceBuffer::from_host(&stream, &query_host)?);
     let key = Arc::new(DeviceBuffer::from_host(&stream, &key_host)?);
     let value = Arc::new(DeviceBuffer::from_host(&stream, &value_host)?);
     let qo_indptr = Arc::new(DeviceBuffer::from_host(&stream, &qo_indptr_host)?);
     let kv_indptr = Arc::new(DeviceBuffer::from_host(&stream, &kv_indptr_host)?);
-    let output = DeviceBuffer::from_host(&stream, &vec![bf16::NAN; spec.output_numel()])?;
-    let lse = DeviceBuffer::from_host(&stream, &vec![f32::NAN; spec.lse_numel()])?;
-    let workspace = DeviceBuffer::<f32>::zeroed(&stream, plan.workspace_required_numel())?;
+    let initial_output = vec![bf16::NAN; spec.output_numel()];
+    let initial_lse = vec![f32::NAN; spec.lse_numel()];
+    let poison_observer_output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let poison_observer_lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
+    let output = DeviceBuffer::from_host(&stream, &initial_output)?;
+    let lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
+    let poison_observer_workspace =
+        DeviceBuffer::<f32>::zeroed(&stream, plan.workspace_required_numel())?;
+    let target_poison_workspace =
+        DeviceBuffer::<f32>::zeroed(&stream, plan.workspace_required_numel())?;
+    let real_workspace = DeviceBuffer::<f32>::zeroed(&stream, plan.workspace_required_numel())?;
 
-    let graph_queue = GraphQueue::new(stream.context(), 2)?;
-    let mut bindings = graph_queue.bindings(8)?;
+    let graph_commands = valid_graph_commands(TILED_GRAPH_COMMANDS_PER_STAGE);
+    let graph_queue = GraphQueue::new(stream.context(), graph_commands)?;
+    let mut bindings = graph_queue.bindings(15)?;
+    let poison_query_handle = bindings.bind_read(Arc::clone(&poison_query))?;
+    let poison_key_handle = bindings.bind_read(Arc::clone(&poison_key))?;
+    let poison_value_handle = bindings.bind_read(Arc::clone(&poison_value))?;
     let query_handle = bindings.bind_read(Arc::clone(&query))?;
     let key_handle = bindings.bind_read(Arc::clone(&key))?;
     let value_handle = bindings.bind_read(Arc::clone(&value))?;
     let qo_indptr_handle = bindings.bind_read(Arc::clone(&qo_indptr))?;
     let kv_indptr_handle = bindings.bind_read(Arc::clone(&kv_indptr))?;
+    let poison_observer_output_handle = bindings.bind_read_write(poison_observer_output)?;
+    let poison_observer_lse_handle = bindings.bind_read_write(poison_observer_lse)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
-    let workspace_handle = bindings.bind_read_write(workspace)?;
+    let poison_observer_workspace_handle = bindings.bind_read_write(poison_observer_workspace)?;
+    let target_poison_workspace_handle = bindings.bind_read_write(target_poison_workspace)?;
+    let real_workspace_handle = bindings.bind_read_write(real_workspace)?;
 
     let captured = graph_queue.capture(bindings, |scope| {
+        plan.enqueue_into(
+            scope,
+            Bf16RaggedPrefillArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                qo_indptr_handle,
+                kv_indptr_handle,
+                poison_observer_output_handle.write(),
+                poison_observer_lse_handle.write(),
+            )
+            .with_workspace(poison_observer_workspace_handle),
+        )?;
+        plan.enqueue_into(
+            scope,
+            Bf16RaggedPrefillArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                qo_indptr_handle,
+                kv_indptr_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            )
+            .with_workspace(target_poison_workspace_handle),
+        )?;
         plan.enqueue_into(
             scope,
             Bf16RaggedPrefillArgs::new(
@@ -378,15 +451,18 @@ fn run_tiled_graph_case(
                 output_handle.write(),
                 lse_handle.write(),
             )
-            .with_workspace(workspace_handle),
+            .with_workspace(real_workspace_handle),
         )
     })?;
-    if captured.commands() != 2 {
+    if captured.commands() != graph_commands {
         return Err("ragged graph captured the wrong command count".into());
     }
 
     drop(plan);
     drop(provider);
+    drop(poison_query);
+    drop(poison_key);
+    drop(poison_value);
     drop(query);
     drop(key);
     drop(value);
@@ -394,7 +470,7 @@ fn run_tiled_graph_case(
     drop(kv_indptr);
 
     let mut exec = captured.instantiate()?;
-    for expected_launch in 1..=2 {
+    for expected_launch in 1..=VALID_GRAPH_REPLAYS {
         let mut completion = exec.launch()?;
         if completion.launch_index() != expected_launch {
             return Err("ragged graph completion reported the wrong replay index".into());
@@ -406,41 +482,72 @@ fn run_tiled_graph_case(
             drop(completion);
         }
     }
-    if exec.launches() != 2 || exec.commands() != 2 {
+    if exec.launches() != VALID_GRAPH_REPLAYS || exec.commands() != graph_commands {
         return Err("ragged graph accounting changed across replay".into());
     }
 
     let mut bindings = exec.into_bindings()?;
+    let poison_observer_output = bindings.take_read_write(poison_observer_output_handle)?;
+    let poison_observer_lse = bindings.take_read_write(poison_observer_lse_handle)?;
     let output = bindings.take_read_write(output_handle)?;
     let lse = bindings.take_read_write(lse_handle)?;
     drop(bindings);
     let actual_output = output.to_host_vec(&stream)?;
     let actual_lse = lse.to_host_vec(&stream)?;
+    let poison_output_comparison = compare_bf16(
+        &poison_observer_output.to_host_vec(&stream)?,
+        &poison_expected_output,
+        "graph prefill poison BF16",
+    )?;
+    let poison_lse_comparison = compare_f32(
+        &poison_observer_lse.to_host_vec(&stream)?,
+        &poison_expected_lse,
+        "graph prefill poison F32 LSE",
+    )?;
     let output_comparison = compare_bf16(&actual_output, &expected_output, "graph prefill BF16")?;
     let lse_comparison = compare_f32(&actual_lse, &expected_lse, "graph prefill F32 LSE")?;
-    if output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT {
+    if poison_output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+        || output_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+    {
         return Err(format!(
             "ragged graph output max abs {:.9e} exceeds {:.9e}",
-            output_comparison.max_abs, OUTPUT_MAX_ABS_LIMIT
+            poison_output_comparison
+                .max_abs
+                .max(output_comparison.max_abs),
+            OUTPUT_MAX_ABS_LIMIT
         )
         .into());
     }
-    if lse_comparison.max_abs > LSE_MAX_ABS_LIMIT {
+    if poison_lse_comparison.max_abs > LSE_MAX_ABS_LIMIT
+        || lse_comparison.max_abs > LSE_MAX_ABS_LIMIT
+    {
         return Err(format!(
             "ragged graph LSE max abs {:.9e} exceeds {:.9e}",
-            lse_comparison.max_abs, LSE_MAX_ABS_LIMIT
+            poison_lse_comparison.max_abs.max(lse_comparison.max_abs),
+            LSE_MAX_ABS_LIMIT
         )
         .into());
     }
 
     println!(
         "{} batch_size=2 nnz_qo=96 nnz_kv=1280 query_heads=16 kv_heads=4 \
-         head_dim=128 algorithm=tiled_gqa4_mma commands=2 replays=2 \
+         head_dim=128 algorithm=tiled_gqa4_mma commands={} commands_per_stage=2 replays={} \
+         replay_stages=independent_poison_then_target_poison_then_real \
+         independent_poison_observable=true output_lse_poisoned_each_replay=true \
+         independent_workspaces=true initial_outputs=poisoned \
          fixed_bindings=true cross_stream=false external_owners_dropped_before_replay=true \
          completion_queries=2 completion_waits=1 completion_drops=1 \
+         poison_output_max_abs={:.9e} poison_output_digest={:016x} \
+         poison_lse_max_abs={:.9e} poison_lse_digest={:016x} \
          output_max_abs={:.9e} output_bit_mismatches={} output_digest={:016x} \
          lse_max_abs={:.9e} lse_bit_mismatches={} lse_digest={:016x}",
         GateCase::new("ragged_prefill_h20", "gqa4_graph"),
+        graph_commands,
+        VALID_GRAPH_REPLAYS,
+        poison_output_comparison.max_abs,
+        poison_output_comparison.digest,
+        poison_lse_comparison.max_abs,
+        poison_lse_comparison.digest,
         output_comparison.max_abs,
         output_comparison.bit_mismatches,
         output_comparison.digest,

--- a/crates/oxide-infer-lab/src/gates/rope.rs
+++ b/crates/oxide-infer-lab/src/gates/rope.rs
@@ -1,3 +1,4 @@
+use super::{VALID_GRAPH_REPLAYS, valid_graph_commands};
 use crate::comparison::compare_bf16;
 use crate::fixture::{deterministic_bf16, page_refcounts};
 use crate::reporting::GateCase;
@@ -18,6 +19,8 @@ use std::error::Error;
 use std::sync::Arc;
 
 const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
+const APPEND_GRAPH_COMMANDS_PER_STAGE: usize = 3;
+const APPEND_WORKSPACE_POISON: i32 = i32::MIN;
 
 fn run_reference_case(
     queue: &mut CommandQueue,
@@ -756,11 +759,32 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
     let query_host = deterministic_bf16(spec.query_numel(), 0x5451_4147);
     let key_host = deterministic_bf16(spec.key_numel(), 0x544b_4147);
     let value_host = deterministic_bf16(spec.value_numel(), 0x5456_4147);
+    let poison_query_host = vec![bf16::ZERO; spec.query_numel()];
+    let poison_key_host = vec![bf16::ZERO; spec.key_numel()];
+    let poison_value_host = vec![bf16::ZERO; spec.value_numel()];
     let key_pages_host = deterministic_bf16(spec.kv_pages_numel(), 0x544b_4343);
     let value_pages_host = deterministic_bf16(spec.kv_pages_numel(), 0x5456_4343);
+    let mut poison_expected_query = vec![bf16::NAN; spec.query_output_numel()];
+    let mut poison_expected_key_pages = key_pages_host.clone();
+    let mut poison_expected_value_pages = value_pages_host.clone();
     let mut expected_query = vec![bf16::NAN; spec.query_output_numel()];
     let mut expected_key_pages = key_pages_host.clone();
     let mut expected_value_pages = value_pages_host.clone();
+    rope_paged_kv_append_tokens_bf16_reference(
+        &poison_query_host,
+        &poison_key_host,
+        &poison_value_host,
+        &batch_indices_host,
+        &positions_host,
+        &page_indptr_host,
+        &page_indices_host,
+        &last_page_len_host,
+        &page_refcounts_host,
+        &mut poison_expected_query,
+        &mut poison_expected_key_pages,
+        &mut poison_expected_value_pages,
+        spec,
+    )?;
     rope_paged_kv_append_tokens_bf16_reference(
         &query_host,
         &key_host,
@@ -776,9 +800,33 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
         &mut expected_value_pages,
         spec,
     )?;
+    for (label, poison, expected) in [
+        ("query", &poison_expected_query[..], &expected_query[..]),
+        (
+            "key pages",
+            &poison_expected_key_pages[..],
+            &expected_key_pages[..],
+        ),
+        (
+            "value pages",
+            &poison_expected_value_pages[..],
+            &expected_value_pages[..],
+        ),
+    ] {
+        if poison
+            .iter()
+            .zip(expected)
+            .all(|(poison, expected)| poison.to_bits() == expected.to_bits())
+        {
+            return Err(format!("explicit append graph {label} poison is not observable").into());
+        }
+    }
 
     let upload_stream = context.new_stream()?;
     let plan = provider.plan_bf16_paged_append_tokens(spec)?;
+    let poison_query = Arc::new(DeviceBuffer::from_host(&upload_stream, &poison_query_host)?);
+    let poison_key = Arc::new(DeviceBuffer::from_host(&upload_stream, &poison_key_host)?);
+    let poison_value = Arc::new(DeviceBuffer::from_host(&upload_stream, &poison_value_host)?);
     let query = Arc::new(DeviceBuffer::from_host(&upload_stream, &query_host)?);
     let key = Arc::new(DeviceBuffer::from_host(&upload_stream, &key_host)?);
     let value = Arc::new(DeviceBuffer::from_host(&upload_stream, &value_host)?);
@@ -797,14 +845,25 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
         &upload_stream,
         &page_refcounts_host,
     )?);
-    let query_output =
-        DeviceBuffer::from_host(&upload_stream, &vec![bf16::NAN; spec.query_output_numel()])?;
+    let initial_query_output = vec![bf16::NAN; spec.query_output_numel()];
+    let poison_observer_query_output =
+        DeviceBuffer::from_host(&upload_stream, &initial_query_output)?;
+    let poison_observer_key_pages = DeviceBuffer::from_host(&upload_stream, &key_pages_host)?;
+    let poison_observer_value_pages = DeviceBuffer::from_host(&upload_stream, &value_pages_host)?;
+    let query_output = DeviceBuffer::from_host(&upload_stream, &initial_query_output)?;
     let key_pages = DeviceBuffer::from_host(&upload_stream, &key_pages_host)?;
     let value_pages = DeviceBuffer::from_host(&upload_stream, &value_pages_host)?;
-    let workspace = DeviceBuffer::<i32>::zeroed(&upload_stream, plan.workspace_required_numel())?;
+    let initial_workspace = vec![APPEND_WORKSPACE_POISON; plan.workspace_required_numel()];
+    let poison_observer_workspace = DeviceBuffer::from_host(&upload_stream, &initial_workspace)?;
+    let target_poison_workspace = DeviceBuffer::from_host(&upload_stream, &initial_workspace)?;
+    let real_workspace = DeviceBuffer::from_host(&upload_stream, &initial_workspace)?;
 
-    let graph_queue = GraphQueue::new(context, 3)?;
-    let mut bindings = graph_queue.bindings(13)?;
+    let graph_commands = valid_graph_commands(APPEND_GRAPH_COMMANDS_PER_STAGE);
+    let graph_queue = GraphQueue::new(context, graph_commands)?;
+    let mut bindings = graph_queue.bindings(21)?;
+    let poison_query_handle = bindings.bind_read(Arc::clone(&poison_query))?;
+    let poison_key_handle = bindings.bind_read(Arc::clone(&poison_key))?;
+    let poison_value_handle = bindings.bind_read(Arc::clone(&poison_value))?;
     let query_handle = bindings.bind_read(Arc::clone(&query))?;
     let key_handle = bindings.bind_read(Arc::clone(&key))?;
     let value_handle = bindings.bind_read(Arc::clone(&value))?;
@@ -814,12 +873,45 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
     let page_indices_handle = bindings.bind_read(Arc::clone(&page_indices))?;
     let last_page_len_handle = bindings.bind_read(Arc::clone(&last_page_len))?;
     let page_refcounts_handle = bindings.bind_read(Arc::clone(&page_refcounts))?;
+    let poison_observer_query_output_handle =
+        bindings.bind_read_write(poison_observer_query_output)?;
+    let poison_observer_key_pages_handle = bindings.bind_read_write(poison_observer_key_pages)?;
+    let poison_observer_value_pages_handle =
+        bindings.bind_read_write(poison_observer_value_pages)?;
     let query_output_handle = bindings.bind_read_write(query_output)?;
     let key_pages_handle = bindings.bind_read_write(key_pages)?;
     let value_pages_handle = bindings.bind_read_write(value_pages)?;
-    let workspace_handle = bindings.bind_read_write(workspace)?;
+    let poison_observer_workspace_handle = bindings.bind_read_write(poison_observer_workspace)?;
+    let target_poison_workspace_handle = bindings.bind_read_write(target_poison_workspace)?;
+    let real_workspace_handle = bindings.bind_read_write(real_workspace)?;
     let captured = graph_queue.capture(bindings, |scope| {
-        let append_map = plan.enqueue_map_into(
+        let poison_observer_map = plan.enqueue_map_into(
+            scope,
+            Bf16PagedKvAppendTokensMapArgs::new(
+                batch_indices_handle,
+                positions_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                page_refcounts_handle,
+                poison_observer_key_pages_handle.write(),
+                poison_observer_value_pages_handle.write(),
+                poison_observer_workspace_handle,
+            ),
+        )?;
+        plan.enqueue_mapped_into(
+            scope,
+            Bf16RopePagedKvAppendMappedArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                poison_observer_map,
+                poison_observer_query_output_handle.write(),
+                poison_observer_key_pages_handle.write(),
+                poison_observer_value_pages_handle.write(),
+            ),
+        )?;
+        let target_poison_map = plan.enqueue_map_into(
             scope,
             Bf16PagedKvAppendTokensMapArgs::new(
                 batch_indices_handle,
@@ -830,7 +922,33 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
                 page_refcounts_handle,
                 key_pages_handle.write(),
                 value_pages_handle.write(),
-                workspace_handle,
+                target_poison_workspace_handle,
+            ),
+        )?;
+        plan.enqueue_mapped_into(
+            scope,
+            Bf16RopePagedKvAppendMappedArgs::new(
+                poison_query_handle,
+                poison_key_handle,
+                poison_value_handle,
+                target_poison_map,
+                query_output_handle.write(),
+                key_pages_handle.write(),
+                value_pages_handle.write(),
+            ),
+        )?;
+        let real_map = plan.enqueue_map_into(
+            scope,
+            Bf16PagedKvAppendTokensMapArgs::new(
+                batch_indices_handle,
+                positions_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                page_refcounts_handle,
+                key_pages_handle.write(),
+                value_pages_handle.write(),
+                real_workspace_handle,
             ),
         )?;
         plan.enqueue_mapped_into(
@@ -839,19 +957,22 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
                 query_handle,
                 key_handle,
                 value_handle,
-                append_map,
+                real_map,
                 query_output_handle.write(),
                 key_pages_handle.write(),
                 value_pages_handle.write(),
             ),
         )
     })?;
-    if captured.commands() != 3 {
+    if captured.commands() != graph_commands {
         return Err("explicit append graph captured the wrong command count".into());
     }
 
     drop(plan);
     drop(provider);
+    drop(poison_query);
+    drop(poison_key);
+    drop(poison_value);
     drop(query);
     drop(key);
     drop(value);
@@ -863,7 +984,7 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
     drop(page_refcounts);
 
     let mut exec = captured.instantiate()?;
-    for expected_launch in 1..=2 {
+    for expected_launch in 1..=VALID_GRAPH_REPLAYS {
         let mut completion = exec.launch()?;
         if completion.launch_index() != expected_launch {
             return Err("explicit append graph completion reported wrong replay index".into());
@@ -875,15 +996,48 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
             drop(completion);
         }
     }
-    if exec.launches() != 2 || exec.commands() != 3 {
+    if exec.launches() != VALID_GRAPH_REPLAYS || exec.commands() != graph_commands {
         return Err("explicit append graph accounting changed across replay".into());
     }
 
     let mut bindings = exec.into_bindings()?;
+    let poison_observer_query_output =
+        bindings.take_read_write(poison_observer_query_output_handle)?;
+    let poison_observer_key_pages = bindings.take_read_write(poison_observer_key_pages_handle)?;
+    let poison_observer_value_pages =
+        bindings.take_read_write(poison_observer_value_pages_handle)?;
     let query_output = bindings.take_read_write(query_output_handle)?;
     let key_pages = bindings.take_read_write(key_pages_handle)?;
     let value_pages = bindings.take_read_write(value_pages_handle)?;
+    let poison_observer_workspace = bindings.take_read_write(poison_observer_workspace_handle)?;
+    let target_poison_workspace = bindings.take_read_write(target_poison_workspace_handle)?;
+    let real_workspace = bindings.take_read_write(real_workspace_handle)?;
     drop(bindings);
+    for (label, workspace) in [
+        ("independent poison", poison_observer_workspace),
+        ("target poison", target_poison_workspace),
+        ("real", real_workspace),
+    ] {
+        let status = workspace.to_host_vec(&upload_stream)?;
+        if status.get(..5) != Some(&[0_i32; 5]) {
+            return Err(format!("explicit append graph {label} status was not successful").into());
+        }
+    }
+    let poison_query_comparison = compare_bf16(
+        &poison_observer_query_output.to_host_vec(&upload_stream)?,
+        &poison_expected_query,
+        "explicit append graph poison query",
+    )?;
+    let poison_key_comparison = compare_bf16(
+        &poison_observer_key_pages.to_host_vec(&upload_stream)?,
+        &poison_expected_key_pages,
+        "explicit append graph poison key pages",
+    )?;
+    let poison_value_comparison = compare_bf16(
+        &poison_observer_value_pages.to_host_vec(&upload_stream)?,
+        &poison_expected_value_pages,
+        "explicit append graph poison value pages",
+    )?;
     let query_comparison = compare_bf16(
         &query_output.to_host_vec(&upload_stream)?,
         &expected_query,
@@ -899,20 +1053,38 @@ fn run_paged_append_tokens_graph_case(context: &Arc<CudaContext>) -> Result<(), 
         &expected_value_pages,
         "explicit append graph value pages",
     )?;
-    if query_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+    if poison_query_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+        || poison_key_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
+        || poison_value_comparison.max_abs != 0.0
+        || query_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
         || key_comparison.max_abs > OUTPUT_MAX_ABS_LIMIT
         || value_comparison.max_abs != 0.0
     {
         return Err("explicit append graph exceeded its correctness limits".into());
     }
     println!(
-        "{} tokens=6 batch_size=3 commands=3 replays=2 fixed_bindings=true \
+        "{} tokens=6 batch_size=3 commands={} commands_per_stage=3 replays={} \
+         replay_stages=independent_poison_then_target_poison_then_real \
+         independent_poison_observable=true append_targets_poisoned_each_replay=true \
+         independent_workspaces=true status_packets_rewritten=true initial_outputs=poisoned \
+         fixed_bindings=true \
          cross_stream=false external_owners_dropped_before_replay=true \
          completion_queries=2 completion_waits=1 completion_drops=1 \
+         poison_query_max_abs={:.9e} poison_query_digest={:016x} \
+         poison_key_pages_max_abs={:.9e} poison_key_pages_digest={:016x} \
+         poison_value_pages_max_abs={:.9e} poison_value_pages_digest={:016x} \
          query_max_abs={:.9e} query_bit_mismatches={} query_digest={:016x} \
          key_pages_max_abs={:.9e} key_pages_bit_mismatches={} key_pages_digest={:016x} \
          value_pages_max_abs={:.9e} value_pages_bit_mismatches={} value_pages_digest={:016x}",
         GateCase::new("rope_h20", "paged_append_tokens_graph"),
+        graph_commands,
+        VALID_GRAPH_REPLAYS,
+        poison_query_comparison.max_abs,
+        poison_query_comparison.digest,
+        poison_key_comparison.max_abs,
+        poison_key_comparison.digest,
+        poison_value_comparison.max_abs,
+        poison_value_comparison.digest,
         query_comparison.max_abs,
         query_comparison.bit_mismatches,
         query_comparison.digest,

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -16,7 +16,7 @@ same thing as CI or an H20 validation run.
 | npm | `11.17.x` | `/website/package.json` |
 | CUDA toolkit | `13.1` for the qualified H20 row | H20 evidence records |
 | Clang/libclang | `21` | cuda-oxide host binding requirement |
-| Device target | `sm_90` for general H20 gates and explicit `sm_90a` for target-restricted algorithms | H20 validation contract |
+| Device target | `CUDA_ARCH` for generic CUDA tests; fixed `sm_90a` for every H20 correctness and benchmark target | Makefile and H20 validation contract |
 
 The root Rust toolchain applies to CPU-only workspace commands. Entering
 `crates/oxide-infer-cuda` or `crates/oxide-infer-lab` selects the pinned
@@ -49,11 +49,22 @@ calling shell sets `NODE_ENV=production`:
 ```bash
 mise trust
 mise install
-make install-website
+USE_MISE=1 make install-website
 ```
 
 Review `mise.toml` before trusting it. The committed configuration selects
 Node 24.19.0 and prepends the Clang 21 binaries and libclang directory.
+
+Make uses the current shell by default. It does not invoke an installed mise
+automatically. Set `USE_MISE=1` only after you trust the repository config:
+
+```bash
+USE_MISE=1 make install-website
+USE_MISE=1 make check
+```
+
+This opt-in prevents an untrusted mise config from blocking unrelated Make
+targets. An activated mise shell also works without `USE_MISE=1`.
 
 The website permits only the version-pinned esbuild script and the optional
 macOS fsevents script declared in `package.json`. An unreviewed dependency
@@ -95,14 +106,17 @@ target GPU.
 ```bash
 make check          # CPU-only Rust checks, package verification, website, audit
 make cuda-check     # CUDA-feature host compilation and Clippy
-make cuda-test      # release tests through cuda-oxide
-make h20            # RMSNorm, GEMM/Graph, and attention correctness programs
+make cuda-test      # generic release tests; CUDA_ARCH selects the device target
+make h20            # H20 correctness programs fixed to sm_90a
 ```
 
 `make h20` runs device programs sequentially because they generate the same
 workspace artifact and share one validation GPU. It is a correctness gate, not
 a Compute Sanitizer or performance gate. Follow
 [H20 validation](h20-validation.md) before recording evidence.
+
+`H20_ARCH` is fixed to `sm_90a` and ignores command-line overrides. Use
+`CUDA_ARCH` only for generic `cuda-test` runs.
 
 ## Dependency caching
 

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -37,7 +37,8 @@ make h20
 ```
 
 The Make targets are the canonical entry points. Evidence records include the
-expanded commands.
+expanded commands. `cuda-test` accepts `CUDA_ARCH` for generic device tests.
+Every H20 correctness and benchmark target fixes `H20_ARCH` to `sm_90a`.
 
 Run one gate during development:
 
@@ -54,8 +55,8 @@ Run one gate during development:
 | `make h20-engine-interop` | `engine_interop_h20` |
 
 `make cuda-test` writes `oxide_infer_cuda.ptx` at the workspace root. Record
-its hash and assemble it for `sm_90` with the same CUDA toolkit used by the
-run.
+its hash and assemble it for the selected `CUDA_ARCH` with the same CUDA
+toolkit used by the run. This generic artifact does not qualify an H20 target.
 
 Before a run, record:
 
@@ -234,19 +235,28 @@ device-qualified status.
 
 ## Compute Sanitizer
 
-Run all four tools against every admitted runner. Use leak checking with
-memcheck.
+Build each admitted runner once, then run all four tools against that exact
+binary. For example:
 
 ```bash
-compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 \
-  target/release/<runner>
-compute-sanitizer --tool racecheck --error-exitcode 99 \
-  target/release/<runner>
-compute-sanitizer --tool synccheck --error-exitcode 99 \
-  target/release/<runner>
-compute-sanitizer --tool initcheck --error-exitcode 99 \
-  target/release/<runner>
+make h20-build-runner H20_RUNNER=rms_norm_h20 | tee h20-build.log
+runner_sha="$(sed -n 's/^runner_binary=.* sha256=\([0-9a-f]\{64\}\) arch=.*/\1/p' h20-build.log)"
+test "${#runner_sha}" -eq 64
+make h20-sanitize-runner H20_RUNNER=rms_norm_h20 \
+  H20_RUNNER_SHA256="$runner_sha"
 ```
+
+The build target uses `sm_90a` with device line information and prints the
+runner's SHA-256 hash. Pass that exact hash to the sanitizer target. The
+sanitizer target has no build dependency.
+
+It rejects a different binary and invokes `compute-sanitizer` directly for
+memcheck, racecheck, synccheck, and initcheck. It verifies the hash after each
+tool. Memcheck includes full leak checking. Each tool uses error exit code 99.
+
+Do not use `cargo oxide sanitize` for qualification. That shortcut can rebuild
+the runner, so it cannot prove that all four reports cover one recorded
+artifact.
 
 For Graph gates, include capture, replay, completion settlement, and graph
 destruction in the sanitizer process. A clean sanitizer run does not replace

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -195,9 +195,9 @@ The current runner covers:
   shared target rejection.
 - one fixed-address six-token Graph case.
 
-One mapped append uses three commands: one validator kernel, one mapped append
-kernel, and one device-to-host status copy. The fixed-address Graph case
-captures this three-command sequence.
+Each mapped-append stage uses three commands: one validator kernel, one mapped
+append kernel, and one device-to-host status copy. The valid-output Graph
+captures three stages, for nine Oxide commands in total.
 
 Each map owns one workspace for the full scope. A second map from the same
 workspace must fail before submission. The map also binds the exact writable
@@ -239,7 +239,8 @@ Build each admitted runner once, then run all four tools against that exact
 binary. For example:
 
 ```bash
-make h20-build-runner H20_RUNNER=rms_norm_h20 | tee h20-build.log
+set -euo pipefail
+make h20-build-runner H20_RUNNER=rms_norm_h20 2>&1 | tee h20-build.log
 runner_sha="$(sed -n 's/^runner_binary=.* sha256=\([0-9a-f]\{64\}\) arch=.*/\1/p' h20-build.log)"
 test "${#runner_sha}" -eq 64
 make h20-sanitize-runner H20_RUNNER=rms_norm_h20 \

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -270,19 +270,26 @@ launch, concurrent replay, and default-stream capture.
 
 Current Graph cases are:
 
-| Operator | Captured commands | Fixture |
-| --- | --- | --- |
-| RMSNorm to GEMM | Two | `(1,4096)` RMSNorm into `(1,4096,4096)` GEMM |
-| Ragged prefill | Two | Long tiled GQA4 `(2,96,1280,16,4)` |
-| Paged decode rejection | Three | Invalid page index with two reusable replays |
-| Paged prefill | Three | Direct GQA4 `(2,6,6,16,4)` |
-| Fused append | Three | Validator, six-token mapped append, and status copy under the exclusive-page contract |
+Every valid-output case captures three stages: an independent poison observer,
+a target-poison stage, and the real stage. The last two stages write the same
+checked addresses in order during every replay.
+
+| Operator | Commands per stage | Captured total | Fixture |
+| --- | ---: | ---: | --- |
+| RMSNorm to GEMM | 2 | 6 | `(1,4096)` RMSNorm into `(1,4096,4096)` GEMM |
+| Ragged prefill | 2 | 6 | Long tiled GQA4 `(2,96,1280,16,4)` |
+| Paged decode rejection | Not applicable | 3 | Invalid page index with two reusable replays |
+| Paged prefill | 3 | 9 | Direct GQA4 `(2,6,6,16,4)` |
+| Fused append | 3 | 9 | Validator, six-token mapped append, and status copy under the exclusive-page contract |
+
+The paged-decode row is a sentinel-preserving rejection Graph. It does not
+qualify a valid-output Graph path.
 
 A current Graph qualification must:
 
 1. Compare the standalone result with the independent reference.
-2. Poison every graph-written output span or append target before replay.
-3. Replay and prove that no poison remains in a valid result.
+2. Capture a target-poison stage before the real stage in every valid replay.
+3. Replay and prove that the real stage replaces the poison.
 4. Drop external plan and read owners before replay.
 5. Exercise explicit `wait()` and completion-drop settlement.
 6. Record capture count, command count, replay count, and binding policy.
@@ -342,7 +349,8 @@ The new scripts require:
 - raw samples from both provider orders.
 - a verified provider version and source identity, or an explicit unverified
   source field.
-- poisoned Graph outputs before the correctness replay.
+- for valid Graph cases, a captured target-poison stage before the real stage
+  inside each correctness replay.
 - strict summaries that reject incompatible contract, run, or execution
   metadata.
 

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -36,10 +36,12 @@ FlashInfer comparison scripts use separate PyTorch F32 references.
 No published result proves cross-provider reference-digest parity.
 The summarizer rejects mixed contracts, fixtures, measurements, and execution identities.
 
-Current Graph qualification requires each validation replay to run an output
-poison command before the checked operator writes that output. Earlier records
-do not satisfy that rule. Benchmark `graph_nodes` fields are handwritten
-metadata, not CUDA driver enumeration.
+Current Graph qualification requires every valid recipe to capture a
+target-poison operator stage before the real operator stage. Both stages run
+inside each replay and write the same output addresses.
+
+Earlier records do not satisfy that rule. Benchmark `graph_nodes` fields are
+handwritten metadata, not CUDA driver enumeration.
 
 A binary FlashInfer wheel records its verified distribution version but no
 source commit unless the artifact proves one.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,7 @@ A stable public surface needs:
 
 ## R0: Rename and normalize the framework
 
-**State:** active.
+**State:** complete.
 
 The rename changes current identifiers to Oxide Infer. Historical records,
 tags, and commit links keep their original names.
@@ -101,7 +101,7 @@ Exit gate:
 
 ## R1: Requalify current source
 
-**State:** planned immediately after R0.
+**State:** active.
 
 The rename and namespace migration change source identity. Historical device
 records do not qualify the new tree.

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#111713" />
+  <rect x="0.5" y="0.5" width="63" height="63" rx="7.5" fill="none" stroke="#28332c" />
+  <path d="M25 16 15 48M49 16 39 48" fill="none" stroke="#d6ff63" stroke-linecap="square" stroke-width="7" />
+</svg>

--- a/website/src/layouts/SiteLayout.astro
+++ b/website/src/layouts/SiteLayout.astro
@@ -26,7 +26,8 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
-    <meta name="theme-color" content="#070910" />
+    <meta name="theme-color" content="#090b0a" />
+    <link rel="icon" type="image/svg+xml" href={local("/favicon.svg")} />
     <link rel="canonical" href={canonical} />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Oxide Infer" />
@@ -43,7 +44,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
     <div class="site-shell">
       <header class="site-header">
         <a class="brand" href={local("/")} aria-label="Oxide Infer home">
-          <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+          <span class="brand-mark" aria-hidden="true">//</span>
           <span class="brand-copy"><strong>OXIDE</strong><small>INFER</small></span>
         </a>
 
@@ -66,7 +67,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
 
       <footer class="site-footer">
         <div class="footer-brand">
-          <span class="footer-glyph" aria-hidden="true">OX</span>
+          <span class="footer-glyph" aria-hidden="true">//</span>
           <div><strong>Oxide Infer</strong><p>Rust-native GPU operator runtime.</p></div>
         </div>
         <div class="footer-links">

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1,21 +1,21 @@
 :root {
   color-scheme: dark;
-  --bg: #070910;
-  --bg-deep: #04050a;
-  --panel: #0d111a;
-  --panel-high: #121824;
-  --metal: #171d28;
-  --line: #242c3a;
-  --line-soft: rgba(145, 167, 201, 0.13);
-  --text: #f2f5fb;
-  --muted: #9aa8bc;
-  --dim: #667387;
-  --blue: #54b7ff;
-  --blue-soft: rgba(84, 183, 255, 0.11);
-  --violet: #9674ff;
-  --magenta: #ed4ca6;
-  --magenta-soft: rgba(237, 76, 166, 0.1);
-  --amber: #e7a95c;
+  --bg: #090b0a;
+  --bg-deep: #080a09;
+  --panel: #111713;
+  --panel-high: #151d18;
+  --metal: #0e1210;
+  --line: #28332c;
+  --line-soft: rgba(153, 177, 161, 0.14);
+  --text: #f4f7f3;
+  --muted: #a4afa7;
+  --dim: #707b73;
+  --accent: #d6ff63;
+  --accent-soft: rgba(214, 255, 99, 0.1);
+  --accent-secondary: #82adff;
+  --accent-secondary-soft: rgba(130, 173, 255, 0.09);
+  --warning: #ff9a68;
+  --warning-soft: rgba(255, 154, 104, 0.09);
   --max: 1280px;
   --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas, monospace;
@@ -32,9 +32,9 @@ body {
   min-width: 320px;
   margin: 0;
   background:
-    radial-gradient(circle at 78% 0%, rgba(84, 183, 255, 0.12), transparent 30rem),
-    radial-gradient(circle at 18% 26%, rgba(150, 116, 255, 0.075), transparent 34rem),
-    linear-gradient(180deg, #080b12 0%, var(--bg) 24rem);
+    radial-gradient(circle at 78% 0%, rgba(130, 173, 255, 0.09), transparent 30rem),
+    radial-gradient(circle at 18% 26%, rgba(214, 255, 99, 0.055), transparent 34rem),
+    var(--bg);
   color: var(--text);
   font-family: var(--sans);
   line-height: 1.6;
@@ -46,8 +46,8 @@ body::before {
   z-index: -1;
   inset: 0;
   background-image:
-    linear-gradient(rgba(129, 153, 189, 0.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(129, 153, 189, 0.055) 1px, transparent 1px);
+    linear-gradient(rgba(153, 177, 161, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(153, 177, 161, 0.045) 1px, transparent 1px);
   background-size: 64px 64px;
   mask-image: linear-gradient(to bottom, black, transparent 86%);
   content: "";
@@ -56,10 +56,10 @@ body::before {
 
 a { color: inherit; text-decoration: none; }
 code, pre { font-family: var(--mono); }
-::selection { background: var(--blue); color: var(--bg-deep); }
+::selection { background: var(--accent); color: #10130e; }
 
 :focus-visible {
-  outline: 2px solid var(--blue);
+  outline: 2px solid var(--accent);
   outline-offset: 4px;
 }
 
@@ -71,8 +71,8 @@ code, pre { font-family: var(--mono); }
   padding: 0.7rem 0.95rem;
   transform: translateY(-180%);
   border-radius: 0.3rem;
-  background: var(--blue);
-  color: var(--bg-deep);
+  background: var(--accent);
+  color: #10130e;
   font-weight: 760;
 }
 
@@ -103,34 +103,30 @@ code, pre { font-family: var(--mono); }
 .brand-mark {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 2px;
+  place-items: center;
   width: 36px;
   height: 36px;
-  padding: 8px;
   overflow: hidden;
-  border: 1px solid #384356;
+  border: 1px solid var(--line);
   border-radius: 0.2rem;
-  background: linear-gradient(145deg, #202837, #0c1018 60%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  background: linear-gradient(145deg, var(--panel-high), var(--bg-deep) 60%);
+  box-shadow: inset 0 1px 0 var(--line-soft);
+  color: var(--accent);
+  font: 760 0.92rem/1 var(--mono);
+  letter-spacing: -0.12em;
+  text-shadow: 0 0 10px rgba(214, 255, 99, 0.28);
 }
 
 .brand-mark::after {
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, transparent 30%, rgba(255, 255, 255, 0.12), transparent 62%);
+  background: linear-gradient(120deg, transparent 30%, rgba(214, 255, 99, 0.09), transparent 62%);
   content: "";
 }
 
-.brand-mark i { align-self: end; background: var(--blue); box-shadow: 0 0 10px rgba(84, 183, 255, 0.45); }
-.brand-mark i:nth-child(1) { height: 38%; opacity: 0.48; }
-.brand-mark i:nth-child(2) { height: 70%; opacity: 0.72; }
-.brand-mark i:nth-child(3) { height: 100%; }
-.brand-mark i:nth-child(4) { height: 58%; background: var(--magenta); }
-
 .brand-copy { display: grid; gap: 0.05rem; line-height: 1; }
 .brand-copy strong { font: 760 0.78rem/1 var(--mono); letter-spacing: 0.16em; }
-.brand-copy small { color: var(--blue); font: 650 0.5rem/1 var(--mono); letter-spacing: 0.33em; }
+.brand-copy small { color: var(--accent); font: 650 0.5rem/1 var(--mono); letter-spacing: 0.33em; }
 
 .site-header nav {
   display: flex;
@@ -138,7 +134,7 @@ code, pre { font-family: var(--mono); }
   padding: 0.25rem;
   border: 1px solid var(--line-soft);
   border-radius: 999px;
-  background: rgba(8, 11, 18, 0.72);
+  background: rgba(12, 16, 14, 0.72);
   backdrop-filter: blur(16px);
 }
 
@@ -162,7 +158,7 @@ code, pre { font-family: var(--mono); }
   font: 640 0.69rem/1 var(--mono);
 }
 
-.source-link:hover { color: var(--blue); }
+.source-link:hover { color: var(--accent); }
 main { min-height: 72vh; }
 
 .hero {
@@ -182,7 +178,7 @@ main { min-height: 72vh; }
   gap: 0.65rem;
   align-items: center;
   margin: 0;
-  color: var(--blue);
+  color: var(--accent);
   font: 670 0.65rem/1.4 var(--mono);
   letter-spacing: 0.11em;
   text-transform: uppercase;
@@ -192,8 +188,8 @@ main { min-height: 72vh; }
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--blue);
-  box-shadow: 0 0 0 5px var(--blue-soft), 0 0 18px rgba(84, 183, 255, 0.6);
+  background: var(--accent);
+  box-shadow: 0 0 0 5px var(--accent-soft), 0 0 18px rgba(214, 255, 99, 0.28);
 }
 
 .eyebrow::before { width: 24px; height: 1px; background: currentColor; content: ""; }
@@ -208,9 +204,7 @@ main { min-height: 72vh; }
 }
 
 .hero h1 span {
-  background: linear-gradient(90deg, var(--blue), var(--violet) 58%, var(--magenta));
-  background-clip: text;
-  color: transparent;
+  color: var(--accent);
 }
 
 .hero-lede {
@@ -238,10 +232,10 @@ main { min-height: 72vh; }
   transition: border-color 150ms ease, transform 150ms ease, background 150ms ease;
 }
 
-.button:hover { transform: translateY(-2px); border-color: var(--blue); }
-.button.primary { border-color: var(--blue); background: var(--blue); color: #06101a; }
-.button.primary:hover { background: #81c9ff; }
-.button.quiet { background: rgba(13, 17, 26, 0.72); color: var(--text); }
+.button:hover { transform: translateY(-2px); border-color: var(--accent); }
+.button.primary { border-color: var(--accent); background: var(--accent); color: #10130e; }
+.button.primary:hover { background: #e0ff88; }
+.button.quiet { background: rgba(17, 23, 19, 0.68); color: var(--text); }
 
 .hero-facts {
   display: flex;
@@ -254,15 +248,15 @@ main { min-height: 72vh; }
   list-style: none;
 }
 
-.hero-facts li::before { margin-right: 0.45rem; color: var(--magenta); content: "/"; }
+.hero-facts li::before { margin-right: 0.45rem; color: var(--accent-secondary); content: "/"; }
 
 .kernel-console {
   position: relative;
   overflow: hidden;
-  border: 1px solid #30394a;
+  border: 1px solid var(--line);
   border-radius: 0.55rem;
-  background: linear-gradient(145deg, rgba(22, 29, 41, 0.96), rgba(7, 10, 16, 0.98));
-  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.52), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background: rgba(15, 20, 17, 0.9);
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.36);
   animation: enter 650ms 100ms ease both;
 }
 
@@ -273,7 +267,7 @@ main { min-height: 72vh; }
   left: -20%;
   width: 24%;
   transform: rotate(12deg);
-  background: linear-gradient(90deg, transparent, rgba(84, 183, 255, 0.09), transparent);
+  background: linear-gradient(90deg, transparent, rgba(130, 173, 255, 0.055), transparent);
   content: "";
   animation: scan 7s 1.2s ease-in-out infinite;
   pointer-events: none;
@@ -283,8 +277,8 @@ main { min-height: 72vh; }
   position: absolute;
   inset: 38px 0 32px;
   background-image:
-    linear-gradient(rgba(130, 153, 187, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(130, 153, 187, 0.045) 1px, transparent 1px);
+    linear-gradient(rgba(153, 177, 161, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(153, 177, 161, 0.045) 1px, transparent 1px);
   background-size: 24px 24px;
   pointer-events: none;
 }
@@ -302,37 +296,37 @@ main { min-height: 72vh; }
 }
 
 .console-footer { border-top: 1px solid var(--line); border-bottom: 0; }
-.console-state { display: flex; gap: 0.42rem; align-items: center; color: var(--blue); }
+.console-state { display: flex; gap: 0.42rem; align-items: center; color: var(--accent); }
 .console-state i { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
 .console-body { position: relative; z-index: 1; padding: 1.2rem; }
 
-.console-ident { display: grid; gap: 0.35rem; padding: 0.9rem 1rem; border-left: 2px solid var(--blue); background: rgba(84, 183, 255, 0.055); }
-.console-ident span { color: var(--blue); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.12em; }
+.console-ident { display: grid; gap: 0.35rem; padding: 0.9rem 1rem; border-left: 2px solid var(--accent); background: rgba(214, 255, 99, 0.055); }
+.console-ident span { color: var(--accent); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.12em; }
 .console-ident strong { font: 560 0.82rem/1.4 var(--mono); }
 
-.provider-switch { display: grid; grid-template-columns: 1fr 1fr; margin: 1rem 0; padding: 3px; border: 1px solid var(--line); background: #070a10; }
+.provider-switch { display: grid; grid-template-columns: 1fr 1fr; margin: 1rem 0; padding: 3px; border: 1px solid var(--line); background: var(--bg-deep); }
 .provider-switch span { padding: 0.48rem; color: var(--dim); font: 620 0.56rem/1 var(--mono); text-align: center; }
-.provider-switch .selected { background: linear-gradient(90deg, var(--blue-soft), rgba(150, 116, 255, 0.11)); color: var(--blue); }
+.provider-switch .selected { background: linear-gradient(90deg, var(--accent-soft), var(--accent-secondary-soft)); color: var(--accent); }
 
 .console-flow { border-top: 1px solid var(--line); }
 .console-flow > div { display: grid; grid-template-columns: 0.8fr 1.6fr auto; gap: 0.8rem; align-items: center; min-height: 61px; padding: 0.65rem 0.8rem; border-bottom: 1px solid var(--line-soft); }
 .console-flow small, .console-flow em { color: var(--dim); font: 550 0.55rem/1 var(--mono); text-transform: uppercase; }
 .console-flow strong { font: 550 0.68rem/1.3 var(--mono); }
 .console-flow em { font-style: normal; }
-.console-flow .flow-active { border-left: 1px solid var(--magenta); background: var(--magenta-soft); }
-.console-flow .flow-active small, .console-flow .flow-active em { color: var(--magenta); }
+.console-flow .flow-active { border-left: 1px solid var(--accent); background: var(--accent-soft); }
+.console-flow .flow-active small, .console-flow .flow-active em { color: var(--accent); }
 
 .scope-strip {
   display: grid;
   grid-template-columns: 1fr 1fr;
   border-block: 1px solid var(--line);
-  background: rgba(10, 14, 22, 0.55);
+  background: rgba(17, 23, 19, 0.55);
 }
 
 .scope-strip div { display: grid; gap: 0.45rem; padding: 1.15rem 1.25rem; }
 .scope-strip div + div { border-left: 1px solid var(--line); }
-.scope-strip span { color: var(--blue); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.1em; }
-.scope-strip div + div span { color: var(--magenta); }
+.scope-strip span { color: var(--accent); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.1em; }
+.scope-strip div + div span { color: var(--accent-secondary); }
 .scope-strip strong { color: var(--muted); font-size: 0.72rem; font-weight: 570; }
 
 .section { padding-block: clamp(5.5rem, 10vw, 8.5rem); border-bottom: 1px solid var(--line-soft); }
@@ -351,13 +345,13 @@ main { min-height: 72vh; }
 .section-heading > p,
 .page-hero > p { max-width: 650px; margin: 0; color: var(--muted); font-size: 0.94rem; }
 
-.execution-chain { display: grid; grid-template-columns: repeat(6, 1fr); margin: 0; padding: 0; border: 1px solid var(--line); background: rgba(11, 15, 23, 0.68); list-style: none; }
+.execution-chain { display: grid; grid-template-columns: repeat(6, 1fr); margin: 0; padding: 0; border: 1px solid var(--line); background: rgba(16, 22, 18, 0.58); list-style: none; }
 .execution-chain li { position: relative; min-height: 240px; padding: 1.25rem; border-right: 1px solid var(--line); }
 .execution-chain li:last-child { border-right: 0; }
-.execution-chain li::after { position: absolute; top: 37px; right: -5px; z-index: 2; width: 8px; height: 8px; border: 2px solid var(--bg); border-radius: 50%; background: var(--blue); content: ""; }
-.execution-chain li:nth-child(5)::after { background: var(--magenta); }
+.execution-chain li::after { position: absolute; top: 37px; right: -5px; z-index: 2; width: 8px; height: 8px; border: 2px solid var(--bg); border-radius: 50%; background: var(--accent); content: ""; }
+.execution-chain li:nth-child(5)::after { background: var(--accent-secondary); }
 .execution-chain li:last-child::after { display: none; }
-.chain-key { color: var(--blue); font: 650 0.59rem/1 var(--mono); }
+.chain-key { color: var(--accent-secondary); font: 650 0.59rem/1 var(--mono); }
 .execution-chain div { margin-top: 4.6rem; }
 .execution-chain h3 { margin: 0 0 0.55rem; font-size: 0.92rem; }
 .execution-chain p { margin: 0; color: var(--muted); font-size: 0.74rem; }
@@ -365,8 +359,8 @@ main { min-height: 72vh; }
 .operator-matrix { display: grid; grid-template-columns: 1.35fr 0.85fr 0.8fr; border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
 .operator-group { min-width: 0; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .operator-group > header { min-height: 132px; padding: 1.2rem; border-bottom: 1px solid var(--line); }
-.operator-group > header span { display: inline-flex; padding: 0.35rem 0.48rem; border: 1px solid rgba(84, 183, 255, 0.3); color: var(--blue); font: 620 0.55rem/1 var(--mono); letter-spacing: 0.05em; text-transform: uppercase; }
-.operator-group.experimental > header span { border-color: rgba(237, 76, 166, 0.32); color: var(--magenta); }
+.operator-group > header span { display: inline-flex; padding: 0.35rem 0.48rem; border: 1px solid rgba(214, 255, 99, 0.28); color: var(--accent); font: 620 0.55rem/1 var(--mono); letter-spacing: 0.05em; text-transform: uppercase; }
+.operator-group.experimental > header span { border-color: rgba(255, 154, 104, 0.3); color: var(--warning); }
 .operator-group.planned > header span { border-color: var(--line); color: var(--dim); }
 .operator-group > header p { margin: 0.8rem 0 0; color: var(--muted); font-size: 0.73rem; }
 .operator-list article { display: grid; grid-template-columns: minmax(110px, 0.7fr) minmax(0, 1.25fr) auto; gap: 0.8rem; align-items: center; min-height: 84px; padding: 0.9rem 1.15rem; border-bottom: 1px solid var(--line-soft); }
@@ -374,21 +368,21 @@ main { min-height: 72vh; }
 .operator-list h3, .operator-list p { margin: 0; }
 .operator-list h3 { font-size: 0.82rem; }
 .operator-list p { color: var(--muted); font-size: 0.69rem; }
-.operator-list code { color: var(--blue); font-size: 0.58rem; text-transform: uppercase; }
-.experimental .operator-list code { color: var(--magenta); }
+.operator-list code { color: var(--accent-secondary); font-size: 0.58rem; text-transform: uppercase; }
+.experimental .operator-list code { color: var(--warning); }
 .planned .operator-list code { color: var(--dim); }
 
-.text-link { display: inline-flex; gap: 0.55rem; align-items: center; margin-top: 1.55rem; color: var(--blue); font: 620 0.7rem/1.4 var(--mono); }
+.text-link { display: inline-flex; gap: 0.55rem; align-items: center; margin-top: 1.55rem; color: var(--accent); font: 620 0.7rem/1.4 var(--mono); }
 .text-link span { transition: transform 140ms ease; }
 .text-link:hover span { transform: translateX(4px); }
 
 .provider-diagram { display: grid; justify-items: center; }
-.provider-core { display: grid; gap: 0.55rem; width: min(100%, 560px); padding: 1.35rem 1.5rem; border: 1px solid rgba(84, 183, 255, 0.35); background: linear-gradient(135deg, var(--blue-soft), rgba(150, 116, 255, 0.06)), var(--panel); text-align: center; }
-.provider-core span { color: var(--blue); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.12em; }
+.provider-core { display: grid; gap: 0.55rem; width: min(100%, 560px); padding: 1.35rem 1.5rem; border: 1px solid rgba(214, 255, 99, 0.34); background: linear-gradient(135deg, var(--accent-soft), rgba(130, 173, 255, 0.055)), var(--panel); text-align: center; }
+.provider-core span { color: var(--accent); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.12em; }
 .provider-core strong { font: 590 1rem/1.4 var(--mono); }
 .provider-core small { color: var(--muted); font: 550 0.62rem/1.4 var(--mono); }
 .provider-branches { position: relative; display: grid; grid-template-columns: 1fr 1fr; width: 50%; height: 72px; }
-.provider-branches::before { position: absolute; top: 0; left: 50%; width: 1px; height: 36px; background: var(--blue); content: ""; }
+.provider-branches::before { position: absolute; top: 0; left: 50%; width: 1px; height: 36px; background: var(--accent); content: ""; }
 .provider-branches i { position: relative; border-top: 1px solid var(--line); }
 .provider-branches i:first-child { margin-top: 35px; border-right: 1px solid var(--line); }
 .provider-branches i:last-child { margin-top: 35px; }
@@ -396,10 +390,10 @@ main { min-height: 72vh; }
 .provider-branches i:first-child::after { left: 0; }
 .provider-branches i:last-child::after { right: 0; }
 .provider-lanes { display: grid; grid-template-columns: 1fr 1fr; width: 100%; border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
-.provider-lanes article { min-height: 290px; padding: clamp(1.4rem, 4vw, 2.4rem); border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: linear-gradient(145deg, rgba(84, 183, 255, 0.055), transparent 42%); }
-.provider-lanes article + article { background: linear-gradient(145deg, rgba(237, 76, 166, 0.05), transparent 42%); }
-.provider-lanes article > span { color: var(--blue); font: 650 0.58rem/1 var(--mono); letter-spacing: 0.1em; }
-.provider-lanes article + article > span { color: var(--magenta); }
+.provider-lanes article { min-height: 290px; padding: clamp(1.4rem, 4vw, 2.4rem); border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: linear-gradient(145deg, rgba(214, 255, 99, 0.055), transparent 42%); }
+.provider-lanes article + article { background: linear-gradient(145deg, rgba(130, 173, 255, 0.055), transparent 42%); }
+.provider-lanes article > span { color: var(--accent); font: 650 0.58rem/1 var(--mono); letter-spacing: 0.1em; }
+.provider-lanes article + article > span { color: var(--accent-secondary); }
 .provider-lanes h3 { margin: 3rem 0 0.6rem; font-size: 1.3rem; }
 .provider-lanes p { max-width: 520px; margin: 0; color: var(--muted); font-size: 0.8rem; }
 .provider-lanes ul { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 1.4rem 0 0; padding: 0; list-style: none; }
@@ -408,9 +402,9 @@ main { min-height: 72vh; }
 .evidence-ledger { display: grid; grid-template-columns: repeat(2, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
 .evidence-ledger article { display: grid; grid-template-columns: 32px minmax(120px, 0.72fr) 1fr; gap: 1rem; min-height: 190px; padding: 1.35rem; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .evidence-ledger article > span { color: var(--dim); font: 570 0.56rem/1 var(--mono); }
-.evidence-ledger article > strong { color: var(--blue); font: 620 clamp(1.4rem, 3vw, 2.7rem)/0.95 var(--mono); letter-spacing: -0.06em; }
-.evidence-ledger article:nth-child(2) > strong { color: var(--violet); }
-.evidence-ledger article:nth-child(3) > strong { color: var(--magenta); }
+.evidence-ledger article > strong { color: var(--accent); font: 620 clamp(1.4rem, 3vw, 2.7rem)/0.95 var(--mono); letter-spacing: -0.06em; }
+.evidence-ledger article:nth-child(2) > strong { color: var(--accent-secondary); }
+.evidence-ledger article:nth-child(3) > strong { color: var(--warning); }
 .evidence-ledger h3, .evidence-ledger p { margin: 0; }
 .evidence-ledger h3 { font-size: 0.82rem; }
 .evidence-ledger p { margin-top: 0.35rem; color: var(--muted); font-size: 0.72rem; }
@@ -418,9 +412,9 @@ main { min-height: 72vh; }
 
 .milestone-list { border-top: 1px solid var(--line); }
 .milestone-list article { display: grid; grid-template-columns: 78px minmax(0, 1fr); gap: 1.2rem; align-items: center; min-height: 112px; border-bottom: 1px solid var(--line); }
-.milestone-list > article > span { color: var(--blue); font: 640 0.57rem/1 var(--mono); }
-.milestone-list article:nth-child(2) > span { color: var(--violet); }
-.milestone-list article:nth-child(3) > span { color: var(--magenta); }
+.milestone-list > article > span { color: var(--accent); font: 640 0.57rem/1 var(--mono); }
+.milestone-list article:nth-child(2) > span { color: var(--accent-secondary); }
+.milestone-list article:nth-child(3) > span { color: var(--warning); }
 .milestone-list h3, .milestone-list p { margin: 0; }
 .milestone-list h3 { font-size: 0.98rem; }
 .milestone-list p { margin-top: 0.3rem; color: var(--muted); font-size: 0.78rem; }
@@ -428,20 +422,20 @@ main { min-height: 72vh; }
 .adapter-flow { display: grid; grid-template-columns: repeat(3, 1fr); align-items: stretch; margin-bottom: 2.2rem; }
 .adapter-flow > div { position: relative; display: grid; gap: 0.42rem; min-height: 150px; padding: 1.25rem; border: 1px solid var(--line); background: var(--panel); }
 .adapter-flow > div + div { border-left: 0; }
-.adapter-flow > div:not(:last-child)::after { position: absolute; top: 50%; right: -8px; z-index: 2; width: 14px; height: 14px; transform: translateY(-50%) rotate(45deg); border-top: 1px solid var(--blue); border-right: 1px solid var(--blue); background: var(--panel); content: ""; }
-.adapter-flow span { color: var(--blue); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.1em; }
+.adapter-flow > div:not(:last-child)::after { position: absolute; top: 50%; right: -8px; z-index: 2; width: 14px; height: 14px; transform: translateY(-50%) rotate(45deg); border-top: 1px solid var(--accent); border-right: 1px solid var(--accent); background: var(--panel); content: ""; }
+.adapter-flow span { color: var(--accent); font: 650 0.55rem/1 var(--mono); letter-spacing: 0.1em; }
 .adapter-flow strong { align-self: end; font: 590 0.92rem/1.3 var(--mono); }
 .adapter-flow small { color: var(--muted); font: 540 0.61rem/1.4 var(--mono); }
-.adapter-gate { background: linear-gradient(135deg, var(--magenta-soft), var(--panel)) !important; }
-.adapter-gate span { color: var(--magenta); }
+.adapter-gate { background: linear-gradient(135deg, var(--accent-secondary-soft), var(--panel)) !important; }
+.adapter-gate span { color: var(--accent-secondary); }
 .adapter-grid { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
 .adapter-grid article { min-height: 185px; padding: 1.2rem; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .adapter-grid span { color: var(--dim); font: 620 0.55rem/1 var(--mono); text-transform: uppercase; }
-.adapter-grid article:first-child span { color: var(--blue); }
+.adapter-grid article:first-child span { color: var(--accent); }
 .adapter-grid h3 { margin: 2.5rem 0 0.45rem; font-size: 1rem; }
 .adapter-grid p { margin: 0; color: var(--muted); font-size: 0.73rem; }
 
-.closing-band { display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: end; margin-block: 4rem 7rem; padding: clamp(1.6rem, 5vw, 3rem); border: 1px solid rgba(84, 183, 255, 0.34); background: linear-gradient(130deg, var(--blue-soft), rgba(150, 116, 255, 0.06) 52%, var(--magenta-soft)), var(--panel); }
+.closing-band { display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: end; margin-block: 4rem 7rem; padding: clamp(1.6rem, 5vw, 3rem); border: 1px solid rgba(214, 255, 99, 0.34); background: linear-gradient(135deg, rgba(214, 255, 99, 0.09), transparent 55%), var(--panel); }
 .closing-actions { margin-top: 0; }
 
 .page-hero { max-width: 940px; padding-block: clamp(5rem, 10vw, 8.5rem) clamp(3.8rem, 7vw, 5.5rem); }
@@ -450,39 +444,39 @@ main { min-height: 72vh; }
 .docs-sidebar { position: sticky; top: 1.5rem; align-self: start; padding: 1rem 0; }
 .docs-sidebar p { margin: 0 0 1rem; color: var(--dim); font: 650 0.56rem/1 var(--mono); letter-spacing: 0.1em; text-transform: uppercase; }
 .docs-sidebar a { display: block; padding: 0.62rem 0.75rem; border-left: 1px solid var(--line); color: var(--muted); font-size: 0.77rem; }
-.docs-sidebar a:hover, .docs-sidebar a[aria-current="page"] { border-left-color: var(--blue); background: linear-gradient(90deg, var(--blue-soft), transparent); color: var(--text); }
+.docs-sidebar a:hover, .docs-sidebar a[aria-current="page"] { border-left-color: var(--accent); background: linear-gradient(90deg, var(--accent-soft), transparent); color: var(--text); }
 .prose { min-width: 0; max-width: 940px; }
 .prose h2 { margin: 3.6rem 0 1rem; padding-top: 1rem; border-top: 1px solid var(--line-soft); font-size: 1.62rem; letter-spacing: -0.035em; }
 .prose h2:first-child { margin-top: 0; }
 .prose h3 { margin: 2rem 0 0.65rem; font-size: 1rem; }
 .prose p, .prose li { color: var(--muted); font-size: 0.88rem; }
-.prose a { color: var(--blue); text-decoration: underline; text-decoration-color: rgba(84, 183, 255, 0.32); text-underline-offset: 0.2em; }
-.prose pre { overflow-x: auto; margin: 1.3rem 0; padding: 1.2rem 1.3rem; border: 1px solid var(--line); background: #05070c; color: #dce9f7; font-size: 0.72rem; }
-.prose code { color: #b8dfff; }
+.prose a { color: var(--accent); text-decoration: underline; text-decoration-color: rgba(214, 255, 99, 0.32); text-underline-offset: 0.2em; }
+.prose pre { overflow-x: auto; margin: 1.3rem 0; padding: 1.2rem 1.3rem; border: 1px solid var(--line); background: #080a09; color: #e1e8e2; font-size: 0.72rem; }
+.prose code { color: var(--accent-secondary); }
 
 .doc-grid { display: grid; grid-template-columns: repeat(2, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
 .doc-card { min-height: 205px; padding: 1.25rem; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.doc-card > span { color: var(--blue); font: 620 0.55rem/1 var(--mono); letter-spacing: 0.07em; }
+.doc-card > span { color: var(--accent-secondary); font: 620 0.55rem/1 var(--mono); letter-spacing: 0.07em; }
 .doc-card h3 { margin: 2.8rem 0 0.45rem; }
 .doc-card p { margin: 0 0 0.85rem; font-size: 0.77rem; }
 .doc-card a { font: 590 0.66rem/1.4 var(--mono); }
 
 .lifecycle-list { margin: 1.2rem 0; padding: 0; border-top: 1px solid var(--line); list-style: none; }
 .lifecycle-list li { display: grid; grid-template-columns: 42px 1fr; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid var(--line-soft); }
-.lifecycle-list > li > span { color: var(--blue); font: 620 0.57rem/1.6 var(--mono); }
+.lifecycle-list > li > span { color: var(--accent-secondary); font: 620 0.57rem/1.6 var(--mono); }
 .lifecycle-list strong { color: var(--text); }
 .lifecycle-list p { margin: 0.2rem 0 0; }
 
-.doc-note { margin: 1.5rem 0; padding: 1.15rem 1.25rem; border-left: 2px solid var(--blue); background: var(--blue-soft); }
-.doc-note.warning { border-left-color: var(--magenta); background: var(--magenta-soft); }
+.doc-note { margin: 1.5rem 0; padding: 1.15rem 1.25rem; border-left: 2px solid var(--accent); background: var(--accent-soft); }
+.doc-note.warning { border-left-color: var(--warning); background: var(--warning-soft); }
 .doc-note > strong { font-size: 0.86rem; }
 .doc-note p { margin: 0.4rem 0 0; font-size: 0.8rem; }
 
 .operator-doc-groups { display: grid; gap: 1.3rem; }
 .operator-doc-group { border: 1px solid var(--line); }
 .operator-doc-group > header { padding: 1rem 1.15rem; border-bottom: 1px solid var(--line); }
-.operator-doc-group > header h3 { margin: 0; color: var(--blue); }
-.operator-doc-group.experimental > header h3 { color: var(--magenta); }
+.operator-doc-group > header h3 { margin: 0; color: var(--accent); }
+.operator-doc-group.experimental > header h3 { color: var(--warning); }
 .operator-doc-group.planned > header h3 { color: var(--dim); }
 .operator-doc-group > header p { margin: 0.35rem 0 0; font-size: 0.75rem; }
 .table-scroll { overflow-x: auto; }
@@ -496,18 +490,18 @@ main { min-height: 72vh; }
 .operator-table, .evidence-table { display: table; }
 .evidence-level-grid { display: grid; grid-template-columns: repeat(2, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
 .evidence-level-card { display: grid; grid-template-columns: 36px 1fr auto; gap: 0.8rem; min-height: 120px; padding: 1rem; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.evidence-level-card > span, .evidence-level-card small { color: var(--blue); font: 590 0.55rem/1.4 var(--mono); }
+.evidence-level-card > span, .evidence-level-card small { color: var(--accent-secondary); font: 590 0.55rem/1.4 var(--mono); }
 .evidence-level-card h3, .evidence-level-card p { margin: 0; }
 .evidence-level-card p { margin-top: 0.25rem; font-size: 0.72rem; }
 .evidence-level-card small { color: var(--dim); }
 
 .site-footer { display: grid; grid-template-columns: 1fr auto; gap: 1.5rem; align-items: center; padding: 2.1rem 0 2.6rem; border-top: 1px solid var(--line); }
 .footer-brand { display: flex; gap: 0.85rem; align-items: center; }
-.footer-glyph { display: grid; place-items: center; width: 36px; height: 36px; border: 1px solid var(--line); background: linear-gradient(145deg, var(--metal), #090c12); color: var(--blue); font: 680 0.6rem/1 var(--mono); }
+.footer-glyph { display: grid; place-items: center; width: 36px; height: 36px; border: 1px solid var(--line); background: linear-gradient(145deg, var(--metal), var(--bg-deep)); color: var(--accent); font: 760 0.8rem/1 var(--mono); letter-spacing: -0.12em; }
 .footer-brand strong { font-size: 0.78rem; }
 .footer-brand p { margin: 0.1rem 0 0; color: var(--dim); font-size: 0.65rem; }
 .footer-links { display: flex; gap: 1.1rem; color: var(--muted); font: 580 0.62rem/1 var(--mono); }
-.footer-links a:hover { color: var(--blue); }
+.footer-links a:hover { color: var(--accent); }
 .footer-note { grid-column: 1 / -1; margin: 0; color: var(--dim); font: 540 0.58rem/1.4 var(--mono); }
 
 @keyframes enter {
@@ -547,7 +541,7 @@ main { min-height: 72vh; }
   .docs-sidebar { position: static; display: flex; overflow-x: auto; padding: 0 0 1rem; }
   .docs-sidebar p { display: none; }
   .docs-sidebar a { white-space: nowrap; border-bottom: 1px solid var(--line); border-left: 0; }
-  .docs-sidebar a:hover, .docs-sidebar a[aria-current="page"] { border-bottom-color: var(--blue); border-left-color: transparent; }
+  .docs-sidebar a:hover, .docs-sidebar a[aria-current="page"] { border-bottom-color: var(--accent); border-left-color: transparent; }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- Restore the standard dark, lime, blue, and orange website palette.
- Use `//` as the header, footer, and favicon mark.
- Fix H20 qualification at `sm_90a` and require explicit mise use.
- Bind all sanitizer runs to the SHA-256 printed by the runner build.
- Poison Graph outputs on every replay in four permanent correctness gates.

## Validation

- `make check`
- `git diff --check`
- Make target and SHA-256 contract dry-runs
- Desktop, mobile, and docs-page browser checks
- H20 workspace CUDA Clippy with warnings denied
- H20 CUDA lab tests: 7 passed
- H20 `sm_90a` correctness: four runners, 48 cases, six Graph cases

The H20 phase 1 run used source commit
`8927ed70624162b82ffe992e813428aa560ddf65` and tree
`9367f9d15bd0b29cc6026b6b442a0a32bdc8e877`. The evidence record is
`docs/results/h20-r1-graph-correctness-8927ed7-20260812.json`.

## Remaining R1 work

This phase does not qualify Compute Sanitizer, performance, the other five
permanent runners, other GPUs, or real engine and serving execution. The PR
remains a draft until we complete or explicitly exclude those items.
