### PR TITLE
Publish H20 R1 phase 2 qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ prove device correctness or performance.
 
 | Family | Current source | State |
 | --- | --- | --- |
-| Attention | Single decode, paged decode, ragged prefill, paged prefill | Implemented; path-specific requalification |
-| KV cache | Paged append and RoPE plus paged append | Implemented; ownership requalification |
-| GEMM | Contiguous BF16 dense through cuBLASLt | Implemented |
-| GEMV | Native BF16 M=1 SM90a algorithm | Experimental |
-| Normalization | RMSNorm for F32, FP16, and BF16 | Implemented; path-specific requalification |
-| Position | BF16 NeoX RoPE with explicit positions | Implemented; path-specific requalification |
+| Attention | Single decode, paged decode, ragged prefill, paged prefill | Declared H20 runner paths qualified in R1 |
+| KV cache | Paged append and RoPE plus paged append | Exclusive-page H20 runner path qualified in R1 |
+| GEMM | Contiguous BF16 dense through cuBLASLt | H20 correctness, Graph, and sanitizer qualified |
+| GEMV | Native BF16 M=1 SM90a algorithm | Experimental; H20 correctness, Graph, and sanitizer qualified |
+| Normalization | RMSNorm for F32, FP16, and BF16 | Declared H20 runner paths qualified in R1 |
+| Position | BF16 NeoX RoPE with explicit positions | Declared H20 runner path qualified in R1 |
 | Activation | SwiGLU and fused epilogues | Planned |
 | Sampling | Logits transforms, RNG, and token selection | Planned |
 | Advanced attention | MLA and expanded KV layouts | Planned |

--- a/docs/design/oxide-infer-architecture.md
+++ b/docs/design/oxide-infer-architecture.md
@@ -63,11 +63,11 @@ not to a top-level `fused_ops` family.
 
 | Family | Current | Experimental | Planned |
 | --- | --- | --- | --- |
-| `attention` | Single decode, paged decode, ragged prefill, paged prefill | Selected source paths await current-source requalification | Sliding window, mixed-batch attention, MLA, broader head dimensions |
+| `attention` | Single decode, paged decode, ragged prefill, paged prefill; declared R1 runner paths are H20-qualified | None | Sliding window, mixed-batch attention, MLA, broader head dimensions |
 | `gemm` | Contiguous BF16 dense GEMM through cuBLASLt | Native SM90a M=1 BF16 GEMV | FP8, FP4, grouped, quantized, and broader small-M algorithms |
-| `kv_cache` | Fused RoPE plus paged append source | Exclusive-page append contract awaits full requalification | Gather, scatter, compaction, remapping, FP8, and INT8 storage |
-| `normalization` | RMSNorm for F32, FP16, and BF16 | Current-source device requalification | Additional normalization contracts from engine demand |
-| `position` | BF16 NeoX RoPE with explicit positions | Current-source device requalification | Other layouts, dimensions, and position transforms |
+| `kv_cache` | Fused RoPE plus exclusive-page paged append; declared R1 runner path is H20-qualified | None | Gather, scatter, compaction, remapping, FP8, and INT8 storage |
+| `normalization` | RMSNorm for F32, FP16, and BF16; declared R1 runner paths are H20-qualified | None | Additional normalization contracts from engine demand |
+| `position` | BF16 NeoX RoPE with explicit positions; declared R1 runner path is H20-qualified | None | Other layouts, dimensions, and position transforms |
 | `activation` | None | None | SwiGLU and other measured activation contracts |
 | `sampling` | None | None | Logits transforms, penalties, Top-K, Top-P, Min-P, logprobs, and RNG |
 | `speculation` | None | None | Draft verification and token compaction |

--- a/docs/flashinfer-parity.md
+++ b/docs/flashinfer-parity.md
@@ -30,17 +30,17 @@ Oxide Infer does not claim complete domain-level parity.
 
 | Domain | Representative upstream surface | Oxide Infer state |
 | --- | --- | --- |
-| Dense decode attention | `single_decode_with_kv_cache`, paged batch decode, XQA | `requalification`: BF16 NHD single-decode and NHD/HND paged-decode providers exist, but their records predate the DeviceRegion launch path |
-| Prefill attention | Single, ragged batch, and paged batch prefill | `requalification`: BF16 NHD D128 providers exist, but their records predate the DeviceRegion launch path |
-| Paged KV append | Standard and MLA paged append, index and position generation | `requalification`: fused standard-RoPE BF16 append now requires exclusive target pages |
+| Dense decode attention | `single_decode_with_kv_cache`, paged batch decode, XQA | `partial device correct`: current R1 covers declared BF16 NHD single-decode and NHD/HND paged-decode runner cases; XQA and broader contracts remain open |
+| Prefill attention | Single, ragged batch, and paged batch prefill | `partial device correct`: current R1 covers declared BF16 NHD D128 ragged and paged runner cases |
+| Paged KV append | Standard and MLA paged append, index and position generation | `partial device correct`: current R1 covers the declared fused standard-RoPE BF16 exclusive-target-page cases; MLA remains open |
 | Attention state and cascade | State merge and cascade wrappers | `planned` at state-merge level |
 | Mixed-batch attention | Batch attention and attention sinks | `unscoped` |
 | MLA attention | Paged MLA decode and prefill | `unscoped` |
 | Sparse, MSA, and POD attention | Sparse, multiple-sequence, and combined prefill/decode wrappers | `unscoped` |
-| Dense GEMM | BF16, FP8, FP4, and tiny GEMM | `requalification`: one contiguous BF16 cuBLASLt plan requires a current-source H20 record |
+| Dense GEMM | BF16, FP8, FP4, and tiny GEMM | `partial device correct`: current R1 covers one contiguous BF16 cuBLASLt contract; FP8, FP4, and broader GEMM remain open |
 | Grouped GEMM | BF16, FP8, and FP4 grouped matrix work | `planned` through vendor providers |
-| Normalization | RMSNorm, add RMSNorm, LayerNorm, and fused QK norm | `requalification`: contiguous RMSNorm F32, FP16, and BF16 providers require current-source H20 records |
-| RoPE | Standard, Llama 3.1, and fused KV variants | `requalification`: standalone BF16 D128 NeoX passed the local H20 gate, but no current-source record is published |
+| Normalization | RMSNorm, add RMSNorm, LayerNorm, and fused QK norm | `partial device correct`: current R1 covers declared contiguous RMSNorm F32, FP16, and BF16 cases |
+| RoPE | Standard, Llama 3.1, and fused KV variants | `partial device correct`: current R1 covers declared standard BF16 D128 NeoX and fused paged-append cases |
 | Sampling and speculation | Sampling, logits processors, and speculative verification | `planned` |
 | MoE | Routing and fused expert execution | `planned` |
 | Quantization | Packbits, FP4, FP8, and KV formats | `planned` |
