### PR TITLE
Optimize long paged GQA4 prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,23 @@ shape, layout, provider, algorithm, and evidence state for every admitted path.
 ## Performance snapshot
 
 Matched BF16 eager-provider timing against FlashInfer 0.6.17 produced stable
-rankings for all 14 measured attention shapes on the recorded H20. Oxide Infer
-has lower combined median latency in 8 shapes; FlashInfer has lower latency in
-6. The representative rows deliberately include both strengths and gaps.
+rankings for all 14 baseline attention shapes on the recorded H20. Oxide Infer
+had lower combined median latency in 8 shapes; FlashInfer had lower latency in
+6. The long paged-GQA4 row below is refreshed from the current optimized path;
+the other rows retain the full-matrix baseline.
 
 | Contract | Shape | Oxide | FlashInfer | Lower latency |
 | --- | --- | ---: | ---: | --- |
 | Paged decode MHA | B1, KV 1, NHD, D128 | 9.54 µs | 13.77 µs | Oxide 1.44× |
 | Ragged prefill MHA | Q 16, KV 16, D128 | 8.25 µs | 13.99 µs | Oxide 1.69× |
 | Ragged prefill GQA4 | Q 32+64, KV 256+1024, D128 | 48.20 µs | 21.82 µs | FlashInfer 2.21× |
-| Paged prefill GQA4 | Q 32+64, KV 256+1024, D128 | 265.66 µs | 23.08 µs | FlashInfer 11.51× |
+| Paged prefill GQA4 | Q 32+64, KV 256+1024, D128 | 57.60 µs | 23.35 µs | FlashInfer 2.47× |
 
 These are CUDA-event measurements of matched operator paths, not isolated
 kernel, model, or serving results. See the [complete record and raw
 samples](docs/results/h20-flashinfer-v0.6.17-attention-eager-performance-7f3d08e-20260812.json).
+The [optimized paged-GQA4 record](docs/results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json)
+contains its source-bound two-order samples and before/after comparison.
 
 ## Providers
 

--- a/crates/oxide-infer-cuda/README.md
+++ b/crates/oxide-infer-cuda/README.md
@@ -50,9 +50,10 @@ The crate exposes these provider families:
   page-table errors at completion.
 - BF16 ragged causal prefill with direct, eight-warp, sixteen-warp, and tiled
   GQA4 plans.
-- BF16 paged causal prefill with direct, eight-warp, and sixteen-warp plans.
-  The caller selects the algorithm. A device validator reports typed query and
-  page metadata errors at completion.
+- BF16 paged causal prefill with direct, eight-warp, sixteen-warp, and tiled
+  GQA4 plans. The tiled plan uses a caller-owned F32 partial workspace. The
+  caller selects the algorithm. A device validator reports typed query and page
+  metadata errors at completion.
 - BF16 D128 NeoX RoPE with explicit positions.
 - Fused RoPE and paged KV append for one token per request or 1 through 64
   explicit tokens.
@@ -83,10 +84,10 @@ correctness, lifecycle, fixed-address Graph behavior, and Compute Sanitizer on
 its recorded target. The experimental M=1 GEMV remains limited to its exact
 `sm_90a` contract and still needs matched performance and engine evidence.
 
-The current R2 record adds matched eager-provider timing for paged decode,
-ragged prefill, and paged prefill against FlashInfer 0.6.17. It exposes strong
-short paths and large long-context GQA prefill gaps; it is not Graph, model, or
-serving evidence.
+The current R2 records add matched eager-provider timing for paged decode,
+ragged prefill, and paged prefill against FlashInfer 0.6.17. The first optimized
+paged-GQA4 path reduces the recorded worst gap substantially, while long-context
+GQA prefill remains behind. These are not Graph, model, or serving results.
 
 The fixed-address Graph runtime retains bindings and provider resources until
 replay completes. Operator-specific Graph evidence remains path-specific.

--- a/crates/oxide-infer-cuda/src/attention/prefill.rs
+++ b/crates/oxide-infer-cuda/src/attention/prefill.rs
@@ -48,7 +48,7 @@ const TILED_KV_SHARED_PAIRS: usize = TILED_KV_ROWS * BF16_PAIRS_PER_HEAD;
 const TILED_KV_COPY_BYTES: usize = 16;
 const TILED_KV_COPY_PAIRS: usize = TILED_KV_COPY_BYTES / size_of::<u32>();
 const TILED_KV_COPIES: usize = TILED_KV_SHARED_PAIRS / TILED_KV_COPY_PAIRS;
