### PR TITLE
Record H20 R1 phase 1 evidence

### DIFF
--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -15,8 +15,11 @@ count one. The engine or KV pager must make shared tails private before enqueue.
 
 All fused-append H20 records dated 2026-08-06 predate this rule. They remain
 useful for implementation history and old-contract performance, but they do
-not qualify the current source. New correctness, sanitizer, Graph, and matched
-performance records are required.
+not qualify the current source.
+
+The 2026-08-12 phase 1 record below qualifies
+current-source correctness for four declared runners and their named
+fixed-address Graph cases. Compute Sanitizer and matched performance remain open.
 
 The current DeviceRegion work changed submission for RMSNorm, GEMM, decode,
 prefill, and RoPE:
@@ -50,6 +53,17 @@ Existing matched attention and attention-Graph records predate these checks.
 Their raw samples remain historical. Rerun them before citing a current
 provider ranking. The notice above excludes all pre-rename device records dated
 through 2026-08-07 from current-source qualification.
+
+## Current-source R1 phase 1
+
+- [H20 phase 1 correctness and fixed-address Graph](h20-r1-graph-correctness-8927ed7-20260812.json)
+  binds clean source `8927ed7`, strict CUDA Clippy, seven lab library tests,
+  and four of nine permanent H20 runners. The runners cover BF16 cuBLASLt GEMM,
+  ragged prefill, paged prefill, RoPE, and fused paged append. They report 48
+  passing case lines and six named Graph cases.
+
+This record is partial R1 evidence. It excludes Compute Sanitizer, performance,
+the other five permanent runners, other GPUs, and engine or serving execution.
 
 ## Runtime, normalization, and GEMM
 