@@ -68,8 +68,10 @@ All attention rows fix BF16, NHD layout, head dimension 128, full attention
 unless the row says causal, and F32 softmax state. Paged rows fix page size 16.
 No row covers sliding windows, soft caps, custom masks, FP8 KV, or MLA.
 
-Every matrix entry predates the DeviceRegion submission path or the project
-rename. Current-source device and Graph records remain open.
+The phase 2 R1 record supersedes the pre-rename device status only for the
+exact current-source cases emitted by its permanent runners. Historical
+performance rows remain historical, and unlisted algorithms or Graph paths
+remain open.
 
 ## Dispatch limits
 

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -62,16 +62,16 @@ The migration moves source directly. It adds no compatibility module.
 
 | Operator | Contract and algorithm | Source state | Evidence boundary |
 | --- | --- | --- | --- |
-| RMSNorm | Contiguous F32, FP16, and BF16. Scalar and packed algorithms. | Current source under `rms_norm`; family migration pending | Historical H20 correctness, sanitizer, and one Graph record require renamed-source requalification. |
-| Dense BF16 GEMM, vendor | Contiguous `D=A*W^T`, BF16 storage, F32 accumulation, explicit `CublasLtHeuristic` | Current | Historical cuBLASLt record requires renamed-source requalification. |
-| Dense BF16 GEMM, native | Same `Spec`, explicit `OxideSm90SimtGemvM1N16K64`, zero workspace | Experimental | Historical native correctness and fixed-address Graph evidence exist under the former provider identity. Sanitizer, SASS, matched performance, and engine gates remain open. |
-| Single decode | BF16 NHD D128, direct MHA, MQA, and GQA | Current | Historical H20 correctness and eager records require renamed-source requalification. |
-| Single decode split-K | Explicit partitions and caller-owned F32 workspace | Current | Historical H20 matrix covers MQA and GQA. MHA, current source, Graph, and policy evidence remain open. |
-| Paged batch decode | BF16 NHD or HND D128, page size 16. Direct MHA and eight-warp MQA or GQA. | Current | Current-source NHD and HND status, sanitizer, Graph, and performance records remain open. |
-| Ragged causal prefill | BF16 NHD D128, bottom-right causal mask. Direct, eight-warp, sixteen-warp, and tiled GQA4. | Current | Historical correctness, eager, and one tiled Graph row require renamed-source requalification. |
-| Paged causal prefill | BF16 NHD D128, page size 16. Caller selects direct, eight-warp, or sixteen-warp. | Current | Historical evidence requires renamed-source requalification. |
-| Standard RoPE | BF16 NHD D128, NeoX split-half, explicit I32 positions | Current source under `rope`; family migration pending | Historical correctness, sanitizer, and eager records require renamed-source requalification. |
-| Fused RoPE plus paged append | BF16 NHD D128, page size 16, one through 64 tokens, exclusive target pages | Requalification | Existing 2026-08-06 records predate the page-ownership contract. |
+| RMSNorm | Contiguous F32, FP16, and BF16. Scalar and packed algorithms. | Current source under `rms_norm`; family migration pending | Current R1 H20 correctness, lifecycle, and sanitizer for the permanent runner; no standalone Graph. |
+| Dense BF16 GEMM, vendor | Contiguous `D=A*W^T`, BF16 storage, F32 accumulation, explicit `CublasLtHeuristic` | Current | Current R1 H20 correctness, RMSNorm-to-GEMM Graph, and sanitizer. |
+| Dense BF16 GEMM, native | Same `Spec`, explicit `OxideSm90SimtGemvM1N16K64`, zero workspace | Experimental | Current R1 H20 correctness, five Graph shapes, and sanitizer. SASS, matched performance, and engine gates remain open. |
+| Single decode | BF16 NHD D128, direct MHA, MQA, and GQA | Current | Current R1 H20 correctness, lifecycle, and sanitizer. No Graph or current performance claim. |
+| Single decode split-K | Explicit partitions and caller-owned F32 workspace | Current | Current R1 runner covers declared MQA and GQA shapes plus sanitizer. MHA, Graph, and current performance remain open. |
+| Paged batch decode | BF16 NHD or HND D128, page size 16. Direct MHA and eight-warp MQA or GQA. | Current | Current R1 H20 correctness, rejection Graph, simulated-engine boundary, and sanitizer. Valid-output Graph and performance remain open. |
+| Ragged causal prefill | BF16 NHD D128, bottom-right causal mask. Direct, eight-warp, sixteen-warp, and tiled GQA4. | Current | Current R1 H20 correctness, tiled GQA4 Graph, and sanitizer for declared runner cases. |
+| Paged causal prefill | BF16 NHD D128, page size 16. Caller selects direct, eight-warp, or sixteen-warp. | Current | Current R1 H20 correctness, valid-output and rejection Graph cases, and sanitizer for declared runner cases. |
+| Standard RoPE | BF16 NHD D128, NeoX split-half, explicit I32 positions | Current source under `rope`; family migration pending | Current R1 H20 correctness and sanitizer; no standalone RoPE Graph. |
+| Fused RoPE plus paged append | BF16 NHD D128, page size 16, one through 64 tokens, exclusive target pages | Current | Current R1 H20 correctness, six-token valid-output Graph, rejection Graph, and sanitizer. |
 
 ## Attention plan policy
 
@@ -79,9 +79,9 @@ Plan creation fixes one algorithm.
 
 | Operator | Current selection | Current Graph boundary |
 | --- | --- | --- |
