### PR TITLE
Raise ragged GQA4 prefill occupancy

### DIFF
--- a/crates/oxide-infer-cuda/src/attention/prefill.rs
+++ b/crates/oxide-infer-cuda/src/attention/prefill.rs
@@ -2325,7 +2325,7 @@ mod kernels {
     }
 
     #[kernel]
-    #[launch_bounds(128)]
+    #[launch_bounds(128, 3)]
     #[allow(clippy::too_many_arguments)]
     #[launch_contract(
         domain = 1,


### PR DESCRIPTION
## What changed

Add a three-block-per-SM launch bound to the long ragged GQA4 tiled prefill entry point. The paged entry point keeps its existing compiler policy.

## Why

The tiled partial kernel, not the merge, dominates the remaining latency. Driver resource queries showed the merged ragged kernel using 178 registers per thread, 0 bytes of local memory, 16 KiB of static shared memory, and only 2 active blocks per SM. The tighter launch bound compiles the ragged entry at 168 registers per thread with no spill and 3 active blocks per SM.

Two bounded alternatives were rejected:

- 32-token KV tiles reached 3 blocks per SM but added enough load/synchronization overhead to regress long ragged GQA4 by about 8%.
- A four-block launch bound forced 248 bytes of local memory per thread and regressed the case to 50.33 us.

## Impact

On the matched BF16 ragged GQA4 shape (batch 2, Q lengths 32/64, KV lengths 256/1024, 16 query heads, 4 KV heads, head dimension 128), the clean committed source recorded:

- Oxide Infer: 47.16 us median across 100 samples
- Previous matched Oxide record: 47.71 us
- FlashInfer 0.6.17 FA2: 21.78 us
- Remaining Oxide/FlashInfer gap: 2.17x

Measurement uses 200 warmups, 100 launches per CUDA-event sample, two provider orders, CPU 20 affinity, and fixed H20 clocks. This is an eager provider-path microbenchmark, not a model or serving claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`: 59 passed
- `ragged_prefill_h20`: all numerical, workspace, metadata, and fixed-address Graph cases passed
- `paged_prefill_h20`: all numerical, workspace, metadata, valid/invalid Graph cases passed
- Exact ragged runner `3e7968a1...`: memcheck, racecheck, synccheck, initcheck passed
- Exact paged runner `09ac7832...`: memcheck, racecheck, synccheck, initcheck passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved GPU attention prefill kernel scheduling to support up to three resident blocks per streaming multiprocessor, potentially improving throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->