--- a/docs/results/h20-r1-graph-correctness-8927ed7-20260812.json
+++ b/docs/results/h20-r1-graph-correctness-8927ed7-20260812.json
@@ -1,0 +1,533 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-12",
+  "claim_level": "correctness_and_cuda_graph",
+  "operator": "r1_phase1_bf16_gemm_prefill_rope_append",
+  "status": "passed",
+  "qualification": {
+    "milestone": "R1",
+    "phase": "phase1",
+    "result": "passed",
+    "r1_complete": false,
+    "permanent_h20_runners_total": 9,
+    "executed_h20_runners": 4,
+    "case_lines_passed": 48,
+    "suite_lines_passed": 4,
+    "graph_case_lines_passed": 6
+  },
+  "source": {
+    "repository": "feichai0017/oxide-infer",
+    "ref": "refs/remotes/origin/r1-h20-requalification",
+    "commit": "8927ed70624162b82ffe992e813428aa560ddf65",
+    "tree": "9367f9d15bd0b29cc6026b6b442a0a32bdc8e877",
+    "checkout": "clean detached HEAD",
+    "worktree_status_bytes": 0,
+    "bundle": {
+      "file": "source.bundle",
+      "sha256": "bae18eedea9b8469f3c1063912c521d4c39eac0e184f965f2bc4e9070dd4e97e",
+      "git_bundle_verify": "passed"
+    },
+    "git_archive_sha256": "cec2763c59b0996c2de70f9f3e62fa6a955d3fe89c3ec185cf37a7e80c86c21c",
+    "cargo_lock_sha256": "46011524357470cbad8877e81b4ca8dc8731ee82e03cd553803d9cbe9601c01c",
+    "cuda_oxide_revision": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+    "runner_sources_sha256": {
+      "crates/oxide-infer-lab/src/gates/mod.rs": "be750d4bac192c2436f1a5a9c6500690bbc36b8aba57112a3660a4747385d571",
+      "crates/oxide-infer-lab/src/gates/bf16_gemm.rs": "915be81d942d9d4e15481a5fe52c823e7752cba6573a84d04f9debe16857baf7",
+      "crates/oxide-infer-lab/src/gates/ragged_prefill.rs": "b25b42eb0054e0e4f29221d6ec7befe268c26dc9613c9a60b30b2fe25a231457",
+      "crates/oxide-infer-lab/src/gates/paged_prefill.rs": "40b2cf20839fd5ece4efe4a40d1b29fe3a19d8957b675d9f79ad359fdf89131a",
+      "crates/oxide-infer-lab/src/gates/rope.rs": "60110cfaba9c07053c4c8e4e834d9e53bdfd5537630eb24a8bdd013e16f181fd"
+    }
+  },
+  "environment": {
+    "observed_at_utc": "2026-08-11T16:31:03Z",
+    "record_date_timezone": "Asia/Shanghai",
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "gpu_uuid": "GPU-3a35e57b-fc54-5620-56ee-deaf5a9c40d3",
+    "compute_capability": "9.0",
+    "memory_mib": 97871,
+    "driver": "535.161.08",
+    "cuda_toolkit": "13.1.115",
+    "nvcc": "Cuda compilation tools, release 13.1, V13.1.115",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "llvm_codegen": "22.1.2-rust-1.96.0-nightly",
+    "bindgen_libclang_path": "/usr/lib/llvm-21/lib",
+    "cargo": "1.96.0-nightly",
+    "cargo_oxide": "0.2.1",
+    "cargo_oxide_sha256": "1e9c2a4badcd280a7ac2f9457c621b816ffabf1ddccc78b24d35ff8affceccd9",
+    "rustc_codegen_cuda_sha256": "a8584a44338f74d98bdf81fd6d11a12871ad0ac808a56178a32e00628d08751b",
+    "compute_sanitizer": {
+      "available": true,
+      "version": "2025.4.1.0",
+      "build": "37093031",
+      "executed": false
+    },
+    "producer_environment_metadata": {
+      "path": "meta/09b-offline-environment.txt",
+      "sha256": "f0e3a626ac6fb01e922487b096b6c5327218d6d2d8549305c6439afae7938758",
+      "producer_bundle_manifest_coverage": false,
+      "persistent_archive_tree_coverage": true
+    },
+    "independent_environment_audit": {
+      "source": "persistent read-only archive file",
+      "path": "meta/19-independent-env-audit.txt",
+      "sha256": "19c53e7d57d4d0e753b9d8693880bf359263e8af0518fb49a5886383007710d7",
+      "observed_at_utc": "2026-08-11T16:31:03Z",
+      "exit_code": 0,
+      "producer_final_manifest_coverage": false,
+      "persistent_archive_tree_coverage": true,
+      "note": "The archived audit file is independent from the producer environment metadata. This record embeds its values above directly."
+    }
+  },
+  "evidence_bundle": {
+    "producer_root": "/tmp/oxide-r1-h20-bundle-8927ed-CzORyU",
+    "persistent_archive": {
+      "directory": "/workspace/oxide-r1-evidence/8927ed-phase1-20260812",
+      "directory_mode_octal": "0555",
+      "file_count": 146,
+      "writable_file_count": 0,
+      "payload_manifest": {
+        "path": "/workspace/oxide-r1-evidence/8927ed-phase1-20260812/TREE.sha256",
+        "sha256": "580e145632c7854d447b3e97607e1b51884fe580cf0f061e5a865a987baebf52",
+        "entries": 145,
+        "verification": "passed"
+      },
+      "deterministic_tar": {
+        "path": "/workspace/oxide-r1-evidence/8927ed-phase1-20260812.tar",
+        "sha256": "51b53be0a0d2cf8218bb3984ba06c3ec84eaa1f770a6a56c10e22f717c442930",
+        "size_bytes": 15728640,
+        "mode_octal": "0444",
+        "listing_check": "passed",
+        "stream_recompute": "matched",
+        "closeout_exit_code": 0,
+        "sidecar_mode_octal": "0444"
+      },
+      "storage_claim": "Persistent read-only, hash-bound archive. This is not a WORM or immutable-storage claim."
+    },
+    "final_logs_manifest": {
+      "path": "meta/18-logs-final.sha256",
+      "sha256": "e82d0fb0e965a39811dccc02627711eefd6bec1c1a6d1797201652f67f8c5e55",
+      "coverage": "all saved files in logs at final manifest creation"
+    },
+    "final_commands_exits_manifest": {
+      "path": "meta/18-commands-exits-final.sha256",
+      "sha256": "8f3c3071418a8c0c18f157378f48e0db86af3f2688ae4b0a8b066a41a7f026aa",
+      "coverage": "all saved .command and .exit files in meta at final manifest creation"
+    },
+    "manifest_index": {
+      "path": "meta/18-manifests.sha256",
+      "entries": {
+        "meta/18-logs-final.sha256": "e82d0fb0e965a39811dccc02627711eefd6bec1c1a6d1797201652f67f8c5e55",
+        "meta/18-commands-exits-final.sha256": "8f3c3071418a8c0c18f157378f48e0db86af3f2688ae4b0a8b066a41a7f026aa"
+      }
+    },
+    "final_audit": {
+      "log": "logs/17-final-audit.log",
+      "log_sha256": "a0ea79b966c66878ed0f72716f8364eb5950038696a7105931dd0358299573b3",
+      "exit_code": 0
+    },
+    "producer_final_manifest_coverage_exclusions": [
+      "auxiliary meta files other than .command and .exit files",
+      "target binaries",
+      "generated IR artifacts",
+      "the manifest index itself"
+    ],
+    "binary_binding": "The producer final manifests do not hash target binaries directly. The covered final-audit log records their SHA-256 values. The persistent TREE manifest directly hashes the four copied runner files at those values."
+  },
+  "accepted_gates": {
+    "strict_cuda_clippy": {
+      "status": "passed",
+      "accepted": true,
+      "scope": "workspace, all targets, CUDA feature, warnings denied",
+      "command": "cargo +nightly-2026-04-03 clippy --workspace --all-targets --features cuda -- -D warnings",
+      "command_metadata": "meta/11-cuda-strict-clippy-offline.command",
+      "command_metadata_sha256": "7feac7790fcf26cc432be12f49fa7c8abd134c553f230a55504be27d90522f69",
+      "exit_code": 0,
+      "log": "logs/11-cuda-strict-clippy-offline.log",
+      "log_sha256": "ca68d16970840b67933837876708e0b9241ce9bd9c9d19aa9a2dfe7cb19f1155",
+      "log_size_bytes": 3992
+    },
+    "oxide_infer_lab_lib_tests": {
+      "status": "passed",
+      "accepted": true,
+      "command": "cargo +nightly-2026-04-03 oxide test --arch sm_90a --cargo-target-dir /tmp/oxide-r1-h20-bundle-8927ed-CzORyU/target -- --package oxide-infer-lab --lib --features cuda --release --locked --offline",
+      "command_metadata": "meta/12-validation-lib-tests.command",
+      "command_metadata_sha256": "8a92ff0a551ae5cda0bfcff4b4b3727a85cfecbd8c51d783105f43526ea29098",
+      "exit_code": 0,
+      "passed": 7,
+      "failed": 0,
+      "ignored": 0,
+      "log": "logs/12-validation-lib-tests.log",
+      "log_sha256": "0b0eb96571347c6dfa1db42230adbdb49652e04ab34bf92aa4349f4b13021b08",
+      "log_size_bytes": 4943
+    }
+  },
+  "runners": [
+    {
+      "name": "bf16_gemm_h20",
+      "status": "passed",
+      "exit_code": 0,
+      "artifact_target": "sm_90a",
+      "case_lines_passed": 7,
+      "case_lines_failed": 0,
+      "graph_case_lines_passed": 1,
+      "suite_status": "pass",
+      "case_names": [
+        "plan",
+        "standalone",
+        "row_major_transpose",
+        "short_buffers",
+        "command_capacity",
+        "rms_norm_gemm_chain",
+        "rms_norm_gemm_graph"
+      ],
+      "command_metadata": "meta/13-bf16_gemm_h20.command",
+      "command_metadata_sha256": "10ee46204d92e6925ef81fac3c955bcab7b546bff01922cb49c8992cdc89103f",
+      "binary_sha256": "2f2b655eab8fe75f9317ea51e43f1d2f3baf8e533f3fc83317a568f56940dc44",
+      "producer_final_manifest_direct_binary_coverage": false,
+      "persistent_archive_tree_binary_coverage": true,
+      "persistent_archive_binary": "runners/bf16_gemm_h20",
+      "log": "logs/13-bf16_gemm_h20.log",
+      "log_sha256": "ac65483cdd277e7fde4a8a7b00258d068a0e8a49d57f0f14906983606e63f542",
+      "log_size_bytes": 5983,
+      "correctness": {
+        "provider": "cuBLASLt",
+        "reported_library_version": 130200,
+        "standalone": {
+          "first_bit_mismatches": 0,
+          "second_bit_mismatches": 0,
+          "first_digest": "9c7c07b655452325",
+          "second_digest": "9c7c07b655452325"
+        },
+        "row_major_transpose": {
+          "bit_mismatches": 0,
+          "digest": "c6b0f58fc67782b9"
+        },
+        "rms_norm_gemm_chain": {
+          "bit_mismatches": 0,
+          "digest": "9c7c07b655452325"
+        }
+      },
+      "cuda_graph": {
+        "case": "rms_norm_gemm_graph",
+        "commands": 6,
+        "commands_per_stage": 2,
+        "replays": 2,
+        "fixed_bindings": true,
+        "independent_poison_observable": true,
+        "output_poisoned_each_replay": true,
+        "poison_bit_mismatches": 0,
+        "poison_digest": "b93a0c83ce3b6325",
+        "output_bit_mismatches": 0,
+        "output_digest": "9c7c07b655452325"
+      }
+    },
+    {
+      "name": "ragged_prefill_h20",
+      "status": "passed",
+      "exit_code": 0,
+      "artifact_target": "sm_90a",
+      "case_lines_passed": 9,
+      "case_lines_failed": 0,
+      "graph_case_lines_passed": 1,
+      "suite_status": "pass",
+      "case_names": [
+        "mha_equal_lengths",
+        "mqa_append_mixed",
+        "gqa4_mixed",
+        "mqa_token_parallel",
+        "gqa4_token_parallel",
+        "short_metadata",
+        "invalid_metadata_guard",
+        "missing_workspace",
+        "gqa4_graph"
+      ],
+      "command_metadata": "meta/14-ragged_prefill_h20.command",
+      "command_metadata_sha256": "22c23ccacdf361ed3b7343b3f283bc393d983232e73d273314ac4696c822bc2d",
+      "binary_sha256": "92e1f899f62c02ed406289fe97475f0241bb9d53d60935284c0e13fa81e4980d",
+      "producer_final_manifest_direct_binary_coverage": false,
+      "persistent_archive_tree_binary_coverage": true,
+      "persistent_archive_binary": "runners/ragged_prefill_h20",
+      "log": "logs/14-ragged_prefill_h20.log",
+      "log_sha256": "41c3bb7711ef37023078b7fad8e8b522cac1c9c4c4ddf18bc59944d78179f001",
+      "log_size_bytes": 3957,
+      "limits": {
+        "output_max_abs": 0.015625,
+        "lse_max_abs": 0.009999999776
+      },
+      "observed_max_abs": {
+        "output": 0.00048828125,
+        "lse": 0.000002861022949
+      },
+      "correctness_digests": {
+        "mha_equal_lengths": {
+          "output": "c4d1273353639c68",
+          "lse": "2258a1bdeffb1be3"
+        },
+        "mqa_append_mixed": {
+          "output": "e0ade8c09c501ec4",
+          "lse": "6e70d3bf8dac2179"
+        },
+        "gqa4_mixed": {
+          "output": "33a1ae47f05b7c52",
+          "lse": "9a4fec9d44672083"
+        },
+        "mqa_token_parallel": {
+          "output": "570fe930b30198db",
+          "lse": "a6a4cb9b0d2cd75a"
+        },
+        "gqa4_token_parallel": {
+          "output": "d07e112321c39da3",
+          "lse": "ccfee2ebe2a7ee89"
+        }
+      },
+      "cuda_graph": {
+        "case": "gqa4_graph",
+        "commands": 6,
+        "commands_per_stage": 2,
+        "replays": 2,
+        "fixed_bindings": true,
+        "independent_poison_observable": true,
+        "output_lse_poisoned_each_replay": true,
+        "poison_output_digest": "1a0564b2e8de2325",
+        "poison_lse_digest": "347e2ffdd1ae8f95",
+        "output_digest": "d07e112321c39da3",
+        "lse_digest": "ccfee2ebe2a7ee89"
+      }
+    },
+    {
+      "name": "paged_prefill_h20",
+      "status": "passed",
+      "exit_code": 0,
+      "artifact_target": "sm_90a",
+      "case_lines_passed": 11,
+      "case_lines_failed": 0,
+      "graph_case_lines_passed": 2,
+      "suite_status": "pass",
+      "case_names": [
+        "mha_equal_lengths",
+        "mha_large_pool_short_table_explicit_direct",
+        "mqa_append_mixed",
+        "gqa4_reordered_reuse",
+        "mqa_token_parallel",
+        "gqa4_token_parallel",
+        "short_metadata",
+        "invalid_query_guard",
+        "duplicate_binding",
+        "gqa4_graph",
+        "invalid_page_graph"
+      ],
+      "command_metadata": "meta/15-paged_prefill_h20.command",
+      "command_metadata_sha256": "5ed74db8a9e60254b6a13263fb06681c92086afa7ca3ac78c724ea9b55f23de4",
+      "binary_sha256": "0eb820e372b9d40ec4e020ddfa002335033196881a68a24dc7597552c8d4cac0",
+      "producer_final_manifest_direct_binary_coverage": false,
+      "persistent_archive_tree_binary_coverage": true,
+      "persistent_archive_binary": "runners/paged_prefill_h20",
+      "log": "logs/15-paged_prefill_h20.log",
+      "log_sha256": "28fed10c8ac7816c5b48d8d8dae268bf468b70ff67dbd40afab440a36f2878c2",
+      "log_size_bytes": 5510,
+      "limits": {
+        "output_max_abs": 0.015625,
+        "lse_max_abs": 0.009999999776
+      },
+      "observed_max_abs": {
+        "output": 0.0001220703125,
+        "lse": 0.000003814697266
+      },
+      "correctness_digests": {
+        "mha_equal_lengths": {
+          "output": "362e1d0afe50ead0",
+          "lse": "c98a0f65f8e15dfc"
+        },
+        "mha_large_pool_short_table_explicit_direct": {
+          "output": "5febfbd96bccc45f",
+          "lse": "d386f949aef3277a"
+        },
+        "mqa_append_mixed": {
+          "output": "162842af1426a43b",
+          "lse": "bd21f0541b1ad5b2"
+        },
+        "gqa4_reordered_reuse": {
+          "output": "e9af0a9ac80aad5b",
+          "lse": "58d52ffef464db34"
+        },
+        "mqa_token_parallel": {
+          "output": "17c4caa2ee3adbf7",
+          "lse": "66ba2cd08e68a3ae"
+        },
+        "gqa4_token_parallel": {
+          "output": "75fb0bd19f594dee",
+          "lse": "4fd230c9729f23e5"
+        }
+      },
+      "cuda_graph": {
+        "valid_gqa4": {
+          "commands": 9,
+          "commands_per_stage": 3,
+          "replays": 2,
+          "fixed_bindings": true,
+          "independent_poison_observable": true,
+          "output_lse_poisoned_each_replay": true,
+          "status_packets_rewritten": true,
+          "poison_output_digest": "6e431751526de325",
+          "poison_lse_digest": "a71cf57149699f15",
+          "output_digest": "e9af0a9ac80aad5b",
+          "lse_digest": "58d52ffef464db34"
+        },
+        "invalid_page_rejection": {
+          "commands": 3,
+          "replays": 2,
+          "fixed_bindings": true,
+          "device_rejected": true,
+          "graph_reusable": true,
+          "bindings_recovered": true,
+          "sentinels_unchanged": true
+        }
+      }
+    },
+    {
+      "name": "rope_h20",
+      "status": "passed",
+      "exit_code": 0,
+      "artifact_target": "sm_90a",
+      "case_lines_passed": 21,
+      "case_lines_failed": 0,
+      "graph_case_lines_passed": 2,
+      "suite_status": "pass",
+      "case_names": [
+        "bf16_pos_ids",
+        "short_buffer",
+        "negative_position_guard",
+        "plan_scope",
+        "paged_append",
+        "paged_append_tokens",
+        "paged_append_tokens_limit",
+        "paged_append_tokens_short_metadata",
+        "paged_append_tokens_graph",
+        "paged_append_graph_rejection",
+        "paged_append_duplicate_guard",
+        "paged_append_invalid_page_guard",
+        "paged_append_shared_target_guard",
+        "paged_append_tokens_guard:duplicate_slot",
+        "paged_append_tokens_guard:batch_index",
+        "paged_append_tokens_guard:position",
+        "paged_append_tokens_guard:page_index",
+        "paged_append_tokens_guard:shared_target",
+        "paged_append_tokens_guard:shared_target_underreported",
+        "paged_append_duplicate_status_source",
+        "paged_append_map_cache_binding"
+      ],
+      "command_metadata": "meta/16-rope_h20.command",
+      "command_metadata_sha256": "ba77e3a353db9ce6bc6667d335d7bb1cc6fdf61573f0c1ad31d9da5902f64369",
+      "binary_sha256": "0b8d7dc748bbb7c6059ceb30f090ed4f0d8f82926c952baa18943c9608805dfb",
+      "producer_final_manifest_direct_binary_coverage": false,
+      "persistent_archive_tree_binary_coverage": true,
+      "persistent_archive_binary": "runners/rope_h20",
+      "log": "logs/16-rope_h20.log",
+      "log_sha256": "e06686dc09780381cb9919caa6cea0acbfdc2a6f5775ad27bed5f08d94b8dbc1",
+      "log_size_bytes": 5498,
+      "output_max_abs_limit": 0.015625,
+      "observed_max_abs": 0.00390625,
+      "correctness_digests": {
+        "bf16_pos_ids": {
+          "query": "d72a05a45159faba",
+          "key": "1777adbab54b38c1"
+        },
+        "paged_append": {
+          "query": "598748d85eba74bc",
+          "key_pages": "887c974af7e1f378",
+          "value_pages": "8598cc5af5b13687"
+        },
+        "paged_append_tokens": {
+          "query": "27c79554ea726631",
+          "key_pages": "2c683e2cb5b1500c",
+          "value_pages": "d2df7f039864b190"
+        },
+        "paged_append_tokens_limit": {
+          "query": "f16dd26323eee0d8",
+          "key_pages": "f51c9f683c4a5efc",
+          "value_pages": "e08e9bbb8b868ee2"
+        }
+      },
+      "cuda_graph": {
+        "paged_append_tokens": {
+          "commands": 9,
+          "commands_per_stage": 3,
+          "replays": 2,
+          "fixed_bindings": true,
+          "independent_poison_observable": true,
+          "append_targets_poisoned_each_replay": true,
+          "status_packets_rewritten": true,
+          "poison_query_digest": "ddb1c0803a19e325",
+          "poison_key_pages_digest": "2c417142d402d2e0",
+          "poison_value_pages_digest": "198939ae6bc6909a",
+          "query_digest": "27c79554ea726631",
+          "key_pages_digest": "2c683e2cb5b1500c",
+          "value_pages_digest": "d2df7f039864b190"
+        },
+        "paged_append_rejection": {
+          "commands": 3,
+          "replays": 3,
+          "semantic_rejections": 3,
+          "dropped_rejection_observed": true,
+          "graph_poisoned": false,
+          "bindings_recovered": true,
+          "sentinels_preserved": true
+        }
+      }
+    }
+  ],
+  "non_accepted_attempts": [
+    {
+      "step": "06-source-parity",
+      "accepted": false,
+      "exit_code": 1,
+      "log": "logs/06-source-parity.log",
+      "log_sha256": "2c8169c2e748210527bb1f0bdac199828a625014497be79f7acd3b64bf520c1f",
+      "reason": "The zsh wrapper assigned to the read-only status variable and failed before parity checks.",
+      "replacement": "06b-source-parity passed with exit code 0. It supports provenance only."
+    },
+    {
+      "step": "08-cuda-strict-clippy",
+      "accepted": false,
+      "exit_code": 2,
+      "log": "logs/08-cuda-strict-clippy.log",
+      "log_sha256": "b4b4470b86a3aa4d206aa3b50834ca61748bb3ec43541b582dc3d3473420adb9",
+      "reason": "The configured replacement directory did not contain the locked cudarc package.",
+      "interpretation": "This is an environment and cache failure, not an accepted pass or a product-code failure.",
+      "replacement": "11-cuda-strict-clippy-offline passed with exit code 0."
+    },
+    {
+      "step": "09-offline-metadata-wrapper",
+      "accepted": false,
+      "wrapper_exit_code": 125,
+      "underlying_metadata_exit_code": 0,
+      "log": "logs/09-offline-metadata-wrapper-error.log",
+      "log_sha256": "cef1bbc21056f0bd0cc571a0ccafe3cabf9c1cd0c330965d9d8552220d1cbb71",
+      "reason": "The zsh path special variable overwrote PATH, so the wrapper result is not validation evidence.",
+      "replacement": "09b-offline-metadata passed with exit code 0. It supports environment preparation only."
+    }
+  ],
+  "accepted_claims": [
+    "Strict CUDA-feature Clippy passes for the workspace, all targets, and denied warnings at the recorded source and toolchain.",
+    "The oxide-infer-lab CUDA release library test target passes seven tests with no failures.",
+    "The BF16 cuBLASLt GEMM runner passes seven named correctness cases, including one fixed-address RMSNorm-to-GEMM Graph case.",
+    "The BF16 ragged-prefill runner passes nine named correctness cases, including one fixed-address poison-and-real Graph case.",
+    "The BF16 paged-prefill runner passes eleven named correctness cases, including valid and rejected fixed-address Graph cases.",
+    "The BF16 RoPE and fused paged-append runner passes twenty-one case lines, including valid and rejected fixed-address Graph cases."
+  ],
+  "excluded_claims": [
+    "R1 completion or complete current-source H20 qualification",
+    "Compute Sanitizer execution or memcheck, racecheck, synccheck, and initcheck results",
+    "operator latency, throughput, speedup, provider ranking, or any other performance result",
+    "the full nine-runner H20 suite",
+    "rms_norm_h20, oxide_sm90_simt_gemv_h20, single_decode_h20, paged_batch_decode_h20, or engine_interop_h20 qualification",
+    "correctness, Graph behavior, or performance on GPUs other than the declared H20",
+    "mutable Graph bindings, graph updates, cross-stream launch, concurrent replay, or CUDA driver node enumeration",
+    "real-engine provider hits, no-copy behavior, model output, TTFT, TPOT, throughput, memory, or serving performance",
+    "hermetic or reproducible build provenance, dependency-cache identity, or complete toolchain archival",
+    "WORM, immutable-storage, or external-signature guarantees for the persistent archive",
+    "production readiness, automatic fallback, distributed execution, or fault recovery"
+  ]
+}

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -69,8 +69,8 @@ export const providerLanes = [
 ]
 
 export const evidenceHighlights = [
-  { value: "Pending", label: "Experimental GEMV", detail: "H20 rerun against renamed source and artifact", sample: "prior record is historical" },
-  { value: "Historical", label: "Core CUDA paths", detail: "correctness, Graph, and matched records", sample: "requalification required" },
+  { value: "Phase 1", label: "Current H20 source", detail: "GEMM, ragged and paged prefill, RoPE, and fused append", sample: "correctness and named Graph cases" },
+  { value: "Pending", label: "Remaining R1", detail: "five runners, Compute Sanitizer, and performance", sample: "not qualified by phase 1" },
   { value: "Simulated", label: "Engine interop", detail: "external pointers and event bridge", sample: "not a model run" },
   { value: "Open", label: "Serving", detail: "TTFT, TPOT, throughput, and memory", sample: "no serving evidence" },
 ]

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -50,12 +50,19 @@ import { evidenceHighlights, evidenceLevels, repositoryUrl } from "../data/site"
       </table>
 
       <div class="doc-note warning">