-| Paged decode | MHA selects direct. MQA and GQA select eight-warp token parallelism. | No renamed-source record |
-| Ragged prefill | Average KV length below 64 selects direct. Long MQA selects sixteen warps. Other long cases select eight warps. Long GQA4 can select tiled split-eight. | Historical tiled long-GQA4 record only |
-| Paged prefill | Caller selects direct, eight-warp, or sixteen-warp. Contract checks reject unsupported combinations. | Historical direct GQA4 fixture only |
+| Paged decode | MHA selects direct. MQA and GQA select eight-warp token parallelism. | Current rejection-only invalid-page Graph; no valid-output Graph |
+| Ragged prefill | Average KV length below 64 selects direct. Long MQA selects sixteen warps. Other long cases select eight warps. Long GQA4 can select tiled split-eight. | Current tiled long-GQA4 valid-output Graph |
+| Paged prefill | Caller selects direct, eight-warp, or sixteen-warp. Contract checks reject unsupported combinations. | Current direct GQA4 valid-output Graph and invalid-page rejection Graph |
 
 Ragged selection uses batch-average KV length. It has no request grouping or
 persistent tuning database. Enqueue does not change the chosen algorithm.

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -17,14 +17,18 @@ All fused-append H20 records dated 2026-08-06 predate this rule. They remain
 useful for implementation history and old-contract performance, but they do
 not qualify the current source.
 
-The 2026-08-12 phase 1 record below qualifies
-current-source correctness for four declared runners and their named
-fixed-address Graph cases. Compute Sanitizer and matched performance remain open.
+The 2026-08-12 phase 2 record below completes R1 for the exact declared H20
+boundary. It binds all nine permanent runners, 89 machine-readable passing
+case lines, 12 named Graph case lines, and 36 of 36 Compute Sanitizer cells to
+clean source `477b47a` and nine recorded `sm_90a` binary hashes. Performance,
+real-model engine execution, serving, and other GPUs remain open.
 
 The current DeviceRegion work changed submission for RMSNorm, GEMM, decode,
 prefill, and RoPE:
 
 - Device and Graph records dated through 2026-08-07 predate that launch path.
+- The phase 2 record qualifies only the current paths and exact cases emitted
+  by its nine permanent runners; it does not revive broader historical claims.
 - The 2026-08-11 experimental Loom GEMV record is a historical pre-rename row.
   It covers the post-change path only for its declared H20 `sm_90a` contract.
 
@@ -54,7 +58,20 @@ Their raw samples remain historical. Rerun them before citing a current
 provider ranking. The notice above excludes all pre-rename device records dated
 through 2026-08-07 from current-source qualification.
 
-## Current-source R1 phase 1
+## Current-source R1 phase 2
+
+- [H20 phase 2 correctness, fixed-address Graph, and sanitizer qualification](h20-r1-phase2-qualification-477b47a-20260812.json)
+  binds clean source `477b47a`, strict CUDA Clippy, seven release `sm_90a` lab
+  tests, all nine permanent H20 runners, and all four sanitizer tools over each
+  exact runner binary. It records 89 machine-readable passing case lines, nine
+  valid-output Graph cases, three rejection Graph cases, and 36 passing
+  sanitizer cells without filters or suppressions.
+
+This record completes R1 at its declared boundary. It excludes performance,
+native GEMV promotion, real mistral.rs model execution, serving metrics, a
+valid-output paged-decode Graph, and all GPUs other than the recorded H20.
+
+## Historical R1 phase 1 precursor
 
 - [H20 phase 1 correctness and fixed-address Graph](h20-r1-graph-correctness-8927ed7-20260812.json)
   binds clean source `8927ed7`, strict CUDA Clippy, seven lab library tests,
@@ -62,8 +79,9 @@ through 2026-08-07 from current-source qualification.
   ragged prefill, paged prefill, RoPE, and fused paged append. They report 48
   passing case lines and six named Graph cases.
 
-This record is partial R1 evidence. It excludes Compute Sanitizer, performance,
-the other five permanent runners, other GPUs, and engine or serving execution.
+This record remains the immutable partial precursor to phase 2. It excludes
+Compute Sanitizer, performance, the other five permanent runners, other GPUs,
+and engine or serving execution.
 
 ## Runtime, normalization, and GEMM
 