-const TILED_PARTITIONS: usize = 8;
+const TILED_PARTITIONS: usize = 4;
 const TILED_MIN_AVERAGE_KV_LEN: usize = 256;
 
 const _: () = {
@@ -58,7 +58,7 @@ const _: () = {
     assert!(TILED_THREADS == 128);
     assert!(TILED_KV_SUBTILES == 4);
     assert!(TILED_KV_COPIES == TILED_THREADS as usize * 8);
-    assert!(TILED_PARTITIONS == 8);
+    assert!(TILED_PARTITIONS == 4);
     assert!(SINGLE_DECODE_HEAD_DIM == 128);
 };
 
@@ -1447,7 +1447,10 @@ mod kernels {
             $shared_tile:expr,
             $global_pairs:expr,
             $thread_in_block:expr,
+            $paged:expr,
             $kv_start:expr,
+            $page_start:expr,
+            $page_indices:expr,
             $kv_tile_start:expr,
             $partition_token_end:expr,
             $num_kv_heads:expr,
@@ -1459,7 +1462,15 @@ mod kernels {
                 ($iteration:literal) => {{
                     let token = $kv_tile_start + token_lane + $iteration * 8;
                     let source_token = usize::min(token, $partition_token_end - 1);
-                    let source_pair = (($kv_start + source_token) * $num_kv_heads + $kv_head)
+                    let physical_token = if $paged {
+                        let logical_page = source_token / PAGED_PREFILL_PAGE_SIZE;
+                        let page_offset = source_token % PAGED_PREFILL_PAGE_SIZE;
+                        let physical_page = $page_indices[$page_start + logical_page] as usize;
+                        physical_page * PAGED_PREFILL_PAGE_SIZE + page_offset
+                    } else {
+                        $kv_start + source_token
+                    };
+                    let source_pair = (physical_token * $num_kv_heads + $kv_head)
                         * BF16_PAIRS_PER_HEAD
                         + pair_in_head;
                     let destination_pair = ($thread_in_block + $iteration * TILED_THREADS as usize)
@@ -1663,31 +1674,14 @@ mod kernels {
         };
     }
 
-    #[kernel]
-    #[launch_bounds(128)]
+    #[inline(always)]
     #[allow(clippy::too_many_arguments)]
-    #[launch_contract(
-        domain = 1,
-        block = (128, 1, 1),
-        min_compute_capability = (9, 0),
-        requires = (
-            batch_size >= 1,
-            nnz_qo >= 1,
-            nnz_kv >= 1,
-            num_query_heads == num_kv_heads * 4,
-            num_kv_heads >= 1,
-            query.len() == nnz_qo * num_query_heads * 128,
-            key.len() == nnz_kv * num_kv_heads * 128,
-            value.len() == nnz_kv * num_kv_heads * 128,
-            qo_indptr.len() == batch_size + 1,
-            kv_indptr.len() == batch_size + 1,
-            workspace.len() == nnz_qo * num_query_heads * 8 * 130,
-        ),
-    )]
-    pub fn ragged_prefill_bf16_nhd_causal_tiled_gqa4(
+    fn prefill_bf16_nhd_causal_tiled_gqa4_impl(
+        paged: bool,
+        kv_tile: *mut u32,
         batch_size: usize,
         nnz_qo: usize,
-        nnz_kv: usize,
+        kv_bound: usize,
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
@@ -1696,10 +1690,11 @@ mod kernels {
         value: &[bf16],
         qo_indptr: &[i32],
         kv_indptr: &[i32],
+        page_indices: &[i32],
+        last_page_len: &[i32],
+        metadata_status: &[i32],
         mut workspace: DisjointSlice<f32>,
     ) {
-        static mut KV_TILE: SharedArray<u32, TILED_KV_SHARED_PAIRS, 16> = SharedArray::UNINIT;
-
         let block = thread::blockIdx_x() as usize;
         let thread_in_block = thread::threadIdx_x() as usize;
         let warp_in_block = thread_in_block / WARP_THREADS as usize;
@@ -1708,11 +1703,12 @@ mod kernels {
         let kv_head = block / TILED_PARTITIONS % num_kv_heads;
         let mut tile_index = block / (TILED_PARTITIONS * num_kv_heads);
 
-        if qo_indptr[0] != 0
-            || kv_indptr[0] != 0
-            || qo_indptr[batch_size] != nnz_qo as i32
-            || kv_indptr[batch_size] != nnz_kv as i32
-        {
+        let metadata_invalid = if paged {
+            metadata_status[0] != STATUS_SUCCESS
+        } else {
+            kv_indptr[0] != 0 || kv_indptr[batch_size] != kv_bound as i32
+        };
+        if qo_indptr[0] != 0 || qo_indptr[batch_size] != nnz_qo as i32 || metadata_invalid {
             return;
         }
 
@@ -1721,30 +1717,50 @@ mod kernels {
         let mut qo_start = 0_usize;
         let mut qo_len = 0_usize;
         let mut kv_start = 0_usize;
+        let mut page_start = 0_usize;
         let mut kv_len = 0_usize;
         while request < batch_size {
             let request_qo_start = qo_indptr[request];
             let request_qo_end = qo_indptr[request + 1];
-            let request_kv_start = kv_indptr[request];
-            let request_kv_end = kv_indptr[request + 1];
+            let request_range_start = kv_indptr[request];
+            let request_range_end = kv_indptr[request + 1];
             if request_qo_start < 0
                 || request_qo_end <= request_qo_start
-                || request_kv_start < 0
-                || request_kv_end <= request_kv_start
                 || request_qo_end as usize > nnz_qo
-                || request_kv_end as usize > nnz_kv
-                || request_qo_end - request_qo_start > request_kv_end - request_kv_start
+                || request_range_start < 0
+                || request_range_end <= request_range_start
             {
                 return;
             }
             let request_qo_len = (request_qo_end - request_qo_start) as usize;
+            let (request_kv_start, request_page_start, request_kv_len) = if paged {
+                let page_count = (request_range_end - request_range_start) as usize;
+                (
+                    0,
+                    request_range_start as usize,
+                    (page_count - 1) * PAGED_PREFILL_PAGE_SIZE + last_page_len[request] as usize,
+                )
+            } else {
+                if request_range_end as usize > kv_bound {
+                    return;
+                }
+                (
+                    request_range_start as usize,
+                    0,
+                    (request_range_end - request_range_start) as usize,
+                )
+            };
+            if request_qo_len > request_kv_len {
+                return;
+            }
             let request_tiles = request_qo_len.div_ceil(TILED_QUERY_ROWS);
             if tile_index < request_tiles {
                 request_tile = tile_index;
                 qo_start = request_qo_start as usize;
                 qo_len = request_qo_len;
-                kv_start = request_kv_start as usize;
-                kv_len = (request_kv_end - request_kv_start) as usize;
+                kv_start = request_kv_start;
+                page_start = request_page_start;
+                kv_len = request_kv_len;
                 break;
             }
             tile_index -= request_tiles;
@@ -1758,9 +1774,6 @@ mod kernels {
         let query_pairs = query.as_ptr().cast::<u32>();
         let key_pairs = key.as_ptr().cast::<u32>();
         let value_pairs = value.as_ptr().cast::<u32>();
-        // SAFETY: one block owns this shared tile and all cross-warp reuse is
-        // ordered by block barriers below.
-        let kv_tile = unsafe { SharedArray::as_raw_mut_ptr(&raw mut KV_TILE) };
 
         let mut output_0 = [0.0_f32; 4];
         let mut output_1 = [0.0_f32; 4];
@@ -1803,7 +1816,10 @@ mod kernels {
                 kv_tile,
                 key_pairs,
                 thread_in_block,
+                paged,
                 kv_start,
+                page_start,
+                page_indices,
                 kv_tile_start,
                 partition_token_end,
                 num_kv_heads,
@@ -2133,7 +2149,10 @@ mod kernels {
                 kv_tile,
                 value_pairs,
                 thread_in_block,
+                paged,
                 kv_start,
+                page_start,
+                page_indices,
                 kv_tile_start,
                 partition_token_end,
                 num_kv_heads,
@@ -2306,6 +2325,132 @@ mod kernels {
     }
 
     #[kernel]
+    #[launch_bounds(128)]
+    #[allow(clippy::too_many_arguments)]
+    #[launch_contract(
+        domain = 1,
+        block = (128, 1, 1),
+        min_compute_capability = (9, 0),
+        requires = (
+            batch_size >= 1,
+            nnz_qo >= 1,
+            nnz_kv >= 1,
+            num_query_heads == num_kv_heads * 4,
+            num_kv_heads >= 1,
+            query.len() == nnz_qo * num_query_heads * 128,
+            key.len() == nnz_kv * num_kv_heads * 128,
+            value.len() == nnz_kv * num_kv_heads * 128,
+            qo_indptr.len() == batch_size + 1,
+            kv_indptr.len() == batch_size + 1,
+            workspace.len() == nnz_qo * num_query_heads * 4 * 130,
+        ),
+    )]
+    pub fn ragged_prefill_bf16_nhd_causal_tiled_gqa4(
+        batch_size: usize,
+        nnz_qo: usize,
+        nnz_kv: usize,
+        num_query_heads: usize,
+        num_kv_heads: usize,
+        softmax_scale_log2: f32,
+        query: &[bf16],
+        key: &[bf16],
+        value: &[bf16],
+        qo_indptr: &[i32],
+        kv_indptr: &[i32],
+        workspace: DisjointSlice<f32>,
+    ) {
+        static mut KV_TILE: SharedArray<u32, TILED_KV_SHARED_PAIRS, 16> = SharedArray::UNINIT;
+        // SAFETY: one block owns this shared tile and the implementation orders
+        // every cross-warp reuse with a block barrier.
+        let kv_tile = unsafe { SharedArray::as_raw_mut_ptr(&raw mut KV_TILE) };
+        prefill_bf16_nhd_causal_tiled_gqa4_impl(
+            false,
+            kv_tile,
+            batch_size,
+            nnz_qo,
+            nnz_kv,
+            num_query_heads,
+            num_kv_heads,
+            softmax_scale_log2,
+            query,
+            key,
+            value,
+            qo_indptr,
+            kv_indptr,
+            kv_indptr,
+            kv_indptr,
+            kv_indptr,
+            workspace,
+        );
+    }
+
+    #[kernel]
+    #[launch_bounds(128)]
+    #[allow(clippy::too_many_arguments)]
+    #[launch_contract(
+        domain = 1,
+        block = (128, 1, 1),
+        min_compute_capability = (9, 0),
+        requires = (
+            batch_size >= 1,
+            nnz_qo >= 1,
+            max_num_pages >= 1,
+            num_query_heads == num_kv_heads * 4,
+            num_kv_heads >= 1,
+            query.len() == nnz_qo * num_query_heads * 128,
+            key_pages.len() == max_num_pages * 16 * num_kv_heads * 128,
+            value_pages.len() == max_num_pages * 16 * num_kv_heads * 128,
+            qo_indptr.len() == batch_size + 1,
+            page_indptr.len() == batch_size + 1,
+            page_indices.len() >= batch_size,
+            last_page_len.len() == batch_size,
+            metadata_status.len() == 5,
+            workspace.len() == nnz_qo * num_query_heads * 4 * 130,
+        ),
+    )]
+    pub fn paged_prefill_bf16_nhd_causal_tiled_gqa4(
+        batch_size: usize,
+        nnz_qo: usize,
+        max_num_pages: usize,
+        num_query_heads: usize,
+        num_kv_heads: usize,
+        softmax_scale_log2: f32,
+        query: &[bf16],
+        key_pages: &[bf16],
+        value_pages: &[bf16],
+        qo_indptr: &[i32],
+        page_indptr: &[i32],
+        page_indices: &[i32],
+        last_page_len: &[i32],
+        metadata_status: &[i32],
+        workspace: DisjointSlice<f32>,
+    ) {
+        static mut KV_TILE: SharedArray<u32, TILED_KV_SHARED_PAIRS, 16> = SharedArray::UNINIT;
+        // SAFETY: one block owns this shared tile and the implementation orders
+        // every cross-warp reuse with a block barrier.
+        let kv_tile = unsafe { SharedArray::as_raw_mut_ptr(&raw mut KV_TILE) };
+        prefill_bf16_nhd_causal_tiled_gqa4_impl(
+            true,
+            kv_tile,
+            batch_size,
+            nnz_qo,
+            max_num_pages,
+            num_query_heads,
+            num_kv_heads,
+            softmax_scale_log2,
+            query,
+            key_pages,
+            value_pages,
+            qo_indptr,
+            page_indptr,
+            page_indices,
+            last_page_len,
+            metadata_status,
+            workspace,
+        );
+    }
+
+    #[kernel]
     #[launch_bounds(32)]
     #[allow(clippy::too_many_arguments)]
     #[launch_contract(
@@ -2315,7 +2460,7 @@ mod kernels {
         requires = (
             nnz_qo >= 1,
             num_query_heads >= 1,
-            workspace.len() == nnz_qo * num_query_heads * 8 * 130,
+            workspace.len() == nnz_qo * num_query_heads * 4 * 130,
             output.len() == nnz_qo * num_query_heads * 128,
             lse.len() == nnz_qo * num_query_heads,
         ),
@@ -2439,12 +2584,27 @@ impl PrefillProvider {
         spec: Bf16PagedPrefillSpec,
         algorithm: Bf16PagedPrefillAlgorithm,
     ) -> Result<Bf16PagedPrefillPlan, PagedPrefillPlanError> {
-        let states = spec
+        if algorithm == Bf16PagedPrefillAlgorithm::TiledGqa4
+            && spec.gqa_group_size() != TILED_GQA_GROUP_SIZE
+        {
+            return Err(PagedPrefillPlanError::TiledGqa4GroupSize {
+                actual: spec.gqa_group_size(),
+            });
+        }
+        let state_count = spec
             .nnz_qo()
             .checked_mul(spec.num_query_heads())
             .ok_or(PagedPrefillPlanError::StateCountOutOfRange(usize::MAX))?;
-        let states = u32::try_from(states)
-            .map_err(|_| PagedPrefillPlanError::StateCountOutOfRange(states))?;
+        let workspace_numel = if algorithm == Bf16PagedPrefillAlgorithm::TiledGqa4 {
+            state_count
+                .checked_mul(TILED_PARTITIONS)
+                .and_then(|states| states.checked_mul(SINGLE_DECODE_PARTIAL_STATE_WIDTH))
+                .ok_or(PagedPrefillPlanError::WorkspaceElementCountOutOfRange)?
+        } else {
+            0
+        };
+        let states = u32::try_from(state_count)
+            .map_err(|_| PagedPrefillPlanError::StateCountOutOfRange(state_count))?;
         let metadata_launch = self
             .module
             .prepare_validate_paged_prefill_metadata(LaunchConfig1D::new(1, 1, 0))?;
@@ -2470,10 +2630,35 @@ impl PrefillProvider {
                         )?,
                 )
             }
+            Bf16PagedPrefillAlgorithm::TiledGqa4 => {
+                let tile_upper_bound = spec
+                    .nnz_qo()
+                    .div_ceil(TILED_QUERY_ROWS)
+                    .checked_add(spec.batch_size() - 1)
+                    .and_then(|tiles| tiles.checked_mul(spec.num_kv_heads()))
+                    .and_then(|tiles| tiles.checked_mul(TILED_PARTITIONS))
+                    .ok_or(PagedPrefillPlanError::StateCountOutOfRange(usize::MAX))?;
+                let tile_upper_bound = u32::try_from(tile_upper_bound)
+                    .map_err(|_| PagedPrefillPlanError::StateCountOutOfRange(tile_upper_bound))?;
+                let partial = self
+                    .module
+                    .prepare_paged_prefill_bf16_nhd_causal_tiled_gqa4(LaunchConfig1D::new(
+                        tile_upper_bound,
+                        TILED_THREADS,
+                        0,
+                    ))?;
+                let merge = self
+                    .module
+                    .prepare_ragged_prefill_bf16_nhd_causal_tiled_gqa4_merge(
+                        LaunchConfig1D::new(states, WARP_THREADS, 0),
+                    )?;
+                Bf16PagedPrefillLaunch::TiledGqa4 { partial, merge }
+            }
         };
         Ok(Bf16PagedPrefillPlan {
             spec,
             algorithm,
+            workspace_numel,
             module: self.module.clone(),
             metadata_launch,
             launch,
@@ -2564,6 +2749,7 @@ pub enum Bf16PagedPrefillAlgorithm {
     Direct,
     TokenParallel8,
     TokenParallel16,
+    TiledGqa4,
 }
 
 #[derive(Clone)]
@@ -2575,12 +2761,18 @@ enum Bf16PagedPrefillLaunch {
     TokenParallel16(
         PreparedLaunch<kernels::__paged_prefill_bf16_nhd_causal_token_parallel16_CudaKernel>,
     ),
+    TiledGqa4 {
+        partial: PreparedLaunch<kernels::__paged_prefill_bf16_nhd_causal_tiled_gqa4_CudaKernel>,
+        merge:
+            PreparedLaunch<kernels::__ragged_prefill_bf16_nhd_causal_tiled_gqa4_merge_CudaKernel>,
+    },
 }
 
 #[derive(Clone)]
 pub struct Bf16PagedPrefillPlan {
     spec: Bf16PagedPrefillSpec,
     algorithm: Bf16PagedPrefillAlgorithm,
+    workspace_numel: usize,
     module: kernels::LoadedModule,
     metadata_launch: PreparedLaunch<kernels::__validate_paged_prefill_metadata_CudaKernel>,
     launch: Bf16PagedPrefillLaunch,
@@ -2593,6 +2785,14 @@ impl Bf16PagedPrefillPlan {
 
     pub const fn algorithm(&self) -> Bf16PagedPrefillAlgorithm {
         self.algorithm
+    }
+
+    pub const fn workspace_required_numel(&self) -> usize {
+        self.workspace_numel
+    }
+
+    pub const fn workspace_required_bytes(&self) -> usize {
+        self.workspace_required_numel() * size_of::<f32>()
     }
 
     pub const fn metadata_status_required_numel(&self) -> usize {
@@ -2608,6 +2808,10 @@ impl Bf16PagedPrefillPlan {
         scope: &mut CommandScope<'_>,
         args: Bf16PagedPrefillArgs,
     ) -> Result<(), PagedPrefillEnqueueError> {
+        if let Bf16PagedPrefillLaunch::TiledGqa4 { partial, merge } = &self.launch {
+            return self.enqueue_tiled_gqa4(scope, args, partial, merge);
+        }
+
         let page_indices_len = {
             let resolved = scope.resolve_rrrrrrrrww(
                 args.query,
@@ -2791,9 +2995,181 @@ impl Bf16PagedPrefillPlan {
                     let result = enqueue_region_launch(resolved.stream, operation);
                     (launch.function().clone(), result)
                 }
+                Bf16PagedPrefillLaunch::TiledGqa4 { .. } => unreachable!(),
             }
         };
         record_paged_launch(scope, permit, function, launch_result)
+    }
+
+    fn enqueue_tiled_gqa4(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: Bf16PagedPrefillArgs,
+        partial: &PreparedLaunch<kernels::__paged_prefill_bf16_nhd_causal_tiled_gqa4_CudaKernel>,
+        merge: &PreparedLaunch<
+            kernels::__ragged_prefill_bf16_nhd_causal_tiled_gqa4_merge_CudaKernel,
+        >,
+    ) -> Result<(), PagedPrefillEnqueueError> {
+        let workspace = args
+            .workspace
+            .ok_or(PagedPrefillEnqueueError::MissingWorkspace)?;
+        let page_indices_len = {
+            let resolved = scope.resolve_rrrrrrrrww(
+                args.query,
+                args.key_pages,
+                args.value_pages,
+                args.qo_indptr,
+                args.page_indptr,
+                args.page_indices,
+                args.last_page_len,
+                args.metadata_status.read(),
+                args.output,
+                args.lse,
+            )?;
+            require_paged_exact_len("Q", resolved.first.len(), self.spec.query_numel())?;
+            require_paged_exact_len("K_pages", resolved.second.len(), self.spec.kv_pages_numel())?;
+            require_paged_exact_len("V_pages", resolved.third.len(), self.spec.kv_pages_numel())?;
+            require_paged_exact_len("qo_indptr", resolved.fourth.len(), self.spec.indptr_numel())?;
+            require_paged_exact_len(
+                "page_indptr",
+                resolved.fifth.len(),
+                self.spec.indptr_numel(),
+            )?;
+            if resolved.sixth.len() < self.spec.batch_size() {
+                return Err(PagedPrefillEnqueueError::PageIndicesTooShort {
+                    minimum: self.spec.batch_size(),
+                    actual: resolved.sixth.len(),
+                });
+            }
+            require_paged_exact_len(
+                "last_page_len",
+                resolved.seventh.len(),
+                self.spec.last_page_len_numel(),
+            )?;
+            require_paged_exact_len(
+                "metadata_status",
+                resolved.eighth.len(),
+                STATUS_PACKET_WORDS,
+            )?;
+            require_paged_exact_len("O", resolved.ninth.len(), self.spec.output_numel())?;
+            require_paged_exact_len("LSE", resolved.tenth.len(), self.spec.lse_numel())?;
+            for (operand, address) in [
+                ("Q", resolved.first.cu_deviceptr()),
+                ("K_pages", resolved.second.cu_deviceptr()),
+                ("V_pages", resolved.third.cu_deviceptr()),
+                ("O", resolved.ninth.cu_deviceptr()),
+            ] {
+                require_paged_alignment(operand, address)?;
+            }
+            resolved.sixth.len()
+        };
+        {
+            let resolved = scope.resolve_rww(workspace.read(), args.output, args.lse)?;
+            require_paged_exact_len(
+                "workspace",
+                resolved.first.len(),
+                self.workspace_required_numel(),
+            )?;
+        }
+
+        scope.require_command_capacity(4)?;
+        let status = scope.reserve_device_status(
+            args.metadata_status.read(),
+            DeviceStatusDecoder::paged_prefill(
+                self.spec.batch_size(),
+                self.spec.nnz_qo(),
+                self.spec.max_num_pages(),
+                page_indices_len,
+                PAGED_PREFILL_PAGE_SIZE,
+            ),
+        )?;
+        let validation_permit = scope.prepare_command()?;
+        let (validation_function, validation_result) = {
+            let resolved = scope.resolve_rrrrw(
+                args.qo_indptr,
+                args.page_indptr,
+                args.page_indices,
+                args.last_page_len,
+                args.metadata_status.write(),
+            )?;
+            let operation = self.module.validate_paged_prefill_metadata_async(
+                &self.metadata_launch,
+                self.spec.batch_size(),
+                self.spec.nnz_qo(),
+                self.spec.max_num_pages(),
+                resolved.first,
+                resolved.second,
+                resolved.third,
+                resolved.fourth,
+                resolved.fifth,
+            );
+            let result = enqueue_region_launch(resolved.stream, operation);
+            (self.metadata_launch.function().clone(), result)
+        };
+        record_paged_metadata_launch(
+            scope,
+            status,
+            validation_permit,
+            validation_function,
+            validation_result,
+        )?;
+
+        let partial_permit = scope.prepare_command()?;
+        let (partial_function, partial_result) = {
+            // The tenth resolved binding is a conservative write dependency;
+            // the partial kernel writes only the F32 workspace in `ninth`.
+            let resolved = scope.resolve_rrrrrrrrww(
+                args.query,
+                args.key_pages,
+                args.value_pages,
+                args.qo_indptr,
+                args.page_indptr,
+                args.page_indices,
+                args.last_page_len,
+                args.metadata_status.read(),
+                workspace.write(),
+                args.output,
+            )?;
+            let operation = self.module.paged_prefill_bf16_nhd_causal_tiled_gqa4_async(
+                partial,
+                self.spec.batch_size(),
+                self.spec.nnz_qo(),
+                self.spec.max_num_pages(),
+                self.spec.num_query_heads(),
+                self.spec.num_kv_heads(),
+                self.spec.softmax_scale() * core::f32::consts::LOG2_E,
+                resolved.first,
+                resolved.second,
+                resolved.third,
+                resolved.fourth,
+                resolved.fifth,
+                resolved.sixth,
+                resolved.seventh,
+                resolved.eighth,
+                resolved.ninth,
+            );
+            let result = enqueue_region_launch(resolved.stream, operation);
+            (partial.function().clone(), result)
+        };
+        record_paged_launch(scope, partial_permit, partial_function, partial_result)?;
+
+        let merge_permit = scope.prepare_command()?;
+        let (merge_function, merge_result) = {
+            let resolved = scope.resolve_rww(workspace.read(), args.output, args.lse)?;
+            let operation = self
+                .module
+                .ragged_prefill_bf16_nhd_causal_tiled_gqa4_merge_async(
+                    merge,
+                    self.spec.nnz_qo(),
+                    self.spec.num_query_heads(),
+                    resolved.first,
+                    resolved.second,
+                    resolved.third,
+                );
+            let result = enqueue_region_launch(resolved.stream, operation);
+            (merge.function().clone(), result)
+        };
+        record_paged_launch(scope, merge_permit, merge_function, merge_result)
     }
 }
 
@@ -3082,6 +3458,7 @@ pub struct Bf16PagedPrefillArgs {
     metadata_status: ReadWrite<i32>,
     output: Write<bf16>,
     lse: Write<f32>,
+    workspace: Option<ReadWrite<f32>>,
 }
 
 impl Bf16PagedPrefillArgs {
@@ -3109,7 +3486,13 @@ impl Bf16PagedPrefillArgs {
             metadata_status,
             output,
             lse,
+            workspace: None,
         }
+    }
+
+    pub const fn with_workspace(mut self, workspace: ReadWrite<f32>) -> Self {
+        self.workspace = Some(workspace);
+        self
     }
 }
 
@@ -3158,6 +3541,10 @@ impl Bf16RaggedPrefillArgs {
 pub enum PagedPrefillPlanError {
     #[error("paged prefill state count {0} exceeds the CUDA grid range")]
     StateCountOutOfRange(usize),
+    #[error("paged prefill workspace element count exceeds usize")]
+    WorkspaceElementCountOutOfRange,
+    #[error("paged tiled GQA4 requires group size 4, got {actual}")]
+    TiledGqa4GroupSize { actual: usize },
     #[error(transparent)]
     Launch(#[from] LaunchContractError),
 }
@@ -3172,6 +3559,8 @@ pub enum PagedPrefillEnqueueError {
     },
     #[error("page_indices requires at least {minimum} entries, got {actual}")]
     PageIndicesTooShort { minimum: usize, actual: usize },
+    #[error("paged prefill algorithm requires an explicit F32 workspace binding")]
+    MissingWorkspace,
     #[error(transparent)]
     Command(#[from] CommandError),
     #[error(transparent)]
@@ -3378,8 +3767,10 @@ mod tests {
             ragged_prefill_algorithm(grouped),
             Bf16RaggedPrefillAlgorithm::TiledGqa4
         );
-        let expected_workspace =
-            grouped.nnz_qo() * grouped.num_query_heads() * 8 * SINGLE_DECODE_PARTIAL_STATE_WIDTH;
-        assert_eq!(expected_workspace, 1_597_440);
+        let expected_workspace = grouped.nnz_qo()
+            * grouped.num_query_heads()
+            * TILED_PARTITIONS
+            * SINGLE_DECODE_PARTIAL_STATE_WIDTH;
+        assert_eq!(expected_workspace, 798_720);
     }
 }

--- a/crates/oxide-infer-lab/src/benchmarks/matched.rs
+++ b/crates/oxide-infer-lab/src/benchmarks/matched.rs
@@ -637,6 +637,7 @@ fn benchmark_paged_prefill_case(
         Bf16PagedPrefillAlgorithm::Direct => "direct_one_warp_per_query_row_head",
         Bf16PagedPrefillAlgorithm::TokenParallel8 => "token_parallel_8warp_block_local_merge",
         Bf16PagedPrefillAlgorithm::TokenParallel16 => "token_parallel_16warp_block_local_merge",
+        Bf16PagedPrefillAlgorithm::TiledGqa4 => "tiled_gqa4_paged_mma_qk_softmax_pv",
     };
     let query_host = deterministic_bf16(spec.query_numel(), case.salt);
     let key_host = deterministic_bf16(spec.kv_pages_numel(), case.salt ^ 0x4b45_5900);
@@ -650,6 +651,8 @@ fn benchmark_paged_prefill_case(
     let last_page_len = Arc::new(DeviceBuffer::from_host(stream, case.last_page_len)?);
     let output = DeviceBuffer::<bf16>::zeroed(stream, spec.output_numel())?;
     let lse = DeviceBuffer::<f32>::zeroed(stream, spec.lse_numel())?;
+    let workspace =
+        DeviceBuffer::<f32>::zeroed(stream, usize::max(plan.workspace_required_numel(), 1))?;
     let mut metadata_statuses = Vec::with_capacity(config.launches_per_sample);
     for _ in 0..config.launches_per_sample {
         metadata_statuses.push(DeviceBuffer::<i32>::zeroed(
@@ -657,12 +660,19 @@ fn benchmark_paged_prefill_case(
             plan.metadata_status_required_numel(),
         )?);
     }
+    let attention_kernels_per_call = if plan.workspace_required_numel() == 0 {
+        1
+    } else {
+        2
+    };
+    let commands_per_call = attention_kernels_per_call + 2;
+    let kernels_per_call = attention_kernels_per_call + 1;
     let command_capacity = config
         .launches_per_sample
-        .checked_mul(3)
+        .checked_mul(commands_per_call)
         .ok_or("paged-prefill command capacity overflowed")?;
     let mut queue = CommandQueue::new(stream.clone(), command_capacity, 1)?;
-    let binding_capacity = 9_usize
+    let binding_capacity = 10_usize
         .checked_add(config.launches_per_sample)
         .ok_or("paged-prefill binding capacity overflowed")?;
     let mut bindings = queue.bindings(binding_capacity)?;
@@ -675,6 +685,7 @@ fn benchmark_paged_prefill_case(
     let last_page_len_handle = bindings.bind_read(last_page_len)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let mut metadata_status_handles = Vec::with_capacity(config.launches_per_sample);
     for metadata_status in metadata_statuses {
         metadata_status_handles.push(bindings.bind_read_write(metadata_status)?);
@@ -685,21 +696,22 @@ fn benchmark_paged_prefill_case(
         benchmark_scopes(context, stream, &mut queue, bindings, config, |scope| {
             let metadata_status_handle = metadata_status_handles[metadata_status_index];
             metadata_status_index = (metadata_status_index + 1) % metadata_status_handles.len();
-            plan.enqueue_into(
-                scope,
-                Bf16PagedPrefillArgs::new(
-                    query_handle,
-                    key_handle,
-                    value_handle,
-                    qo_indptr_handle,
-                    page_indptr_handle,
-                    page_indices_handle,
-                    last_page_len_handle,
-                    metadata_status_handle,
-                    output_handle.write(),
-                    lse_handle.write(),
-                ),
-            )?;
+            let mut args = Bf16PagedPrefillArgs::new(
+                query_handle,
+                key_handle,
+                value_handle,
+                qo_indptr_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                metadata_status_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            );
+            if plan.workspace_required_numel() != 0 {
+                args = args.with_workspace(workspace_handle);
+            }
+            plan.enqueue_into(scope, args)?;
             Ok(())
         })?;
     let mut request_qo_lens = Vec::with_capacity(spec.batch_size());
@@ -733,11 +745,11 @@ fn benchmark_paged_prefill_case(
             "page_table_location": "device",
             "metadata_validation": "device_status",
             "validator_kernels_per_call": 1,
-            "attention_kernels_per_call": 1,
+            "attention_kernels_per_call": attention_kernels_per_call,
             "status_readbacks_per_call": 1,
-            "commands_per_call": 3
+            "commands_per_call": commands_per_call
         }),
-        kernels_per_call: 2,
+        kernels_per_call,
         shape: json!({
             "batch_size": spec.batch_size(),
             "nnz_qo": spec.nnz_qo(),
@@ -1636,7 +1648,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedPrefillCase {
                 name: "bf16_paged_prefill_gqa4_b2_q32_64_kv256_1024_qh16_kvh4_d128_p16",
-                algorithm: Bf16PagedPrefillAlgorithm::TokenParallel8,
+                algorithm: Bf16PagedPrefillAlgorithm::TiledGqa4,
                 batch_size: 2,
                 max_num_pages: 96,
                 query_heads: 16,

--- a/crates/oxide-infer-lab/src/benchmarks/paged_prefill_graph.rs
+++ b/crates/oxide-infer-lab/src/benchmarks/paged_prefill_graph.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 const PROVIDER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MEASUREMENT: &str = "fixed_address_cuda_graph_single_replay_event";
 const FIXTURE_ID: &str = "xorshift64_mod2001_bf16_i32_paged_prefill_v1";
-const CASE: &str = "bf16_paged_prefill_gqa4_b2_q4_2_kv23_18_qh16_kvh4_d128_p16";
+const CASE: &str = "bf16_paged_prefill_gqa4_b2_q32_64_kv256_1024_qh16_kvh4_d128_p16";
 const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
 const LSE_MAX_ABS_LIMIT: f32 = 0.01;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
@@ -58,21 +58,26 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
     let context = CudaContext::new(0)?;
     let provider = PrefillProvider::load(&context)?;
-    let spec = Bf16PagedPrefillSpec::new(2, 6, 6, 16, 4, 128, 16)?;
-    let qo_indptr_host = [0_i32, 4, 6];
-    let page_indptr_host = [0_i32, 2, 4];
-    let page_indices_host = [5_i32, 1, 5, 3];
-    let last_page_len_host = [7_i32, 2];
+    let spec = Bf16PagedPrefillSpec::new(2, 96, 96, 16, 4, 128, 16)?;
+    let qo_indptr_host = [0_i32, 32, 96];
+    let page_indptr_host = [0_i32, 16, 80];
+    let page_indices_host = [
+        15_i32, 3, 27, 9, 31, 1, 35, 5, 39, 7, 43, 11, 47, 13, 51, 17, 19, 21, 23, 25, 29, 33, 37,
+        41, 45, 49, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91,
+        93, 95, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42,
+        44, 46, 48, 50, 52, 54, 56, 58, 60, 62,
+    ];
+    let last_page_len_host = [16_i32, 16];
     spec.validate_metadata(
         &qo_indptr_host,
         &page_indptr_host,
         &page_indices_host,
         &last_page_len_host,
     )?;
-    let plan = provider.plan_bf16_paged(spec, Bf16PagedPrefillAlgorithm::Direct)?;
-    let query_host = deterministic_bf16(spec.query_numel(), 0x4001);
-    let key_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x4b45_5900);
-    let value_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x5641_4c55_4500);
+    let plan = provider.plan_bf16_paged(spec, Bf16PagedPrefillAlgorithm::TiledGqa4)?;
+    let query_host = deterministic_bf16(spec.query_numel(), 0x8001);
+    let key_host = deterministic_bf16(spec.kv_pages_numel(), 0x8001 ^ 0x4b45_5900);
+    let value_host = deterministic_bf16(spec.kv_pages_numel(), 0x8001 ^ 0x5641_4c55_4500);
     let mut expected_output = vec![bf16::NAN; spec.output_numel()];
     let mut expected_lse = vec![f32::NAN; spec.lse_numel()];
     paged_prefill_bf16_reference(
@@ -103,9 +108,10 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     let lse = DeviceBuffer::from_host(&upload_stream, &vec![f32::NAN; spec.lse_numel()])?;
     let metadata_status =
         DeviceBuffer::<i32>::zeroed(&upload_stream, plan.metadata_status_required_numel())?;
+    let workspace = DeviceBuffer::<f32>::zeroed(&upload_stream, plan.workspace_required_numel())?;
 
-    let graph_queue = GraphQueue::new(&context, 3)?;
-    let mut bindings = graph_queue.bindings(10)?;
+    let graph_queue = GraphQueue::new(&context, 4)?;
+    let mut bindings = graph_queue.bindings(11)?;
     let query_handle = bindings.bind_read(query)?;
     let key_handle = bindings.bind_read(key_pages)?;
     let value_handle = bindings.bind_read(value_pages)?;
@@ -116,6 +122,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     let metadata_status_handle = bindings.bind_read_write(metadata_status)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
     let captured = graph_queue.capture(bindings, |scope| {
         plan.enqueue_into(
             scope,
@@ -130,10 +137,11 @@ pub fn run() -> Result<(), Box<dyn Error>> {
                 metadata_status_handle,
                 output_handle.write(),
                 lse_handle.write(),
-            ),
+            )
+            .with_workspace(workspace_handle),
         )
     })?;
-    if captured.commands() != 3 {
+    if captured.commands() != 4 {
         return Err("paged-prefill Graph benchmark captured the wrong command count".into());
     }
     let mut exec = captured.instantiate()?;
@@ -189,15 +197,15 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         dtype: "bf16",
         layout: "NHD_D128_page16",
         execution: json!({
-            "algorithm": "direct_one_warp_per_query_row_head",
+            "algorithm": "tiled_gqa4_paged_mma_qk_softmax_pv",
             "causal": "bottom_right",
             "graph": "fixed_address_private_stream",
-            "graph_nodes": 3,
+            "graph_nodes": 4,
             "metadata_validation": "device_status",
             "validator_kernels_per_call": 1,
-            "attention_kernels_per_call": 1,
+            "attention_kernels_per_call": 2,
             "status_readbacks_per_call": 1,
-            "commands_per_call": 3,
+            "commands_per_call": 4,
             "completion_event_inside_timed_interval": true,
             "correctness": {
                 "output_max_abs": output_comparison.max_abs,
@@ -208,14 +216,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
                 "lse_digest": format!("{:016x}", lse_comparison.digest)
             }
         }),
-        kernels_per_call: 2,
+        kernels_per_call: 3,
         shape: json!({
             "batch_size": 2,
-            "nnz_qo": 6,
-            "max_num_pages": 6,
-            "referenced_pages": 4,
-            "request_qo_lens": [4, 2],
-            "request_kv_lens": [23, 18],
+            "nnz_qo": 96,
+            "max_num_pages": 96,
+            "referenced_pages": 80,
+            "request_qo_lens": [32, 64],
+            "request_kv_lens": [256, 1024],
             "query_heads": 16,
             "kv_heads": 4,
             "head_dim": 128,

--- a/crates/oxide-infer-lab/src/gates/paged_prefill.rs
+++ b/crates/oxide-infer-lab/src/gates/paged_prefill.rs
@@ -16,8 +16,17 @@ use std::sync::Arc;
 
 const OUTPUT_MAX_ABS_LIMIT: f32 = 0.015_625;
 const LSE_MAX_ABS_LIMIT: f32 = 0.01;
-const PAGED_GRAPH_COMMANDS_PER_STAGE: usize = 3;
+const PAGED_GRAPH_COMMANDS_PER_STAGE: usize = 4;
 const STATUS_POISON: i32 = i32::MIN;
+const LONG_GQA4_QO_INDPTR: [i32; 3] = [0, 32, 96];
+const LONG_GQA4_PAGE_INDPTR: [i32; 3] = [0, 16, 80];
+const LONG_GQA4_PAGE_INDICES: [i32; 80] = [
+    15, 3, 27, 9, 31, 1, 35, 5, 39, 7, 43, 11, 47, 13, 51, 17, 19, 21, 23, 25, 29, 33, 37, 41, 45,
+    49, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 0,
+    2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50,
+    52, 54, 56, 58, 60, 62,
+];
+const LONG_GQA4_LAST_PAGE_LEN: [i32; 2] = [16, 16];
 
 #[derive(Clone, Copy)]
 struct MetadataInput<'a> {
@@ -59,6 +68,7 @@ fn run_case(
         Bf16PagedPrefillAlgorithm::Direct => "direct_one_warp_per_query_row_head",
         Bf16PagedPrefillAlgorithm::TokenParallel8 => "token_parallel_8warp_block_local_merge",
         Bf16PagedPrefillAlgorithm::TokenParallel16 => "token_parallel_16warp_block_local_merge",
+        Bf16PagedPrefillAlgorithm::TiledGqa4 => "tiled_gqa4_paged_mma_qk_softmax_pv",
     };
     let query_host = deterministic_bf16(spec.query_numel(), salt);
     let key_host = deterministic_bf16(spec.kv_pages_numel(), salt ^ 0x4b45_5900);
@@ -89,7 +99,9 @@ fn run_case(
         DeviceBuffer::<i32>::zeroed(&stream, plan.metadata_status_required_numel())?;
     let output = DeviceBuffer::from_host(&stream, &vec![bf16::NAN; spec.output_numel()])?;
     let lse = DeviceBuffer::from_host(&stream, &vec![f32::NAN; spec.lse_numel()])?;
-    let mut bindings = queue.bindings(10)?;
+    let workspace =
+        DeviceBuffer::<f32>::zeroed(&stream, usize::max(plan.workspace_required_numel(), 1))?;
+    let mut bindings = queue.bindings(11)?;
     let query_handle = bindings.bind_read(query)?;
     let key_handle = bindings.bind_read(key_pages)?;
     let value_handle = bindings.bind_read(value_pages)?;
@@ -100,25 +112,32 @@ fn run_case(
     let metadata_status_handle = bindings.bind_read_write(metadata_status)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
 
     let mut scope = queue.begin(bindings)?;
-    plan.enqueue_into(
-        &mut scope,
-        Bf16PagedPrefillArgs::new(
-            query_handle,
-            key_handle,
-            value_handle,
-            qo_handle,
-            page_indptr_handle,
-            page_indices_handle,
-            last_page_len_handle,
-            metadata_status_handle,
-            output_handle.write(),
-            lse_handle.write(),
-        ),
-    )?;
+    let mut args = Bf16PagedPrefillArgs::new(
+        query_handle,
+        key_handle,
+        value_handle,
+        qo_handle,
+        page_indptr_handle,
+        page_indices_handle,
+        last_page_len_handle,
+        metadata_status_handle,
+        output_handle.write(),
+        lse_handle.write(),
+    );
+    if plan.workspace_required_numel() != 0 {
+        args = args.with_workspace(workspace_handle);
+    }
+    plan.enqueue_into(&mut scope, args)?;
     let completion = scope.finish();
-    if completion.submitted() != 3 {
+    let expected_commands = if plan.workspace_required_numel() == 0 {
+        3
+    } else {
+        4
+    };
+    if completion.submitted() != expected_commands {
         return Err("paged prefill completion covered the wrong command count".into());
     }
     bindings = completion.wait()?;
@@ -149,7 +168,7 @@ fn run_case(
         "{} batch_size={} nnz_qo={} query_heads={} kv_heads={} group_size={} \
          max_num_pages={} referenced_pages={} page_size={} kv_lens={} layout=NHD \
          causal=bottom_right dtype=BF16 accumulation=F32 lse_domain=log2 \
-         algorithm={} commands=3 validator_kernels=1 attention_kernels=1 \
+         algorithm={} commands={} validator_kernels=1 attention_kernels={} \
          status_readbacks=1 stream=non_default \
          output_max_abs={:.9e} output_bit_mismatches={} output_digest={:016x} \
          lse_max_abs={:.9e} lse_bit_mismatches={} lse_digest={:016x}",
@@ -164,6 +183,8 @@ fn run_case(
         spec.page_size(),
         kv_lens,
         algorithm,
+        expected_commands,
+        expected_commands - 2,
         output_comparison.max_abs,
         output_comparison.bit_mismatches,
         output_comparison.digest,
@@ -429,26 +450,101 @@ fn run_duplicate_binding_case(
     Ok(())
 }
 
+fn run_missing_workspace_case(
+    queue: &mut CommandQueue,
+    provider: &PrefillProvider,
+) -> Result<(), Box<dyn Error>> {
+    let spec = Bf16PagedPrefillSpec::new(1, 1, 16, 4, 1, 128, 16)?;
+    let plan = provider.plan_bf16_paged(spec, Bf16PagedPrefillAlgorithm::TiledGqa4)?;
+    if plan.workspace_required_numel() == 0 {
+        return Err("missing-workspace gate did not select tiled GQA4".into());
+    }
+    let stream = queue.stream().clone();
+    let query = Arc::new(DeviceBuffer::<bf16>::zeroed(&stream, spec.query_numel())?);
+    let key_pages = Arc::new(DeviceBuffer::<bf16>::zeroed(
+        &stream,
+        spec.kv_pages_numel(),
+    )?);
+    let value_pages = Arc::new(DeviceBuffer::<bf16>::zeroed(
+        &stream,
+        spec.kv_pages_numel(),
+    )?);
+    let qo_indptr = Arc::new(DeviceBuffer::from_host(&stream, &[0_i32, 1])?);
+    let page_indptr = Arc::new(DeviceBuffer::from_host(&stream, &[0_i32, 16])?);
+    let page_indices = Arc::new(DeviceBuffer::from_host(
+        &stream,
+        &(0_i32..16).collect::<Vec<_>>(),
+    )?);
+    let last_page_len = Arc::new(DeviceBuffer::from_host(&stream, &[16_i32])?);
+    let metadata_status =
+        DeviceBuffer::<i32>::zeroed(&stream, plan.metadata_status_required_numel())?;
+    let output = DeviceBuffer::<bf16>::zeroed(&stream, spec.output_numel())?;
+    let lse = DeviceBuffer::<f32>::zeroed(&stream, spec.lse_numel())?;
+    let mut bindings = queue.bindings(10)?;
+    let query_handle = bindings.bind_read(query)?;
+    let key_handle = bindings.bind_read(key_pages)?;
+    let value_handle = bindings.bind_read(value_pages)?;
+    let qo_handle = bindings.bind_read(qo_indptr)?;
+    let page_indptr_handle = bindings.bind_read(page_indptr)?;
+    let page_indices_handle = bindings.bind_read(page_indices)?;
+    let last_page_len_handle = bindings.bind_read(last_page_len)?;
+    let metadata_status_handle = bindings.bind_read_write(metadata_status)?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let lse_handle = bindings.bind_read_write(lse)?;
+
+    let mut scope = queue.begin(bindings)?;
+    let error = plan
+        .enqueue_into(
+            &mut scope,
+            Bf16PagedPrefillArgs::new(
+                query_handle,
+                key_handle,
+                value_handle,
+                qo_handle,
+                page_indptr_handle,
+                page_indices_handle,
+                last_page_len_handle,
+                metadata_status_handle,
+                output_handle.write(),
+                lse_handle.write(),
+            ),
+        )
+        .expect_err("paged tiled GQA4 must require an explicit workspace");
+    if !matches!(error, PagedPrefillEnqueueError::MissingWorkspace) {
+        return Err(format!("missing workspace returned the wrong error: {error}").into());
+    }
+    let completion = scope.finish();
+    if completion.submitted() != 0 {
+        return Err("missing workspace reached CUDA submission".into());
+    }
+    drop(completion.wait()?);
+    println!(
+        "{} workspace=required before_submission=true",
+        GateCase::new("paged_prefill_h20", "missing_workspace")
+    );
+    Ok(())
+}
+
 fn run_graph_case(
     queue: &mut CommandQueue,
     provider: &PrefillProvider,
 ) -> Result<(), Box<dyn Error>> {
-    let spec = Bf16PagedPrefillSpec::new(2, 6, 6, 16, 4, 128, 16)?;
-    let qo_indptr_host = [0_i32, 4, 6];
-    let page_indptr_host = [0_i32, 2, 4];
-    let page_indices_host = [5_i32, 1, 5, 3];
-    let last_page_len_host = [7_i32, 2];
+    let spec = Bf16PagedPrefillSpec::new(2, 96, 96, 16, 4, 128, 16)?;
+    let qo_indptr_host = LONG_GQA4_QO_INDPTR;
+    let page_indptr_host = LONG_GQA4_PAGE_INDPTR;
+    let page_indices_host = LONG_GQA4_PAGE_INDICES;
+    let last_page_len_host = LONG_GQA4_LAST_PAGE_LEN;
     spec.validate_metadata(
         &qo_indptr_host,
         &page_indptr_host,
         &page_indices_host,
         &last_page_len_host,
     )?;
-    let plan = provider.plan_bf16_paged(spec, Bf16PagedPrefillAlgorithm::Direct)?;
+    let plan = provider.plan_bf16_paged(spec, Bf16PagedPrefillAlgorithm::TiledGqa4)?;
     let stream = queue.stream().clone();
-    let query_host = deterministic_bf16(spec.query_numel(), 0x4001);
-    let key_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x4b45_5900);
-    let value_host = deterministic_bf16(spec.kv_pages_numel(), 0x4001 ^ 0x5641_4c55_4500);
+    let query_host = deterministic_bf16(spec.query_numel(), 0x8001);
+    let key_host = deterministic_bf16(spec.kv_pages_numel(), 0x8001 ^ 0x4b45_5900);
+    let value_host = deterministic_bf16(spec.kv_pages_numel(), 0x8001 ^ 0x5641_4c55_4500);
     let poison_query_host = vec![bf16::ZERO; spec.query_numel()];
     let poison_key_host = vec![bf16::ZERO; spec.kv_pages_numel()];
     let poison_value_host = vec![bf16::ZERO; spec.kv_pages_numel()];
@@ -512,10 +608,11 @@ fn run_graph_case(
     let poison_observer_lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
     let output = DeviceBuffer::from_host(&stream, &initial_output)?;
     let lse = DeviceBuffer::from_host(&stream, &initial_lse)?;
+    let workspace = DeviceBuffer::<f32>::zeroed(&stream, plan.workspace_required_numel())?;
 
     let graph_commands = valid_graph_commands(PAGED_GRAPH_COMMANDS_PER_STAGE);
     let graph_queue = GraphQueue::new(stream.context(), graph_commands)?;
-    let mut bindings = graph_queue.bindings(17)?;
+    let mut bindings = graph_queue.bindings(18)?;
     let poison_query_handle = bindings.bind_read(Arc::clone(&poison_query))?;
     let poison_key_handle = bindings.bind_read(Arc::clone(&poison_key_pages))?;
     let poison_value_handle = bindings.bind_read(Arc::clone(&poison_value_pages))?;
@@ -533,6 +630,7 @@ fn run_graph_case(
     let poison_observer_lse_handle = bindings.bind_read_write(poison_observer_lse)?;
     let output_handle = bindings.bind_read_write(output)?;
     let lse_handle = bindings.bind_read_write(lse)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
 
     let captured = graph_queue.capture(bindings, |scope| {
         plan.enqueue_into(
@@ -548,7 +646,8 @@ fn run_graph_case(
                 poison_observer_status_handle,
                 poison_observer_output_handle.write(),
                 poison_observer_lse_handle.write(),
-            ),
+            )
+            .with_workspace(workspace_handle),
         )?;
         plan.enqueue_into(
             scope,
@@ -563,7 +662,8 @@ fn run_graph_case(
                 target_poison_status_handle,
                 output_handle.write(),
                 lse_handle.write(),
-            ),
+            )
+            .with_workspace(workspace_handle),
         )?;
         plan.enqueue_into(
             scope,
@@ -578,7 +678,8 @@ fn run_graph_case(
                 real_status_handle,
                 output_handle.write(),
                 lse_handle.write(),
-            ),
+            )
+            .with_workspace(workspace_handle),
         )
     })?;
     if captured.commands() != graph_commands {
@@ -674,9 +775,9 @@ fn run_graph_case(
     }
 
     println!(
-        "{} batch_size=2 nnz_qo=6 query_heads=16 kv_heads=4 page_size=16 \
-         algorithm=direct_one_warp_per_query_row_head commands={} commands_per_stage=3 \
-         validator_kernels_per_stage=1 attention_kernels_per_stage=1 \
+        "{} batch_size=2 nnz_qo=96 query_heads=16 kv_heads=4 page_size=16 \
+         algorithm=tiled_gqa4_paged_mma_qk_softmax_pv commands={} commands_per_stage=4 \
+         validator_kernels_per_stage=1 attention_kernels_per_stage=2 \
          status_readbacks_per_stage=1 replays={} \
          replay_stages=independent_poison_then_target_poison_then_real \
          independent_poison_observable=true output_lse_poisoned_each_replay=true \
@@ -688,7 +789,7 @@ fn run_graph_case(
          poison_lse_max_abs={:.9e} poison_lse_digest={:016x} \
          output_max_abs={:.9e} output_bit_mismatches={} output_digest={:016x} \
          lse_max_abs={:.9e} lse_bit_mismatches={} lse_digest={:016x}",
-        GateCase::new("paged_prefill_h20", "gqa4_graph"),
+        GateCase::new("paged_prefill_h20", "gqa4_tiled_graph"),
         graph_commands,
         VALID_GRAPH_REPLAYS,
         poison_output_comparison.max_abs,
@@ -843,7 +944,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     let context = CudaContext::new(0)?;
     let provider = PrefillProvider::load(&context)?;
     let stream: Arc<CudaStream> = context.new_stream()?;
-    let mut queue = CommandQueue::new(stream, 3, 1)?;
+    let mut queue = CommandQueue::new(stream, 4, 1)?;
 
     run_case(
         &mut queue,
@@ -922,19 +1023,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     run_case(
         &mut queue,
         &provider,
-        "gqa4_token_parallel",
+        "gqa4_tiled",
         Bf16PagedPrefillSpec::new(2, 96, 96, 16, 4, 128, 16)?,
-        Bf16PagedPrefillAlgorithm::TokenParallel8,
+        Bf16PagedPrefillAlgorithm::TiledGqa4,
         MetadataInput {
-            qo_indptr: &[0, 32, 96],
-            page_indptr: &[0, 16, 80],
-            page_indices: &[
-                15, 3, 27, 9, 31, 1, 35, 5, 39, 7, 43, 11, 47, 13, 51, 17, 19, 21, 23, 25, 29, 33,
-                37, 41, 45, 49, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85,
-                87, 89, 91, 93, 95, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32,
-                34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62,
-            ],
-            last_page_len: &[16, 16],
+            qo_indptr: &LONG_GQA4_QO_INDPTR,
+            page_indptr: &LONG_GQA4_PAGE_INDPTR,
+            page_indices: &LONG_GQA4_PAGE_INDICES,
+            last_page_len: &LONG_GQA4_LAST_PAGE_LEN,
         },
         0x8001,
     )?;
@@ -945,6 +1041,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     run_short_metadata_case(&mut queue, &preflight_plan)?;
     run_invalid_query_guard(&mut queue, &provider)?;
     run_duplicate_binding_case(&mut queue, &provider)?;
+    run_missing_workspace_case(&mut queue, &provider)?;
     run_graph_case(&mut queue, &provider)?;
     run_invalid_page_graph_rejection_case(&context, &provider)?;
     println!(

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -143,7 +143,7 @@ online-softmax state, split states, and merge arithmetic use F32.
 | Paged batch decode | `Q/O [batch,qh,128]`, pages `[max_pages,16,kvh,128]`, full attention | MHA `(1,2,8,8)`, MQA `(3,7,8,1)`, GQA `(4,8,16,4)` as `(batch,max_pages,qh,kvh)` |
 | Ragged causal prefill | Contiguous Q/K/V with separate I32 `qo_indptr` and `kv_indptr` | `(batch,nnz_qo,nnz_kv,qh,kvh)`: `(1,4,4,8,8)`, `(3,6,13,8,1)`, `(2,6,11,16,4)`, `(3,21,896,8,1)`, `(2,96,1280,16,4)` |
 | Paged causal prefill | Ragged Q plus page-size-16 KV and bottom-right causal mask | Short: `(batch,nnz_qo,max_pages,qh,kvh)` is `(1,4,2,8,8)`, `(3,6,7,8,1)`, or `(2,6,6,16,4)` |
-| Paged causal prefill, long | Same contract with block-local token partitioning | MQA `(3,21,64,8,1)` uses sixteen warps. GQA4 `(2,96,96,16,4)` uses eight warps |
+| Paged causal prefill, long | Same contract with partitioned F32 state | MQA `(3,21,64,8,1)` uses sixteen warps. GQA4 `(2,96,96,16,4)` uses tiled split-four |
 
 Paged metadata uses I32 `page_indptr`, `page_indices`, and `last_page_len`.
 Cover mixed lengths, partial tails, physical-page order, and read-only page
@@ -156,25 +156,27 @@ kv_index <= kv_len - qo_len + query_index
 ```
 
 The current ragged runner selects direct for the three short cases, sixteen
-warps for long MQA, and tiled split-eight for long GQA4. Earlier records cover
+warps for long MQA, and tiled split-four for long GQA4. Earlier records cover
 the eight-warp stage, but the current runner needs a dedicated eight-warp case
 before that path gains current-source qualification.
 
 The tiled GQA4 workspace is F32
-`[nnz_qo, query_heads, 8, 130]`. One completion covers the partial and merge
+`[nnz_qo, query_heads, 4, 130]`. One completion covers the partial and merge
 kernels. A missing workspace must fail before CUDA submission.
 
 Paged prefill requires an explicit algorithm at plan creation. The gate uses
-direct for short cases, sixteen warps for long MQA, and eight warps for long
-GQA4. These choices are fixtures, not an automatic runtime policy.
+direct for short cases, sixteen warps for long MQA, and tiled split-four for
+long GQA4. The tiled plan requires an explicit F32 workspace and rejects a
+missing binding before submission.
 
 The token-parallel plans keep partial F32 online-softmax states in block-local
 shared memory and need no caller workspace.
 
-Paged decode and paged prefill each submit three commands: one validator
-kernel, one attention kernel, and one device-to-host status copy. Invalid
-metadata must preserve sentinels, return bindings, and leave the queue or
-fixed-address Graph reusable.
+Paged decode and direct or token-parallel paged prefill submit three commands:
+one validator, one attention kernel, and one status copy. Tiled paged prefill
+submits four commands because partial and merge are separate attention kernels.
+Invalid metadata must preserve sentinels, return bindings, and leave the queue
+or fixed-address Graph reusable.
 
 ## RoPE and paged append gate
 
@@ -280,7 +282,7 @@ checked addresses in order during every replay.
 | RMSNorm to GEMM | 2 | 6 | `(1,4096)` RMSNorm into `(1,4096,4096)` GEMM |
 | Ragged prefill | 2 | 6 | Long tiled GQA4 `(2,96,1280,16,4)` |
 | Paged decode rejection | Not applicable | 3 | Invalid page index with two reusable replays |
-| Paged prefill | 3 | 9 | Direct GQA4 `(2,6,6,16,4)` |
+| Paged prefill | 4 | 12 | Long tiled GQA4 `(2,96,96,16,4)` |
 | Fused append | 3 | 9 | Validator, six-token mapped append, and status copy under the exclusive-page contract |
 
 The paged-decode row is a sentinel-preserving rejection Graph. It does not

--- a/docs/flashinfer-parity.md
+++ b/docs/flashinfer-parity.md
@@ -59,8 +59,8 @@ The upstream links remain in the pinned
 | Single decode | Direct online softmax | MHA, MQA, and GQA | None |
 | Single decode split-K | Explicit partitions, F32 partial workspace, and eight-warp merge | MQA and GQA | None |
 | Paged batch decode | Direct MHA. Eight-warp token-parallel MQA and GQA | MHA, MQA, GQA, mixed lengths, page order, and read-only page reuse | None |
-| Ragged causal prefill | Direct, eight-warp, sixteen-warp, and tiled GQA4 split-eight | Direct short MHA, MQA, and GQA. Long MQA uses sixteen warps. Published stages also cover eight-warp and tiled GQA4 paths | Tiled long GQA4 only |
-| Paged causal prefill | Direct online softmax, sixteen-warp long MQA, and eight-warp long GQA4 | Short MHA, MQA, and GQA. The 2026-08-07 source also covers long MQA and long GQA4 | One direct GQA4 fixture |
+| Ragged causal prefill | Direct, eight-warp, sixteen-warp, and tiled GQA4 split-four | Direct short MHA, MQA, and GQA. Long MQA uses sixteen warps. Current stages also cover tiled GQA4 | Tiled long GQA4 only |
+| Paged causal prefill | Direct, eight-warp, sixteen-warp, and tiled GQA4 split-four | Short MHA, MQA, and GQA plus long MQA and tiled GQA4 | Tiled long GQA4 plus invalid-page rejection |
 | Standard RoPE | D128 NeoX split-half with explicit I32 positions | Positions through 32,767 in the recorded fixture | None |
 | Fused RoPE plus paged append | One through 64 explicit tokens with per-page reference counts | Requalification | Requalification |
 
@@ -84,17 +84,15 @@ Ragged prefill uses average KV length across the batch:
 - below 64 tokens: direct.
 - at least 64 tokens with one KV head: sixteen warps.
 - other long shapes: eight warps.
-- GQA group size four with average KV length at least 256: tiled split-eight.
+- GQA group size four with average KV length at least 256: tiled split-four.
 
 This policy does not use a length histogram or request grouping. The tiled
 Graph record does not qualify the other ragged algorithms.
 
-Paged prefill selects direct execution below an average physical page-pool
-capacity of 64 tokens per request. Long MQA selects sixteen warps. Other
-admitted long shapes select eight warps.
-
-The direct GQA4 Graph record does not qualify token-parallel plans, mutable
-metadata, or graph updates.
+Paged prefill uses explicit caller selection. The current long MQA fixture uses
+sixteen warps; the long GQA4 fixture uses tiled split-four with a caller-owned
+F32 workspace. The tiled Graph record does not qualify mutable metadata, graph
+updates, concurrent replay, or other algorithms.
 
 ## Paged KV ownership difference
 
@@ -135,6 +133,11 @@ covers 14 paged-decode, ragged-prefill, and paged-prefill shapes against the
 pinned FlashInfer release. It retains both provider orders and 2,800 raw
 latency samples. Oxide has lower combined median eager latency in eight stable
 shapes and FlashInfer in six.
+
+The [optimized paged-GQA4 record](results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json)
+supersedes only the long paged-GQA4 row. It binds the tiled split-four source,
+both provider orders, paged and ragged correctness and Graph gates, and all
+four sanitizer tools for both exact runners.
 
 The older [token-parallel correctness record](results/h20-bf16-paged-prefill-token-parallel-correctness-20260807.json)
 and [long-context performance record](results/h20-flashinfer-v0.6.16.post1-paged-prefill-long-eager-performance-20260807.json)

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -69,7 +69,7 @@ The migration moves source directly. It adds no compatibility module.
 | Single decode split-K | Explicit partitions and caller-owned F32 workspace | Current | Current R1 runner covers declared MQA and GQA shapes plus sanitizer. MHA, Graph, and current performance remain open. |
 | Paged batch decode | BF16 NHD or HND D128, page size 16. Direct MHA and eight-warp MQA or GQA. | Current | Current R1 device correctness, rejection Graph, simulated-engine boundary, and sanitizer. Current R2 matched eager performance covers six shapes; valid-output Graph remains open. |
 | Ragged causal prefill | BF16 NHD D128, bottom-right causal mask. Direct, eight-warp, sixteen-warp, and tiled GQA4. | Current | Current R1 device correctness, tiled GQA4 Graph, and sanitizer. Current R2 matched eager performance covers three shapes. |
-| Paged causal prefill | BF16 NHD D128, page size 16. Caller selects direct, eight-warp, or sixteen-warp. | Current | Current R1 device correctness, valid-output and rejection Graph cases, and sanitizer. Current R2 matched eager performance covers five shapes. |
+| Paged causal prefill | BF16 NHD D128, page size 16. Caller selects direct, eight-warp, sixteen-warp, or tiled GQA4 with F32 workspace. | Current | Current device correctness, long tiled valid-output Graph, rejection Graph, sanitizer, and matched eager performance. |
 | Standard RoPE | BF16 NHD D128, NeoX split-half, explicit I32 positions | Current source under `rope`; family migration pending | Current R1 device correctness and sanitizer; no standalone RoPE Graph. |
 | Fused RoPE plus paged append | BF16 NHD D128, page size 16, one through 64 tokens, exclusive target pages | Current | Current R1 device correctness, six-token valid-output Graph, rejection Graph, and sanitizer. |
 
@@ -80,8 +80,8 @@ Plan creation fixes one algorithm.
 | Operator | Current selection | Current Graph boundary |
 | --- | --- | --- |
 | Paged decode | MHA selects direct. MQA and GQA select eight-warp token parallelism. | Current rejection-only invalid-page Graph; no valid-output Graph |
-| Ragged prefill | Average KV length below 64 selects direct. Long MQA selects sixteen warps. Other long cases select eight warps. Long GQA4 can select tiled split-eight. | Current tiled long-GQA4 valid-output Graph |
-| Paged prefill | Caller selects direct, eight-warp, or sixteen-warp. Contract checks reject unsupported combinations. | Current direct GQA4 valid-output Graph and invalid-page rejection Graph |
+| Ragged prefill | Average KV length below 64 selects direct. Long MQA selects sixteen warps. Other long cases select eight warps. Long GQA4 can select tiled split-four. | Current tiled long-GQA4 valid-output Graph |
+| Paged prefill | Caller selects direct, eight-warp, sixteen-warp, or tiled GQA4. Tiled GQA4 requires group size four and explicit workspace. | Current tiled long-GQA4 valid-output Graph and invalid-page rejection Graph |
 
 Ragged selection uses batch-average KV length. It has no request grouping or
 persistent tuning database. Enqueue does not change the chosen algorithm.

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -76,6 +76,13 @@ valid-output paged-decode Graph, and all GPUs other than the recorded H20.
 
 ## Current-source R2 matched performance
 
+- [Optimized long paged-GQA4 eager performance against FlashInfer 0.6.17](h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json)
+  binds clean source `49290b5`, exact paged and ragged tiled-GQA4 runners, both
+  provider orders, correctness and Graph limits, and all four Compute
+  Sanitizer tools. Oxide moves from 265.66 to 57.60 microseconds on the recorded
+  shape, a 4.61x speedup. FlashInfer remains lower at 23.35 microseconds, a
+  2.47x gap.
+
 - [Matched BF16 attention eager-provider performance against FlashInfer 0.6.17](h20-flashinfer-v0.6.17-attention-eager-performance-7f3d08e-20260812.json)
   binds the unchanged product source at merged commit `7f3d08e`, the exact
   Rust runner binary, FlashInfer 0.6.17, both provider orders, and 2,800 raw
@@ -86,9 +93,9 @@ valid-output paged-decode Graph, and all GPUs other than the recorded H20.
 The record is an eager-provider microbenchmark on one recorded H20. It does
 not establish an overall library winner, isolated-kernel or Graph performance,
 native GEMV promotion, model speed, serving throughput, or behavior on another
-GPU. The largest measured gap is long-context GQA4 paged prefill, where
-FlashInfer has 11.51x lower median latency; that is now an explicit optimization
-target.
+GPU. Its largest measured gap was long-context GQA4 paged prefill at 11.51x;
+the optimized record above supersedes that row only. The remaining gap and the
+long ragged-GQA4 path stay explicit optimization targets.
 
 ## Historical R1 phase 1 precursor
 

--- a/docs/results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json
+++ b/docs/results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json
@@ -1,0 +1,503 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-12",
+  "claim_level": "matched_eager_provider_performance",
+  "status": "passed",
+  "source": {
+    "oxide_commit": "49290b587838205961b10fc22db108db46018e42",
+    "oxide_tree": "06ad36ab539dcb44cdbd2b7164ee88607a19a8ed",
+    "product_source_state": "clean committed source",
+    "cargo_lock_sha256": "46011524357470cbad8877e81b4ca8dc8731ee82e03cd553803d9cbe9601c01c",
+    "oxide_runner_sha256": {
+      "paged_prefill_h20": "9e4918da359ce8d0f44b3b836f5f742aa93a13c21ad100410790a989bccfbc17",
+      "ragged_prefill_h20": "ca32225575dd6764ed065e7fcc140939c4da53027fe7757dd7aa773b1371b2a0"
+    },
+    "oxide_runner_sanitizer": "both exact runners passed memcheck,racecheck,synccheck,initcheck with zero errors or hazards",
+    "oxide_harness_sha256": "3a3f219e0a8d030b8af014e754a39befafd8a8a85c0808659a21f38987e80218",
+    "flashinfer_harness_sha256": "0d5c6f85840a35239f7c95d1b50010ceeddede98d7bf668625f623a5da2e9e5d",
+    "summarizer_sha256": "363f9c3f4e06097b1e46f5903c55c94f2278f96b80ca3dd2daf36117b2b9629b"
+  },
+  "baseline": {
+    "name": "FlashInfer",
+    "version": "0.6.17",
+    "tag": "v0.6.17",
+    "tag_commit": "a0a6b019b9b27d49d209f85d028a1ae5a9b347d7",
+    "python_package": "flashinfer-python==0.6.17",
+    "wheel_source_provenance": "unverified; distribution version only",
+    "torch": "2.10.0a0+git89fc82e.aml"
+  },
+  "environment": {
+    "gpu": "NVIDIA H20",
+    "gpu_uuid": "GPU-3a35e57b-fc54-5620-56ee-deaf5a9c40d3",
+    "compute_capability": "9.0",
+    "memory_mib": 97871,
+    "driver": "535.161.08",
+    "cuda_toolkit": "13.1.115",
+    "torch_cuda": "13.1",
+    "application_clocks_mhz": {
+      "sm": 1980,
+      "memory": 2619
+    },
+    "power_limit_watts": 500,
+    "pstate": "P0",
+    "cpu_affinity": [
+      20
+    ],
+    "omp_num_threads": 1,
+    "mkl_num_threads": 1,
+    "flashinfer_nvshmem_library_path": "/usr/lib/x86_64-linux-gnu/nvshmem/13"
+  },
+  "measurement": {
+    "name": "eager_stream_batch_cuda_event",
+    "definition": "CUDA event interval around 100 sequential provider calls on one stream, divided by 100",
+    "warmup_launches": 200,
+    "launches_per_sample": 100,
+    "samples_per_provider_order": 50,
+    "combined_samples_per_provider": 100,
+    "provider_orders": [
+      [
+        "oxide-infer",
+        "flashinfer"
+      ],
+      [
+        "flashinfer",
+        "oxide-infer"
+      ]
+    ],
+    "excluded_from_timed_region": [
+      "planning",
+      "JIT compilation",
+      "module loading",
+      "tensor allocation",
+      "workspace initialization",
+      "fixture copies",
+      "final host synchronization"
+    ],
+    "included_caveat": "eager host-submission gaps remain inside the CUDA-event interval; not isolated-kernel, Graph, model, or serving timing"
+  },
+  "qualification": {
+    "paged_tiled_gqa4": {
+      "status": "passed",
+      "output_max_abs": 0.00048828125,
+      "lse_max_abs": 2.86102294921875e-6,
+      "commands": 4,
+      "attention_kernels": 2
+    },
+    "paged_tiled_gqa4_graph": {
+      "status": "passed",
+      "commands_per_stage": 4,
+      "captured_commands": 12,
+      "replays": 2,
+      "fixed_bindings": true,
+      "independent_status_packets": true,
+      "external_owners_dropped_before_replay": true
+    },
+    "ragged_tiled_gqa4": {
+      "status": "passed",
+      "output_max_abs": 0.00048828125,
+      "lse_max_abs": 2.86102294921875e-6,
+      "commands": 2,
+      "graph_replays": 2
+    },
+    "workspace_contract": "missing paged and ragged tiled workspaces rejected before CUDA submission",
+    "sanitizers": {
+      "tools": [
+        "memcheck",
+        "racecheck",
+        "synccheck",
+        "initcheck"
+      ],
+      "paged_prefill_h20": "passed",
+      "ragged_prefill_h20": "passed"
+    }
+  },
+  "case": {
+    "operator": "paged_prefill",
+    "case": "bf16_paged_prefill_gqa4_b2_q32_64_kv256_1024_qh16_kvh4_d128_p16",
+    "dtype": "bf16",
+    "layout": "NHD_D128_page16",
+    "shape": {
+      "batch_size": 2,
+      "head_dim": 128,
+      "kv_heads": 4,
+      "max_num_pages": 96,
+      "nnz_qo": 96,
+      "page_size": 16,
+      "query_heads": 16,
+      "referenced_pages": 80,
+      "request_kv_lens": [
+        256,
+        1024
+      ],
+      "request_qo_lens": [
+        32,
+        64
+      ]
+    },
+    "fixture_id": "xorshift64_mod2001_bf16_i32_paged_prefill_v1",
+    "fixture_digests": {
+      "key_pages": "b4ea1f13ea2fb977",
+      "last_page_len": "0868f807b519bdad",
+      "page_indices": "b7671f409220de25",
+      "page_indptr": "d916e2186be14eb7",
+      "qo_indptr": "d9b9b2186c6b5e77",
+      "query": "7f517a5efa9174a5",
+      "value_pages": "04e7d36418c04659"
+    },
+    "providers": {
+      "oxide-infer": {
+        "version": "1.0.0-alpha.1",
+        "commit": "49290b587838205961b10fc22db108db46018e42",
+        "execution": {
+          "algorithm": "tiled_gqa4_paged_mma_qk_softmax_pv",
+          "attention_kernels_per_call": 2,
+          "causal": "bottom_right",
+          "commands_per_call": 4,
+          "metadata_validation": "device_status",
+          "page_table_location": "device",
+          "status_readbacks_per_call": 1,
+          "validator_kernels_per_call": 1
+        },
+        "correctness": {
+          "reference": "independent Rust F32 paged-attention formula",
+          "output_max_abs": 0.00048828125,
+          "output_max_abs_limit": 0.015625,
+          "lse_max_abs": 2.86102294921875e-6,
+          "lse_max_abs_limit": 0.01,
+          "output_digest": "ecc019acaabc1d50",
+          "lse_digest": "e8af25bd49ef2923"
+        },
+        "combined": {
+          "samples": 100,
+          "median_us": 57.599520683288574,
+          "p10_us": 57.469279766082764,
+          "p90_us": 57.690335273742676,
+          "min_us": 57.438721656799316,
+          "max_us": 57.957119941711426
+        },
+        "per_order": {
+          "oxide_first": {
+            "samples": 50,
+            "median_us": 57.494401931762695,
+            "p10_us": 57.46092700958252,
+            "p90_us": 57.530049324035645,
+            "min_us": 57.438721656799316,
+            "max_us": 57.957119941711426
+          },
+          "oxide_second": {
+            "samples": 50,
+            "median_us": 57.66224145889282,
+            "p10_us": 57.60847806930542,
+            "p90_us": 57.70479965209961,
+            "min_us": 57.5980806350708,
+            "max_us": 57.79679775238037
+          }
+        },
+        "order_delta_percent": 0.2914977758786367,
+        "raw_samples_us": {
+          "oxide_first": [
+            57.506561279296875,
+            57.48032093048096,
+            57.48640060424805,
+            57.47136116027832,
+            57.47744083404541,
+            57.516160011291504,
+            57.50112056732178,
+            57.45344161987305,
+            57.47583866119385,
+            57.511677742004395,
+            57.48032093048096,
+            57.50080108642578,
+            57.4454402923584,
+            57.45920181274414,
+            57.49055862426758,
+            57.52416133880615,
+            57.5267219543457,
+            57.522878646850586,
+            57.493438720703125,
+            57.53119945526123,
+            57.488322257995605,
+            57.494401931762695,
+            57.462401390075684,
+            57.499518394470215,
+            57.493438720703125,
+            57.46367931365967,
+            57.481279373168945,
+            57.50976085662842,
+            57.957119941711426,
+            57.58272171020508,
+            57.51391887664795,
+            57.50432014465332,
+            57.489919662475586,
+            57.494401931762695,
+            57.522239685058594,
+            57.50783920288086,
+            57.49504089355469,
+            57.54848003387451,
+            57.46784210205078,
+            57.46943950653076,
+            57.522239685058594,
+            57.46111869812012,
+            57.482237815856934,
+            57.438721656799316,
+            57.529921531677246,
+            57.49983787536621,
+            57.45823860168457,
+            57.50080108642578,
+            57.46623992919922,
+            57.539520263671875
+          ],
+          "oxide_second": [
+            57.662081718444824,
+            57.63999938964844,
+            57.63999938964844,
+            57.60096073150635,
+            57.66335964202881,
+            57.75424003601074,
+            57.5980806350708,
+            57.60511875152588,
+            57.68415927886963,
+            57.64319896697998,
+            57.60863780975342,
+            57.67551898956299,
+            57.634878158569336,
+            57.65471935272217,
+            57.714881896972656,
+            57.62144088745117,
+            57.62752056121826,
+            57.6035213470459,
+            57.67551898956299,
+            57.67776012420654,
+            57.670722007751465,
+            57.66240119934082,
+            57.66143798828125,
+            57.66079902648926,
+            57.65088081359863,
+            57.68735885620117,
+            57.68608093261719,
+            57.612481117248535,
+            57.61951923370361,
+            57.640318870544434,
+            57.64480113983154,
+            57.67648220062256,
+            57.66848087310791,
+            57.69120216369629,
+            57.6416015625,
+            57.66848087310791,
+            57.706241607666016,
+            57.79679775238037,
+            57.70143985748291,
+            57.65888214111328,
+            57.70463943481445,
+            57.71872043609619,
+            57.64224052429199,
+            57.6796817779541,
+            57.700161933898926,
+            57.69023895263672,
+            57.641921043395996,
+            57.60704040527344,
+            57.674241065979004,
+            57.68320083618164
+          ]
+        }
+      },
+      "flashinfer": {
+        "version": "0.6.17",
+        "commit": null,
+        "execution": {
+          "algorithm": "flashinfer_batch_paged_prefill_wrapper",
+          "backend": "fa2",
+          "causal": "bottom_right",
+          "disable_split_kv": false,
+          "kernel_count": {
+            "status": "unverified"
+          },
+          "page_table_location": "device"
+        },
+        "correctness": {
+          "lse_bit_mismatches": 1530,
+          "lse_digest": "5146cf004eee6219",
+          "lse_domain": "log2",
+          "lse_max_abs": 0.0003428459167480469,
+          "lse_max_abs_limit": 0.01,
+          "lse_reference_digest": "0b9ae4c394a516ac",
+          "output_bit_mismatches": 93035,
+          "output_digest": "135e088832c1794b",
+          "output_max_abs": 0.00048828125,
+          "output_max_abs_limit": 0.015625,
+          "output_reference_digest": "6521467467bcd6e5",
+          "reference": "independent PyTorch F32 paged-attention formula"
+        },
+        "combined": {
+          "samples": 100,
+          "median_us": 23.345600366592407,
+          "p10_us": 23.298527240753174,
+          "p90_us": 23.411328554153442,
+          "min_us": 23.265280723571777,
+          "max_us": 28.504960536956787
+        },
+        "per_order": {
+          "flashinfer_first": {
+            "samples": 50,
+            "median_us": 23.318560123443604,
+            "p10_us": 23.292832851409912,
+            "p90_us": 23.395391702651978,
+            "min_us": 23.265280723571777,
+            "max_us": 28.504960536956787
+          },
+          "flashinfer_second": {
+            "samples": 50,
+            "median_us": 23.366079330444336,
+            "p10_us": 23.3371844291687,
+            "p90_us": 23.411328554153442,
+            "min_us": 23.307840824127197,
+            "max_us": 24.206080436706543
+          }
+        },
+        "order_delta_percent": 0.20357534108266517,
+        "raw_samples_us": {
+          "flashinfer_first": [
+            23.34496021270752,
+            23.318400382995605,
+            23.31712007522583,
+            23.3024001121521,
+            23.31615924835205,
+            23.29024076461792,
+            23.31199884414673,
+            23.32159996032715,
+            23.26848030090332,
+            23.319358825683594,
+            23.289599418640137,
+            23.34752082824707,
+            23.327999114990234,
+            23.322880268096924,
+            23.372159004211426,
+            23.428800106048584,
+            23.316481113433838,
+            23.32319974899292,
+            28.504960536956787,
+            23.31808090209961,
+            23.322880268096924,
+            23.45792055130005,
+            23.448638916015625,
+            23.317759037017822,
+            23.309760093688965,
+            23.314878940582275,
+            23.305599689483643,
+            23.298559188842773,
+            23.311359882354736,
+            23.293120861053467,
+            23.29472064971924,
+            23.296959400177002,
+            23.278400897979736,
+            23.31360101699829,
+            23.3187198638916,
+            23.36832046508789,
+            23.32576036453247,
+            23.32832098007202,
+            23.392319679260254,
+            23.42303991317749,
+            23.298239707946777,
+            23.329920768737793,
+            23.319039344787598,
+            23.34752082824707,
+            23.32063913345337,
+            23.32159996032715,
+            23.265280723571777,
+            23.33024024963379,
+            23.313920497894287,
+            23.297600746154785
+          ],
+          "flashinfer_second": [
+            23.41536045074463,
+            23.375680446624756,
+            23.366398811340332,
+            23.42911958694458,
+            23.421120643615723,
+            23.387839794158936,
+            23.37280035018921,
+            23.368959426879883,
+            23.3187198638916,
+            23.361599445343018,
+            23.347198963165283,
+            23.346240520477295,
+            23.357439041137695,
+            23.35968017578125,
+            23.339519500732422,
+            23.35103988647461,
+            23.353281021118164,
+            23.37376117706299,
+            23.41088056564331,
+            23.342719078063965,
+            23.370559215545654,
+            23.438398838043213,
+            23.313279151916504,
+            23.369600772857666,
+            23.341760635375977,
+            23.361599445343018,
+            23.369600772857666,
+            23.343679904937744,
+            23.350400924682617,
+            23.35455894470215,
+            23.36735963821411,
+            23.369600772857666,
+            23.383359909057617,
+            23.37183952331543,
+            23.356480598449707,
+            23.375999927520752,
+            23.321919441223145,
+            23.382079601287842,
+            23.36832046508789,
+            23.33888053894043,
+            23.38912010192871,
+            23.365440368652344,
+            23.307840824127197,
+            23.36575984954834,
+            23.352959156036377,
+            24.206080436706543,
+            23.381121158599854,
+            23.321919441223145,
+            23.36832046508789,
+            23.347198963165283
+          ]
+        }
+      }
+    },
+    "ranking": {
+      "status": "stable",
+      "lower_latency_provider": "flashinfer",
+      "lower_latency_factor": 2.4672537771062673,
+      "oxide_over_flashinfer_latency_ratio": 2.4672537771062673
+    },
+    "optimization": {
+      "previous_oxide_median_us": 265.6644821166992,
+      "current_oxide_median_us": 57.599520683288574,
+      "oxide_speedup": 4.612268973164855,
+      "previous_flashinfer_median_us": 23.08192014694214,
+      "previous_gap_ratio": 11.50963526541331,
+      "current_gap_ratio": 2.4672537771062673,
+      "gap_ratio_reduction": 4.66495800805398,
+      "previous_record": "h20-flashinfer-v0.6.17-attention-eager-performance-7f3d08e-20260812.json"
+    }
+  },
+  "raw_file_sha256": {
+    "accepted-oxide-first.jsonl": "ea2806d31d5bb483dc71022443c1ea975795b3cc72dd3a86be31c056b98796b8",
+    "accepted-flashinfer-second.jsonl": "db984072008dc2632e2af745a22d2122507de2b4381c75010926eae5eb2ab834",
+    "accepted-flashinfer-first.jsonl": "4ae12aeab6b1783c7c6facb657546afd8ce246117ba9f409a551aa87aa0a27d9",
+    "accepted-oxide-second.jsonl": "cd85bd7d68efee47af24697c29a7e05bbd4fbee75a9856f3511f791364a6b832"
+  },
+  "accepted_claims": [
+    "The admitted long paged GQA4 eager path is correct within the recorded BF16 and LSE limits.",
+    "Oxide median latency improved by the recorded factor relative to the prior source-bound baseline on this GPU.",
+    "FlashInfer retains lower median latency by the recorded factor for this exact contract.",
+    "Both provider order deltas are below five percent.",
+    "The exact Oxide runner passed memcheck, racecheck, synccheck, and initcheck."
+  ],
+  "excluded_claims": [
+    "isolated-kernel timing",
+    "CUDA Graph performance",
+    "end-to-end model or serving performance",
+    "other GPUs or shapes",
+    "FlashInfer wheel source-commit provenance"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,7 +139,9 @@ Exit gate:
 The first current-source matched baseline covers 14 BF16 attention shapes
 against FlashInfer 0.6.17. All 14 pass the provider-order stability gate;
 Oxide has lower combined median eager latency in eight and FlashInfer in six.
-The long-context GQA4 prefill gaps are the first attention optimization target.
+The first paged long-context GQA4 optimization reduced the recorded Oxide
+latency from 265.66 to 57.60 microseconds. FlashInfer remains 2.47x lower on
+that exact eager contract, and long ragged GQA4 remains a related target.
 
 The current native candidate is `OxideSm90SimtGemvM1N16K64`. It admits BF16
 `M=1`, `N % 16 = 0`, `K % 64 = 0`, no post-operation, and zero workspace on
@@ -147,7 +149,7 @@ H20 `sm_90a`.
 
 Work:
 
-- Profile and reduce the long ragged and paged GQA4 prefill gaps without
+- Continue reducing the long ragged and paged GQA4 prefill gaps without
   regressing the current short paths.
 - Keep eager-provider, Graph, engine, and serving measurements separate.
 - Preserve the five-shape Qwen2.5-1.5B census identity.

--- a/tools/flashinfer/paged_prefill_graph_bench.py
+++ b/tools/flashinfer/paged_prefill_graph_bench.py
@@ -23,7 +23,7 @@ from matched_bench import (
 
 
 MEASUREMENT = "fixed_address_cuda_graph_single_replay_event"
-CASE = "bf16_paged_prefill_gqa4_b2_q4_2_kv23_18_qh16_kvh4_d128_p16"
+CASE = "bf16_paged_prefill_gqa4_b2_q32_64_kv256_1024_qh16_kvh4_d128_p16"
 
 
 def env_positive_int(name: str, default: int) -> int:
@@ -42,17 +42,23 @@ def main() -> None:
     run_label = os.environ.get("OXIDE_BENCH_RUN_LABEL", "unlabeled")
 
     batch_size = 2
-    nnz_qo = 6
-    max_num_pages = 6
+    nnz_qo = 96
+    max_num_pages = 96
     query_heads = 16
     kv_heads = 4
     head_dim = 128
     page_size = 16
-    qo_indptr_values = (0, 4, 6)
-    page_indptr_values = (0, 2, 4)
-    page_indices_values = (5, 1, 5, 3)
-    last_page_len_values = (7, 2)
-    salt = 0x4001
+    qo_indptr_values = (0, 32, 96)
+    page_indptr_values = (0, 16, 80)
+    page_indices_values = (
+        15, 3, 27, 9, 31, 1, 35, 5, 39, 7, 43, 11, 47, 13, 51, 17,
+        19, 21, 23, 25, 29, 33, 37, 41, 45, 49, 53, 55, 57, 59, 61, 63,
+        65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95,
+        0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32,
+        34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62,
+    )
+    last_page_len_values = (16, 16)
+    salt = 0x8001
 
     query_host = deterministic_bf16(nnz_qo * query_heads * head_dim, salt)
     key_host = deterministic_bf16(
@@ -211,8 +217,8 @@ def main() -> None:
                     "nnz_qo": nnz_qo,
                     "max_num_pages": max_num_pages,
                     "referenced_pages": len(page_indices_values),
-                    "request_qo_lens": [4, 2],
-                    "request_kv_lens": [23, 18],
+                    "request_qo_lens": [32, 64],
+                    "request_kv_lens": [256, 1024],
                     "query_heads": query_heads,
                     "kv_heads": kv_heads,
                     "head_dim": head_dim,

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -1,6 +1,7 @@
 export const repositoryUrl = "https://github.com/feichai0017/oxide-infer"
 export const homeUrl = "https://feichai0017.github.io/oxide-infer/"
 export const performanceEvidenceUrl = `${repositoryUrl}/blob/main/docs/results/h20-flashinfer-v0.6.17-attention-eager-performance-7f3d08e-20260812.json`
+export const pagedPrefillOptimizationEvidenceUrl = `${repositoryUrl}/blob/main/docs/results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json`
 
 export const navigation = [
   { label: "Overview", href: "/" },
@@ -126,9 +127,9 @@ export const performanceRows = [
   {
     name: "Paged prefill · GQA4",
     shape: "Q 32+64 · KV 256+1024 · D128",
-    oxideUs: "265.66",
-    flashinferUs: "23.08",
-    result: "FlashInfer 11.51× lower",
+    oxideUs: "57.60",
+    flashinferUs: "23.35",
+    result: "FlashInfer 2.47× lower",
     winner: "flashinfer",
   },
 ]

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -5,6 +5,7 @@ import {
   evidenceHighlights,
   evidenceLevels,
   performanceEvidenceUrl,
+  pagedPrefillOptimizationEvidenceUrl,
   performanceRows,
   repositoryUrl,
 } from "../data/site";
@@ -80,9 +81,8 @@ import {
         <strong>Operator timing, not a serving claim.</strong>
         <p>
           Measured on one NVIDIA H20 using matched eager-provider CUDA-event
-          timing. Oxide has lower median latency in 8 of 14 stable shapes;
-          FlashInfer has lower latency in 6, including the largest long-context
-          GQA prefill cases.
+          timing. The 14-shape baseline is retained, while the long paged-GQA4
+          row is refreshed from the optimized source-bound record.
         </p>
         <a href={performanceEvidenceUrl} target="_blank" rel="noreferrer">
           Open the current comparison record and raw samples
@@ -108,23 +108,22 @@ import {
       </div>
 
       <div class="doc-note">
-        <strong>Paged prefill has three explicit algorithms.</strong>
+        <strong>Paged prefill has four explicit algorithms.</strong>
         <p>
-          The caller selects direct, eight-warp, or sixteen-warp execution.
-          The phase 2 record qualifies the current declared correctness,
-          rejection, fixed-address Graph, and sanitizer paths.
+          The caller selects direct, eight-warp, sixteen-warp, or tiled GQA4
+          execution. Tiled GQA4 uses a caller-owned F32 partial workspace.
         </p>
         <p>
-          The current matched record now covers direct, eight-warp, and
-          sixteen-warp eager-provider paths. Short shapes are competitive, but
-          long MQA and GQA4 prefill remain explicit optimization targets.
+          The tiled paged-GQA4 path is 4.61× faster than its prior Oxide
+          baseline for the recorded long shape. FlashInfer remains 2.47× lower
+          latency, so long MQA and GQA prefill remain optimization targets.
         </p>
         <a href={`${repositoryUrl}/blob/main/docs/results/h20-bf16-paged-prefill-token-parallel-correctness-20260807.json`}>
           Historical token-parallel correctness record
         </a>
         <span> · </span>
-        <a href={performanceEvidenceUrl} target="_blank" rel="noreferrer">
-          Current matched performance record
+        <a href={pagedPrefillOptimizationEvidenceUrl} target="_blank" rel="noreferrer">
+          Optimized paged-GQA4 performance record
         </a>
       </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,6 +7,7 @@ import {
   milestones,
   operatorGroups,
   performanceEvidenceUrl,
+  pagedPrefillOptimizationEvidenceUrl,
   performanceRows,
   performanceSummary,
   providerLanes,
@@ -180,11 +181,14 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
     </div>
     <p class="performance-note">
       NVIDIA H20 · CUDA events · 200 warmups · 100 samples/provider/shape across
-      both orders. The table deliberately includes two wins and two known
-      optimization targets.
+      both orders. The long paged-GQA4 row is refreshed from the optimized
+      source; the other rows retain the 14-shape baseline.
     </p>
     <a class="text-link" href={performanceEvidenceUrl} target="_blank" rel="noreferrer">
       Open all 14 shapes and raw samples <span>↗</span>
+    </a>
+    <a class="text-link" href={pagedPrefillOptimizationEvidenceUrl} target="_blank" rel="noreferrer">
+      Open the optimized paged-GQA4 record <span>↗</span>
     </a>
   </section>
 


### PR DESCRIPTION
## What changed

- add an explicit paged tiled-GQA4 prefill plan using the shared cp.async + WMMA partial/merge core
- reduce tiled partitions from eight to four and expose the required caller-owned F32 workspace
- extend eager and fixed-address CUDA Graph benchmarks to the long GQA4 fixture
- add missing-workspace, correctness, lifecycle, and rejection coverage
- publish a source-bound FlashInfer 0.6.17 comparison and refresh the concise README/site snapshot

## Why

Long paged GQA4 prefill still used the per-query-head SIMT token-parallel scan while the equivalent ragged contract already used the tiled MMA path. On the recorded long shape this left Oxide at 265.66 μs versus FlashInfer at 23.08 μs.

The new paged plan reuses the tiled QK/softmax/PV implementation with paged KV addressing and an explicit split-four workspace. The source-bound two-order result is 57.60 μs for Oxide versus 23.35 μs for FlashInfer: a 4.61× Oxide speedup, with a remaining 2.47× latency gap.

## Impact

- short paged-prefill paths retain their existing direct/token-parallel plans
- long GQA4 callers can explicitly select `TiledGqa4` and bind the reported F32 workspace
- tiled execution submits validator, partial, merge, and status-readback commands
- no automatic runtime provider switching is introduced

## Validation

- `make check`
- CUDA-feature Clippy with warnings denied
- `make h20-paged-prefill`
- `make h20-ragged-prefill`
- fixed-address paged and ragged Graph lifecycle gates
- exact `paged_prefill_h20` and `ragged_prefill_h20` binaries under memcheck, racecheck, synccheck, and initcheck
- 200 warmups, 100 launches/sample, 50 samples per provider order against FlashInfer 0.6.17