-        <strong>The merged CUDA source requires requalification.</strong>
+        <strong>Current-source H20 qualification is partial.</strong>
         <p>
-          DeviceRegion changed the submission path for every provider. The
-          published device, Graph, and performance records cover earlier source
-          trees. They remain historical records for those exact trees.
+          The phase 1 record covers strict CUDA Clippy, seven lab tests, and
+          four of nine permanent H20 runners. It records correctness and named
+          fixed-address Graph cases.
         </p>
+        <p>
+          It does not cover Compute Sanitizer, performance, the other five
+          runners, other GPUs, or engine execution.
+        </p>
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-r1-graph-correctness-8927ed7-20260812.json`}>
+          Current-source H20 phase 1 record
+        </a>
       </div>
 
       <div class="doc-note">


### PR DESCRIPTION
## Summary

- Add the H20 R1 phase 1 correctness and fixed-address Graph record.
- Bind the record to source commit `8927ed7`, final log manifests, four runner
  binaries, and a persistent read-only evidence archive.
- Update the results index and website to show partial current-source coverage.

## Recorded result

- Workspace CUDA Clippy passed with warnings denied.
- Seven CUDA lab library tests passed.
- Four of nine permanent H20 runners passed 48 cases and six named Graph cases.
- The Graph recipes cover per-replay target poison for GEMM, ragged prefill,
  paged prefill, RoPE, and fused paged append.

The record does not qualify Compute Sanitizer, performance, the other five
runners, other GPUs, engine integration, or serving. R1 remains active.

## Checks

- `make check`
- JSON structure, count, SHA-256, and remote manifest assertions
- Independent evidence and archive audit with no P0, P1, or actionable P2
- Website check and five-page static build