--- a/docs/results/h20-r1-phase2-qualification-477b47a-20260812.json
+++ b/docs/results/h20-r1-phase2-qualification-477b47a-20260812.json
@@ -1,0 +1,449 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-12",
+  "claim_level": "correctness_cuda_graph_and_sanitizer",
+  "operator": "r1_phase2_current_source_operator_matrix",
+  "status": "passed",
+  "qualification": {
+    "milestone": "R1",
+    "phase": "phase2",
+    "result": "passed",
+    "r1_complete": true,
+    "permanent_h20_runners_total": 9,
+    "executed_h20_runners": 9,
+    "passed_h20_runners": 9,
+    "machine_readable_case_lines_passed": 89,
+    "named_graph_case_lines_passed": 12,
+    "valid_output_graph_case_lines_passed": 9,
+    "rejection_graph_case_lines_passed": 3,
+    "sanitizer_tools_per_runner": 4,
+    "sanitizer_cells_total": 36,
+    "sanitizer_cells_passed": 36,
+    "sanitizer_cells_failed": 0
+  },
+  "source": {
+    "repository": "feichai0017/oxide-infer",
+    "ref": "r1-h20-phase2",
+    "commit": "477b47ad739fc3e572706322eb53a0b4c0aebb04",
+    "tree": "f3d5cfd80790abe3831011fb002fb62c94138b21",
+    "checkout": "clean detached HEAD",
+    "worktree_status_bytes": 0,
+    "cargo_lock_sha256": "46011524357470cbad8877e81b4ca8dc8731ee82e03cd553803d9cbe9601c01c",
+    "bundle": {
+      "file": "source/oxide-r1-phase2.bundle",
+      "sha256": "092eb4663fbefc6ac59a70912bb6078c130b07b3b2253ef63b9df14ab0f4f509",
+      "git_bundle_verify": "passed"
+    },
+    "cuda_oxide": {
+      "commit": "868f8ec4ef900bae7e67e7f9508b2da66eee5472",
+      "tree": "41dfd8a317e085f1d7d8ae1b14de0fddc51ea2a3",
+      "checkout": "clean detached HEAD",
+      "bundle": {
+        "file": "source/cuda-oxide-868f8ec.bundle",
+        "sha256": "48b987cd19e57fcecda87b1cef141f81384d6e793a2e1fc396d3c6f4d596714b",
+        "git_bundle_verify": "passed"
+      }
+    },
+    "locked_vendor_closure": {
+      "archive": "source/locked-vendor.tar",
+      "sha256": "ef843493259ce6dc196d6793cccc03c4f35d85c1508313ec82065753ebac2c35",
+      "cargo_metadata_offline": "passed for backend root, nested codegen workspace, and Oxide workspace"
+    }
+  },
+  "environment": {
+    "observed_at_utc": "2026-08-11T19:02:54Z",
+    "record_date_timezone": "Asia/Shanghai",
+    "host": "redacted-h20-validation-host",
+    "gpu": "NVIDIA H20",
+    "gpu_uuid": "GPU-3a35e57b-fc54-5620-56ee-deaf5a9c40d3",
+    "compute_capability": "9.0",
+    "memory_mib": 97871,
+    "driver": "535.161.08",
+    "cuda_toolkit": "13.1.115",
+    "nvcc": "Cuda compilation tools, release 13.1, V13.1.115",
+    "rust": "rustc 1.96.0-nightly (55e86c996 2026-04-02)",
+    "cargo": "cargo 1.96.0-nightly (888f67534 2026-03-30)",
+    "rust_toolchain": "nightly-2026-04-03",
+    "cargo_oxide": "0.2.1",
+    "cargo_oxide_sha256": "1e9c2a4badcd280a7ac2f9457c621b816ffabf1ddccc78b24d35ff8affceccd9",
+    "rustc_codegen_cuda_sha256": "9f3f47fa4888b593c47a7439eeabbd22350581d0079e0bdab371375eb751591e",
+    "compute_sanitizer": {
+      "version": "2026.2.1.0",
+      "build": "38334959",
+      "distribution_package": "cuda-sanitizer-13-3_13.3.75-1_amd64.deb",
+      "distribution_url": "https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-sanitizer-13-3_13.3.75-1_amd64.deb",
+      "distribution_sha256": "ab5467d9473adfb528481d1b6166b9bc718ab668563a3466d0f2c5d8dd27aa4f",
+      "host_install_modified": false,
+      "filters": [],
+      "suppressions": []
+    },
+    "metadata": {
+      "path": "meta/12-final-environment.txt",
+      "sha256": "b53e4db9a70c34c941aef8315fb874901a7d9efbffb5252e6f46bf543a7ffca6"
+    }
+  },
+  "accepted_gates": {
+    "locked_offline_vendor_closure": {
+      "status": "passed",
+      "accepted": true,
+      "vendor_log": "logs/01-vendor.log",
+      "vendor_log_sha256": "56d34f07383c276c6c96c6b4cdc9fbeafcf111e1a44c659da0b4d8f61622bdea",
+      "backend_log": "logs/03-backend-setup.log",
+      "backend_log_sha256": "823899a5c656a38589d419dceda18a0b923f16fbb914f4acd064c0db3b203da6",
+      "backend_exit_code": 0
+    },
+    "cuda_doctor": {
+      "status": "passed",
+      "accepted": true,
+      "command_metadata": "meta/04-cuda-doctor.command",
+      "command_metadata_sha256": "2d05127613d22dd2a392a14cbcb7f9c67551c54b8e87cd94ef7a64f4fbe0ed2f",
+      "exit_code": 0,
+      "log": "logs/04-cuda-doctor.log",
+      "log_sha256": "876dde29cc6709b7eaec5e55009b1a5d59611aeb66f4aee4d97b69e2f95eceed",
+      "log_size_bytes": 1682
+    },
+    "strict_cuda_clippy": {
+      "status": "passed",
+      "accepted": true,
+      "scope": "workspace, all targets, CUDA feature, warnings denied",
+      "command_metadata": "meta/05-cuda-strict-clippy.command",
+      "command_metadata_sha256": "2110762c8f2f8d7aac8d96470fe636790c887aff4784a47dbf7e2d26e34437be",
+      "exit_code": 0,
+      "log": "logs/05-cuda-strict-clippy.log",
+      "log_sha256": "e21891d52a591e3597cbcad0d27c638558c30f5ad2f34d0a301f6339be11a869",
+      "log_size_bytes": 3987
+    },
+    "oxide_infer_lab_tests": {
+      "status": "passed",
+      "accepted": true,
+      "artifact_target": "sm_90a",
+      "profile": "release",
+      "passed": 7,
+      "failed": 0,
+      "command_metadata": "meta/06-lab-tests.command",
+      "command_metadata_sha256": "1dee40357d2454f710f57e29d026557b844b3d4d9a88c0a91558e04e13549c02",
+      "exit_code": 0,
+      "log": "logs/06-lab-tests.log",
+      "log_sha256": "faa774d7f7f24c726bae1b405b12be69632c9e0e54e9fa77a8d807c0d3999cc0",
+      "log_size_bytes": 5023
+    },
+    "normal_runner_matrix": {
+      "status": "passed",
+      "accepted": true,
+      "built_once_each": true,
+      "runner_count": 9,
+      "runner_count_passed": 9,
+      "machine_readable_case_lines_passed": 89,
+      "named_graph_case_lines_passed": 12,
+      "audit_metadata": "meta/08-normal-runner-audit.exit",
+      "audit_metadata_sha256": "cfe90029a9c6aff51747b12c69a7464cb2403474e6dc3542128f6c4205fdba12"
+    },
+    "compute_sanitizer_matrix": {
+      "status": "passed",
+      "accepted": true,
+      "binary_rebuilds": 0,
+      "binary_hash_verified_before_and_after_every_cell": true,
+      "tools": [
+        "memcheck --leak-check full --error-exitcode 99",
+        "racecheck --error-exitcode 99",
+        "synccheck --error-exitcode 99",
+        "initcheck --error-exitcode 99"
+      ],
+      "filters": [],
+      "suppressions": [],
+      "runner_count": 9,
+      "cell_count": 36,
+      "passed": 36,
+      "failed": 0,
+      "matrix": "meta/11-sanitizer-2026-matrix.tsv",
+      "matrix_sha256": "6310e92a5df881f7180a54a383e37999642e32af48f126f4e7d0d7751c91e7ac",
+      "summary": "meta/11-sanitizer-2026-summary.txt",
+      "summary_sha256": "6d6314b82d31162312b4ccf8bb3f73b3a4ba1aeff72fceed072e393e6b4c6dba"
+    },
+    "final_audit": {
+      "status": "passed",
+      "accepted": true,
+      "command_metadata": "meta/12-final-audit.command",
+      "command_metadata_sha256": "68c72e616e72242ec4319dd4a092dbd9ecdfdff167651ad6de007c8c55ef2d17",
+      "exit_code": 0,
+      "log": "logs/12-final-audit.log",
+      "log_sha256": "15892184ac33503375a3a5d3ff7588132cba519d97cfed898996ae5bd0f71e52",
+      "log_size_bytes": 216
+    }
+  },
+  "runners": [
+    {
+      "name": "rms_norm_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "2c7cb65142450b11a46c952fcfc6c67137fb22f8419b8e02ba9aaddb0ac04197",
+      "normal_log": "logs/07-run-rms_norm_h20.log",
+      "normal_log_sha256": "86938368e6f258da51f896e3159aeffa4f56fde882deda18fbea446888fa1c1c",
+      "normal_log_size_bytes": 5044,
+      "coverage": "F32, FP16, and BF16 scalar/packed correctness, short buffers, signed zero, chaining, partial-scope rejection, and queue reuse",
+      "graph": "no standalone RMSNorm Graph; the BF16 RMSNorm-to-GEMM Graph is covered by bf16_gemm_h20",
+      "sanitizer_log_sha256": {
+        "memcheck": "9271a41b016c36961bd3f61dcb54579ec5a1e0da82b1a37318a0e790f3f977a2",
+        "racecheck": "f9161ec57f98cdb04ef1f2d9b1433f85d13f1bbe30f32772510c821a08599305",
+        "synccheck": "bc40243c9fc4e601b7df544b03ef6fec5cb4eec29ba7d296fd757cefca4af8cf",
+        "initcheck": "bc40243c9fc4e601b7df544b03ef6fec5cb4eec29ba7d296fd757cefca4af8cf"
+      }
+    },
+    {
+      "name": "bf16_gemm_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "7a07bc0211f213f0926cc3c7e3c2151c2aac96dab2561bf102ff17928a301938",
+      "normal_log": "logs/07-run-bf16_gemm_h20.log",
+      "normal_log_sha256": "715e96471271cbf7e164e202d587d3180f952eb93c2e356377bc1a1d729a3c00",
+      "normal_log_size_bytes": 1800,
+      "case_lines_passed": 7,
+      "graph_case_lines_passed": 1,
+      "valid_output_graph_cases": ["rms_norm_gemm_graph"],
+      "sanitizer_log_sha256": {
+        "memcheck": "56e6e0caa6d159cc31b6857efe03b7429cbe0caf5cba86232c2bdecaa0bf3fbc",
+        "racecheck": "deb325f45992a99444cb3575e39be97c19e0f2369638ec9f428e3dc7c0dee8c8",
+        "synccheck": "ecc827a9a5f8f401d1c8d8362883624111fa8cc184b01b52ffcfef49bf6c1046",
+        "initcheck": "ecc827a9a5f8f401d1c8d8362883624111fa8cc184b01b52ffcfef49bf6c1046"
+      }
+    },
+    {
+      "name": "oxide_sm90_simt_gemv_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "154d2d5b7c6719297e44cc7396c7dec8fc0db62419de6a4b6f1377b6635d64f7",
+      "normal_log": "logs/07-run-oxide_sm90_simt_gemv_h20.log",
+      "normal_log_sha256": "0f0fbbeb7e64ae5cb104de4f8ab2bad8f3fdce28c0f9f4f97c1e689cead9988a",
+      "normal_log_size_bytes": 5911,
+      "case_lines_passed": 16,
+      "graph_case_lines_passed": 5,
+      "valid_output_graph_shapes_m_n_k": [[1, 1536, 1536], [1, 256, 1536], [1, 17920, 1536], [1, 1536, 8960], [1, 151936, 1536]],
+      "sanitizer_log_sha256": {
+        "memcheck": "35d8b91c8d60d1d31181860ef27965a8081dc7816299d2c684a520093b434dfc",
+        "racecheck": "236d9be2c92ed0355f8ad80ac7bf78c92bcaab6783c6d4e45514142a85e38095",
+        "synccheck": "0854b1c07afc833350fa022912bd3c607acc05da3ca05d662518d53effccec8a",
+        "initcheck": "0854b1c07afc833350fa022912bd3c607acc05da3ca05d662518d53effccec8a"
+      }
+    },
+    {
+      "name": "single_decode_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "34dffa4c338bbbd7762406c7bb0398a478bccbd771c8168fa7343d305b9ddff5",
+      "normal_log": "logs/07-run-single_decode_h20.log",
+      "normal_log_sha256": "98663f8705cd46d51dbf75ac180832d9cddb2bfaac75600c2fc613d39a14e2dd",
+      "normal_log_size_bytes": 3634,
+      "case_lines_passed": 13,
+      "graph_case_lines_passed": 0,
+      "sanitizer_log_sha256": {
+        "memcheck": "7373076b3b3e9cc1430199a52a2402b41db4308d52c695bb6fe0a12a503206b1",
+        "racecheck": "5cc981fbf45b920023ca4da6cf8bd9283f33375593d0263aabe3386ef63077e5",
+        "synccheck": "916e44d9140fc86be93ca8029beaa9d906b25e3728d8fc2df5e3045965c9f01c",
+        "initcheck": "916e44d9140fc86be93ca8029beaa9d906b25e3728d8fc2df5e3045965c9f01c"
+      }
+    },
+    {
+      "name": "paged_batch_decode_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "0b43512d48e7bb8f76cc727693ede1db37aae0f71abaed3e68bf1fec74900d0e",
+      "normal_log": "logs/07-run-paged_batch_decode_h20.log",
+      "normal_log_sha256": "b14891a4190149f57db5920e004735afc0aeda63f41df7d1af570197f2c94e2b",
+      "normal_log_size_bytes": 3844,
+      "case_lines_passed": 11,
+      "graph_case_lines_passed": 1,
+      "rejection_graph_cases": ["invalid_page_graph"],
+      "valid_output_graph_exclusion": "no valid-output paged-decode Graph gate",
+      "sanitizer_log_sha256": {
+        "memcheck": "3ff75a434467bf5631034602615727c36ff86b48ff6d1754b227cb97dae0db51",
+        "racecheck": "86d04f66242ee4069e7cba8c0de1c64a24bd4b082936a9da703ea240ce7113f3",
+        "synccheck": "3f6da57658e0615a15fb579c6968ad36974c533d0a02a4896c285aa8baf1ac61",
+        "initcheck": "3f6da57658e0615a15fb579c6968ad36974c533d0a02a4896c285aa8baf1ac61"
+      }
+    },
+    {
+      "name": "ragged_prefill_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "7ea2caf636356aad79dfe70ebac87f983cbe3e9e919f54b5003a847540b26b0f",
+      "normal_log": "logs/07-run-ragged_prefill_h20.log",
+      "normal_log_sha256": "d02c4b65defe6df4b662cb6422dc758041ddd7c5a521c2fb370a82cd9c0a5928",
+      "normal_log_size_bytes": 3410,
+      "case_lines_passed": 9,
+      "graph_case_lines_passed": 1,
+      "valid_output_graph_cases": ["gqa4_graph"],
+      "sanitizer_log_sha256": {
+        "memcheck": "6b5e550fe3f2b630019495f40027a2f6522d7bf851e64d7114b4cdd132230f4b",
+        "racecheck": "b7693d0c935266afc43748ff7de0c53f7c4508382d4a94d1533b2e95832c6bcd",
+        "synccheck": "8f416348c44924d32fce4234c33128965db73e089f13b0cbdb2ddc46a935eed8",
+        "initcheck": "8f416348c44924d32fce4234c33128965db73e089f13b0cbdb2ddc46a935eed8"
+      }
+    },
+    {
+      "name": "paged_prefill_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "5da60ec7e47679b6f8cc2af3da08085e9d36c5f6395dee245ec7b60c49e62827",
+      "normal_log": "logs/07-run-paged_prefill_h20.log",
+      "normal_log_sha256": "3c114ee08c6e403623cbc084b4c84103c295001529860f9296441d11ae09aa28",
+      "normal_log_size_bytes": 4967,
+      "case_lines_passed": 11,
+      "graph_case_lines_passed": 2,
+      "valid_output_graph_cases": ["gqa4_graph"],
+      "rejection_graph_cases": ["invalid_page_graph"],
+      "sanitizer_log_sha256": {
+        "memcheck": "e33c103b3ad351d4ca4bf39f75ea722c3b9895425ec1d9d6daf028c2e33f8031",
+        "racecheck": "7741ad3b333d9e56e1363add130683c46f8063147f94a311bef5e837bc93bed0",
+        "synccheck": "fb2ccf0b76a238287e10fa82eb3be3f13521a2dded0edb7e80db6b84ed3d7b0e",
+        "initcheck": "fb2ccf0b76a238287e10fa82eb3be3f13521a2dded0edb7e80db6b84ed3d7b0e"
+      }
+    },
+    {
+      "name": "rope_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "0781285d89780c5ffcefedcfb0a5309fe47a21d0711fdd516bcb5ac6f21c03df",
+      "normal_log": "logs/07-run-rope_h20.log",
+      "normal_log_sha256": "d751b57e1824e245b7418e74536551787a8c74e9c578f60b87d18a1cd8fa73fa",
+      "normal_log_size_bytes": 4991,
+      "case_lines_passed": 21,
+      "graph_case_lines_passed": 2,
+      "valid_output_graph_cases": ["paged_append_tokens_graph"],
+      "rejection_graph_cases": ["paged_append_graph_rejection"],
+      "sanitizer_log_sha256": {
+        "memcheck": "4dae82da0f8998f84ef5ed2a34ea1c349fb09fbca29c00f34c71374f000da551",
+        "racecheck": "e7c39cb2a3815963473c689624ea355cffd0497ab5d54f32cc7fff7bcef9841a",
+        "synccheck": "9ad9d5e856f23ca9599c6f15100f806f442482e155001dc873e1d9fe961b05d5",
+        "initcheck": "9ad9d5e856f23ca9599c6f15100f806f442482e155001dc873e1d9fe961b05d5"
+      }
+    },
+    {
+      "name": "engine_interop_h20",
+      "status": "passed",
+      "artifact_target": "sm_90a",
+      "binary_sha256": "446a95656703c8aa951ea5ed2169318310d2c8e1b362b1c83b91f19be45eecbb",
+      "normal_log": "logs/07-run-engine_interop_h20.log",
+      "normal_log_sha256": "7f0308df865b35f8fb44cd3609736f4a31c55450d485f253b215307ff5739c14",
+      "normal_log_size_bytes": 738,
+      "case_lines_passed": 1,
+      "graph_case_lines_passed": 0,
+      "boundary": "simulated_engine",
+      "coverage": "external regions, event bridge, no adapter D2D copies, two in flight, cross-thread completion, typed rejection, and queue reuse",
+      "sanitizer_log_sha256": {
+        "memcheck": "11562bd39eb21a0a96e5e4fa27ebac2a49acafdfa1b4813437cd3e6f4ab2ab1b",
+        "racecheck": "6229baeee4d6a658b2f046412cd3ca1affa9835a483d26cdaeae70caa5b0ca18",
+        "synccheck": "9b94e3959c150db95d83e39fb9a01e3ef75efaa81b9311a1932f23e9fe15b29a",
+        "initcheck": "9b94e3959c150db95d83e39fb9a01e3ef75efaa81b9311a1932f23e9fe15b29a"
+      }
+    }
+  ],
+  "graph_boundary": {
+    "valid_output_graph_case_lines": 9,
+    "rejection_graph_case_lines": 3,
+    "valid_output_paths": [
+      "BF16 RMSNorm to cuBLASLt GEMM",
+      "five declared native SM90a GEMV census shapes",
+      "ragged prefill tiled GQA4",
+      "paged prefill direct GQA4",
+      "six-token fused RoPE plus paged append"
+    ],
+    "rejection_only_paths": [
+      "paged batch decode invalid page",
+      "paged prefill invalid page",
+      "fused append semantic rejection"
+    ],
+    "explicit_exclusions": [
+      "standalone RMSNorm has no independent Graph gate",
+      "single decode has no Graph gate",
+      "paged batch decode has no valid-output Graph gate",
+      "engine interop has no Graph gate"
+    ]
+  },
+  "nonaccepted_attempts": [
+    {
+      "tool": "Compute Sanitizer 2025.4.1.0 build 37093031",
+      "result": "35 of 36 cells passed; bf16_gemm_h20 racecheck exited 99 with nine reported hazards inside a cuBLASLt nvjet_sm90 kernel",
+      "accepted": false,
+      "filters": [],
+      "suppressions": [],
+      "failure_log": "logs/09-sanitize-bf16_gemm_h20-racecheck.log",
+      "failure_log_sha256": "e8a7761597c4742f4e127ea4384eb0c125e98a920632987476ebc4fc24eb3536",
+      "binary_sha256_before": "7a07bc0211f213f0926cc3c7e3c2151c2aac96dab2561bf102ff17928a301938",
+      "binary_sha256_after": "7a07bc0211f213f0926cc3c7e3c2151c2aac96dab2561bf102ff17928a301938",
+      "resolution": "reran the complete 36-cell matrix under one verified 2026.2.1 tool distribution; NVIDIA release notes state that 2026.1 fixed Hopper warpgroup racecheck false positives",
+      "release_notes": "https://docs.nvidia.com/compute-sanitizer/ReleaseNotes/index.html"
+    }
+  ],
+  "evidence_bundle": {
+    "persistent_archive": {
+      "directory": "/workspace/oxide-r1-evidence/477b47-phase2-20260812",
+      "directory_mode_octal": "0555",
+      "file_count": 375,
+      "writable_file_count": 0,
+      "payload_manifest": {
+        "path": "/workspace/oxide-r1-evidence/477b47-phase2-20260812/TREE.sha256",
+        "sha256": "2a6727d48b02254f39ef8cc1ef92d3520c9d0dea22af960419724fe2e08535b5",
+        "entries": 374,
+        "verification": "passed"
+      },
+      "deterministic_tar": {
+        "path": "/workspace/oxide-r1-evidence/477b47-phase2-20260812.tar",
+        "sha256": "e4f548f38932ca4bb356c2351d06d71af815b812207086e97746869e2c48ed9e",
+        "size_bytes": 199843840,
+        "mode_octal": "0444",
+        "listing_check": "passed",
+        "stream_recompute": "matched"
+      },
+      "verification_sidecar": {
+        "path": "/workspace/oxide-r1-evidence/477b47-phase2-20260812.tar.verify.txt",
+        "sha256": "14f5dfd1152ad85be7459bac3c31f3b473a8817779720cb505fccfa976cd5ed0"
+      },
+      "storage_claim": "Persistent read-only, hash-bound archive. This is not a WORM or immutable-storage claim."
+    },
+    "final_manifests": {
+      "logs": {
+        "path": "meta/13-logs-final.sha256",
+        "sha256": "86581b6742cf4334a79e16568cfe7d0bf3aac3b06afca3cc1fcc45fbde48a175",
+        "entries": 103
+      },
+      "commands_and_exits": {
+        "path": "meta/13-commands-exits-final.sha256",
+        "sha256": "4a502cd2e481089f6ac4cef8199c367aa854a9d013f98c4e2c63fd9f3a6d0bc9",
+        "entries": 210
+      },
+      "artifacts": {
+        "path": "meta/13-artifacts-final.sha256",
+        "sha256": "a6ce79f0d0ab00bcd27c5ace765ebe5fb62787bf278ebf4ef1b7fd5f50fddf11",
+        "entries": 17
+      },
+      "source_inputs": {
+        "path": "meta/13-source-inputs.sha256",
+        "sha256": "b15995869cebe1dd78d6ea8a2dcbb571f944c97aa860089f4733f0b7e78aeb1a",
+        "entries": 4
+      },
+      "index": {
+        "path": "meta/13-manifests.sha256",
+        "sha256": "66db5a17761ddb4ebc02d88b73614d58e82da30958c473b3b3f144017285a8c3"
+      }
+    }
+  },
+  "accepted_claims": [
+    "The exact clean Oxide source commit and tree pass strict CUDA Clippy and seven release sm_90a lab tests on the declared H20.",
+    "All nine permanent H20 runners pass their declared correctness, lifecycle, rejection, and recovery cases.",
+    "The nine named valid-output Graph cases and three named rejection Graph cases pass their declared fixed-address replay boundaries.",
+    "All four declared Compute Sanitizer tools pass all nine exact hash-bound runner binaries without filters or suppressions.",
+    "The native SM90a M=1 GEMV passes correctness, five fixed-address Graph shapes, and all four sanitizer tools; it remains experimental pending R2 performance and engine gates.",
+    "The simulated-engine boundary passes its declared external-region, stream-handoff, no-adapter-copy, recovery, and sanitizer gates."
+  ],
+  "excluded_claims": [
+    "operator or end-to-end performance",
+    "a native GEMV performance win or promotion",
+    "real mistral.rs model execution or provider hits",
+    "model output parity",
+    "TTFT, TPOT, tokens per second, peak HBM, or serving throughput",
+    "a valid-output paged batch-decode Graph",
+    "standalone RMSNorm, single-decode, or engine-interoperability Graph behavior",
+    "contracts, shapes, layouts, algorithms, or dtypes not emitted by the nine runner logs",
+    "correctness, sanitizer, Graph, or performance behavior on any GPU other than the declared NVIDIA H20"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,12 @@ Exit gate:
 
 ## R1: Requalify current source
 
-**State:** active.
+**State:** complete.
+
+The phase 2 H20 record binds clean source `477b47a`, all nine permanent
+`sm_90a` runners, 89 machine-readable passing case lines, 12 named Graph case
+lines, and 36 of 36 Compute Sanitizer cells. Performance and real-model engine
+claims remain outside R1.
 
 The rename and namespace migration change source identity. Historical device
 records do not qualify the new tree.

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -22,7 +22,7 @@ export const operatorGroups = [
   {
     state: "Current source",
     tone: "current",
-    note: "Implemented contracts. Most CUDA paths need current-source H20 requalification.",
+    note: "Implemented contracts. Declared permanent-runner paths passed current-source H20 R1 qualification.",
     operators: [
       { name: "RMSNorm", boundary: "F32, FP16, BF16 · scalar and packed", provider: "Native" },
       { name: "Dense GEMM", boundary: "BF16 D=A×Wᵀ · F32 accumulation", provider: "Vendor" },
@@ -69,15 +69,15 @@ export const providerLanes = [
 ]
 
 export const evidenceHighlights = [
-  { value: "Phase 1", label: "Current H20 source", detail: "GEMM, ragged and paged prefill, RoPE, and fused append", sample: "correctness and named Graph cases" },
-  { value: "Pending", label: "Remaining R1", detail: "five runners, Compute Sanitizer, and performance", sample: "not qualified by phase 1" },
-  { value: "Simulated", label: "Engine interop", detail: "external pointers and event bridge", sample: "not a model run" },
+  { value: "9 / 9", label: "Current H20 runners", detail: "89 passing case lines and 12 named Graph cases", sample: "exact source and binary hashes" },
+  { value: "36 / 36", label: "Compute Sanitizer", detail: "memcheck, racecheck, synccheck, and initcheck", sample: "no filters or suppressions" },
+  { value: "Simulated", label: "Engine interop", detail: "qualified external pointers and event bridge", sample: "still not a model run" },
   { value: "Open", label: "Serving", detail: "TTFT, TPOT, throughput, and memory", sample: "no serving evidence" },
 ]
 
 export const evidenceLevels = [
   { level: "01", name: "Contract", status: "Required", detail: "CPU oracle, edge cases, and typed rejection" },
-  { level: "02", name: "Device", status: "Per source", detail: "GPU correctness, lifecycle, and sanitizer" },
+  { level: "02", name: "Device", status: "H20 qualified", detail: "Current-source correctness, lifecycle, Graph, and sanitizer" },
   { level: "03", name: "Performance", status: "Per shape", detail: "Matched inputs, streams, and raw samples" },
 
   { level: "04", name: "Graph", status: "Per plan", detail: "Capture, replay, addresses, and retention" },

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -49,19 +49,21 @@ import { evidenceHighlights, evidenceLevels, repositoryUrl } from "../data/site"
         </tbody>
       </table>
 
-      <div class="doc-note warning">
-        <strong>Current-source H20 qualification is partial.</strong>
+      <div class="doc-note">
+        <strong>Current-source H20 R1 qualification is complete.</strong>
         <p>
-          The phase 1 record covers strict CUDA Clippy, seven lab tests, and
-          four of nine permanent H20 runners. It records correctness and named
-          fixed-address Graph cases.
+          The phase 2 record binds clean source <code>477b47a</code>, strict
+          CUDA Clippy, seven release <code>sm_90a</code> lab tests, all nine
+          permanent H20 runners, 89 passing case lines, and 12 named Graph
+          cases.
         </p>
         <p>
-          It does not cover Compute Sanitizer, performance, the other five
-          runners, other GPUs, or engine execution.
+          All 36 Compute Sanitizer cells pass without filters or suppressions.
+          Performance, real-model engine execution, serving, and other GPUs
+          remain outside this record.
         </p>
-        <a href={`${repositoryUrl}/blob/main/docs/results/h20-r1-graph-correctness-8927ed7-20260812.json`}>
-          Current-source H20 phase 1 record
+        <a href={`${repositoryUrl}/blob/main/docs/results/h20-r1-phase2-qualification-477b47a-20260812.json`}>
+          Current-source H20 phase 2 record
         </a>
       </div>
 
@@ -69,13 +71,13 @@ import { evidenceHighlights, evidenceLevels, repositoryUrl } from "../data/site"
         <strong>Paged prefill has three explicit algorithms.</strong>
         <p>
           The caller selects direct, eight-warp, or sixteen-warp execution.
-          Published token-parallel records predate the DeviceRegion and typed
-          metadata-status paths.
+          The phase 2 record qualifies the current declared correctness,
+          rejection, fixed-address Graph, and sanitizer paths.
         </p>
         <p>
-          Those records do not qualify the merged source. Correctness,
-          sanitizer, and matched performance require a new run before Oxide Infer can
-          publish a current provider ranking.
+          Historical performance records still predate the DeviceRegion and
+          typed metadata-status paths. A matched current-source run is required
+          before Oxide Infer can publish a current provider ranking.
         </p>
         <a href={`${repositoryUrl}/blob/main/docs/results/h20-bf16-paged-prefill-token-parallel-correctness-20260807.json`}>
           Historical token-parallel correctness record
@@ -89,9 +91,9 @@ import { evidenceHighlights, evidenceLevels, repositoryUrl } from "../data/site"
       <div class="doc-note">
         <strong>Engine interop is a simulated boundary.</strong>
         <p>
-          The H20 gate checks external pointers, the event-bridge path, and
-          zero adapter D2D copies for direct single decode. It does not run a model.
-          HND paged decode and a linear authority handoff exist in source. A
+          The phase 2 H20 gate qualifies external pointers, the event-bridge
+          path, zero adapter D2D copies, recovery, and all four sanitizer tools
+          for direct single and HND paged decode. It does not run a model. A
           mistral.rs provider hit and model-output comparison remain open.
         </p>
       </div>
@@ -105,8 +107,9 @@ import { evidenceHighlights, evidenceLevels, repositoryUrl } from "../data/site"
         </p>
         <p>
           The 2026-08-06 append records measured the earlier single-kernel path
-          without exclusive-page ownership or typed status. They do not support
-          a current performance or Graph claim.
+          without exclusive-page ownership or typed status. Phase 2 qualifies
+          the current path's declared correctness, valid-output and rejection
+          Graph cases, and sanitizer matrix, but not current performance.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- publish the current-source H20 R1 Phase 2 qualification record for clean `477b47a`
- record 9/9 permanent runners, 89 passing case lines, 12 named Graph cases, and 36/36 sanitizer cells
- update the evidence index, roadmap, operator status docs, and website while keeping performance, model, and serving claims excluded

## Why

The rename and DeviceRegion submission changes invalidated older device evidence. This record requalifies the exact current source and hash-bound `sm_90a` artifacts. The complete accepted sanitizer matrix uses Compute Sanitizer 2026.2.1 without filters or suppressions; the older 2025.4.1 cuBLASLt racecheck report is retained as a nonaccepted attempt.

## Impact

R1 is marked complete only for the declared H20 correctness, lifecycle, fixed-address Graph, rejection, and sanitizer boundary. Native GEMV remains experimental, and R2 performance work has not started. This PR changes evidence, documentation, and website status only; it does not change product source code.

## Validation

- isolated offline full repository `make check`
- CUDA doctor and strict CUDA Clippy
- 7/7 release `sm_90a` lab tests
- 9/9 normal H20 runners
- 36/36 Compute Sanitizer cells: memcheck, racecheck, synccheck, and initcheck
- deterministic evidence archive SHA-256 `e4f548f38932ca4bb356c2351d06d71af815b812207086e97746869e2c48ed9e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented completed H20 R1 phase 2 qualification for nine runners, 89 passing cases, 12 Graph cases, and 36 sanitizer checks.
  * Updated operator status and parity records with current qualification details and coverage boundaries.
  * Clarified exclusions, including performance, serving, model execution, and other GPU support.
  * Marked R1 as complete and identified prior qualification records as historical.
* **Website**
  * Updated evidence pages and status messaging to reflect H20 qualification and current coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->