### PR TITLE
Add matched M=1 GEMV benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ NPM := $(RUN) npm --prefix website
 	h20-ragged-prefill h20-paged-prefill h20-rope h20-engine-interop h20 \
 	h20-runner-preflight h20-build-runner h20-sanitize-runner \
 	bench-oxide bench-paged-oxide bench-ragged-oxide \
+	bench-sm90-gemv-oxide bench-sm90-gemv-cublaslt \
 	bench-paged-prefill-oxide bench-paged-prefill-graph-oxide bench-ragged-graph-oxide \
 	bench-rope-oxide bench-rope-append-oxide \
 	bench-rope-append-tokens-oxide bench-rope-append-tokens-graph-oxide bench-split-k
@@ -58,6 +59,8 @@ help:
 		'make h20-paged-prefill  Run paged prefill H20 correctness' \
 		'make h20-rope       Run standard RoPE H20 correctness' \
 		'make bench-oxide     Run the Oxide side of the matched H20 benchmark' \
+		'make bench-sm90-gemv-oxide  Run the five-shape native M=1 GEMV benchmark' \
+		'make bench-sm90-gemv-cublaslt  Run its matched cuBLASLt baseline' \
 		'make bench-paged-oxide  Run Oxide matched paged-decode cases only' \
 		'make bench-ragged-oxide  Run Oxide matched ragged-prefill cases only' \
 		'make bench-paged-prefill-oxide  Run Oxide matched paged-prefill cases only' \
@@ -171,6 +174,12 @@ h20-sanitize-runner: h20-runner-preflight
 
 bench-oxide:
 	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
+
+bench-sm90-gemv-oxide:
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=oxide OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
+
+bench-sm90-gemv-cublaslt:
+	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=cublaslt OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'
 
 bench-paged-oxide:
 	@set -o pipefail; cd $(VALIDATION_CRATE) && OXIDE_BENCH_OPERATORS=paged_batch_decode OXIDE_SOURCE_COMMIT="$(OXIDE_SOURCE_COMMIT)" $(CARGO) +nightly-2026-04-03 oxide run oxide_matched_bench_h20 --bin oxide_matched_bench_h20 --features cuda --arch $(H20_ARCH) | sed -n '/^{/p'

--- a/crates/oxide-infer-lab/src/benchmarks/matched.rs
+++ b/crates/oxide-infer-lab/src/benchmarks/matched.rs
@@ -1,14 +1,15 @@
 use crate::benchmark::BenchmarkRecord;
 use crate::comparison::{compare_bf16, digest_bf16};
 use crate::fixture::{deterministic_bf16, page_refcounts};
+use crate::support::gemm_fixture::{CENSUS_SHAPES, exact_fixture};
 use cuda_core::{CudaContext, CudaStream, DeviceBuffer, sys};
 use half::bf16;
 use oxide_infer::{
     Bf16DenseGemmSpec, Bf16PagedBatchDecodeSpec, Bf16PagedPrefillSpec, Bf16RaggedPrefillSpec,
     Bf16RopePagedKvAppendSpec, Bf16RopePagedKvAppendTokensSpec, Bf16RopePosIdsSpec,
     Bf16SingleDecodeSpec, Bf16SingleDecodeSplitKSpec, DType, PagedKvLayout, RmsNormSpec,
-    rope_paged_kv_append_bf16_reference, rope_paged_kv_append_tokens_bf16_reference,
-    rope_pos_ids_bf16_reference,
+    bf16_dense_gemm_reference, rope_paged_kv_append_bf16_reference,
+    rope_paged_kv_append_tokens_bf16_reference, rope_pos_ids_bf16_reference,
 };
 use oxide_infer_cuda::attention::{
     Bf16PagedBatchDecodeAlgorithm, Bf16PagedBatchDecodeArgs, Bf16PagedPrefillAlgorithm,
@@ -17,7 +18,8 @@ use oxide_infer_cuda::attention::{
 };
 use oxide_infer_cuda::command::{CheckedBindings, CommandQueue, Read, ReadWrite};
 use oxide_infer_cuda::gemm::{
-    Bf16DenseGemmOperands, Bf16DenseGemmPlan, Bf16DenseGemmSelection, GemmPlanner,
+    Bf16DenseGemmAlgorithm, Bf16DenseGemmOperands, Bf16DenseGemmPlan, Bf16DenseGemmSelection,
+    GemmPlanner, GemmProviderId, GemmProviderVersion,
 };
 use oxide_infer_cuda::rms_norm::{RmsNormArgs, RmsNormBf16Plan, RmsNormProvider};
 use oxide_infer_cuda::rope::{
@@ -32,6 +34,7 @@ use std::sync::Arc;
 const PROVIDER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MEASUREMENT: &str = "eager_stream_batch_cuda_event";
 const FIXTURE_ID: &str = "xorshift64_mod2001_bf16_v1";
+const GEMV_FIXTURE_ID: &str = "dyadic_exact_qwen25_15b_gemv_census_v1";
 const PAGED_FIXTURE_ID: &str = "xorshift64_mod2001_bf16_i32_page_table_layout_v2";
 const PAGED_PREFILL_FIXTURE_ID: &str = "xorshift64_mod2001_bf16_i32_paged_prefill_v1";
 const RAGGED_FIXTURE_ID: &str = "xorshift64_mod2001_bf16_i32_ragged_indptr_v1";
@@ -325,6 +328,130 @@ fn benchmark_gemm(
         fixture_digests: json!({
             "activation": format!("{:016x}", digest_bf16(&activation_host)),
             "weight_storage": format!("{:016x}", digest_bf16(&weight_host))
+        }),
+        warmup_launches: config.warmup_launches,
+        launches_per_sample: config.launches_per_sample,
+        samples_us,
+    }
+    .write_json_line()?;
+    Ok(())
+}
+
+fn gemv_selection_from_env() -> Result<Bf16DenseGemmSelection, Box<dyn Error>> {
+    match env::var("OXIDE_BENCH_GEMV_PROVIDER") {
+        Ok(value) if value == "oxide" => Ok(Bf16DenseGemmSelection::Oxide),
+        Ok(value) if value == "cublaslt" => Ok(Bf16DenseGemmSelection::CublasLt),
+        Ok(value) => {
+            Err(format!("OXIDE_BENCH_GEMV_PROVIDER must be oxide or cublaslt, got {value}").into())
+        }
+        Err(env::VarError::NotPresent) => {
+            Err("OXIDE_BENCH_GEMV_PROVIDER is required for gemv_m1".into())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn gemv_algorithm_name(algorithm: Bf16DenseGemmAlgorithm) -> &'static str {
+    match algorithm {
+        Bf16DenseGemmAlgorithm::CublasLtHeuristic => "cublaslt_heuristic",
+        Bf16DenseGemmAlgorithm::OxideSm90SimtGemvM1N16K64 => "oxide_sm90_simt_gemv_m1_n16_k64",
+    }
+}
+
+fn gemv_provider_version(planner: &GemmPlanner, provider: GemmProviderId) -> serde_json::Value {
+    match planner.provider_version(provider) {
+        GemmProviderVersion::CublasLt(version) => json!(version),
+        GemmProviderVersion::Oxide(version) => json!(version),
+    }
+}
+
+fn benchmark_gemv_case(
+    context: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    planner: &GemmPlanner,
+    selection: Bf16DenseGemmSelection,
+    dimensions: (usize, usize, usize),
+    config: BenchConfig,
+    identity: &RunIdentity,
+) -> Result<(), Box<dyn Error>> {
+    let spec = Bf16DenseGemmSpec::new(dimensions.0, dimensions.1, dimensions.2)?;
+    let plan = planner.plan_bf16_dense(spec, selection)?;
+    let plan_info = plan.plan_info();
+    let (activation_host, weight_host) = exact_fixture(spec);
+    let mut expected = vec![bf16::ZERO; spec.output_numel()];
+    bf16_dense_gemm_reference(&activation_host, &weight_host, &mut expected, spec)?;
+
+    let activation = Arc::new(DeviceBuffer::from_host(stream, &activation_host)?);
+    let weight = Arc::new(DeviceBuffer::from_host(stream, &weight_host)?);
+    let output = DeviceBuffer::<bf16>::zeroed(stream, spec.output_numel())?;
+    let workspace = DeviceBuffer::<u8>::zeroed(stream, plan.workspace_required_bytes())?;
+    let mut queue = CommandQueue::new(stream.clone(), config.launches_per_sample, 1)?;
+    let mut bindings = queue.bindings(4)?;
+    let activation_handle = bindings.bind_read(activation)?;
+    let weight_handle = bindings.bind_read(weight)?;
+    let output_handle = bindings.bind_read_write(output)?;
+    let workspace_handle = bindings.bind_read_write(workspace)?;
+
+    let (mut bindings, samples_us) =
+        benchmark_scopes(context, stream, &mut queue, bindings, config, |scope| {
+            plan.enqueue_into(
+                scope,
+                Bf16DenseGemmOperands::new(
+                    activation_handle,
+                    weight_handle,
+                    output_handle.write(),
+                    workspace_handle.write(),
+                ),
+            )?;
+            Ok(())
+        })?;
+    let output = bindings.take_read_write(output_handle)?;
+    let actual = output.to_host_vec(stream)?;
+    let comparison = compare_bf16(&actual, &expected, "matched GEMV")?;
+    if comparison.bit_mismatches != 0 {
+        return Err(format!(
+            "matched GEMV provider {} differed from the exact CPU reference: bit_mismatches={} max_abs={}",
+            plan_info.provider().name(),
+            comparison.bit_mismatches,
+            comparison.max_abs,
+        )
+        .into());
+    }
+
+    let case = format!("bf16_gemv_m1_n{}_k{}", spec.n(), spec.k());
+    BenchmarkRecord {
+        schema_version: 1,
+        provider: "oxide-infer",
+        provider_version: PROVIDER_VERSION,
+        provider_commit: &identity.provider_commit,
+        run_label: &identity.run_label,
+        measurement: MEASUREMENT,
+        operator: "gemv",
+        case: &case,
+        dtype: "bf16",
+        layout: "A_row_major_W_row_major_transposed",
+        execution: json!({
+            "provider": plan_info.provider().name(),
+            "provider_version": gemv_provider_version(planner, plan_info.provider()),
+            "algorithm": gemv_algorithm_name(plan_info.algorithm()),
+            "commands_per_call": 1,
+            "workspace_required_bytes": plan_info.workspace_required_bytes(),
+            "estimated_waves_count": plan.estimated_waves_count(),
+            "correctness": {
+                "reference": "oxide-infer CPU F32 sequential dense GEMM",
+                "tolerance": "bit_exact_dyadic_fixture",
+                "max_abs": comparison.max_abs,
+                "bit_mismatches": comparison.bit_mismatches,
+                "output_digest": format!("{:016x}", comparison.digest),
+                "reference_digest": format!("{:016x}", digest_bf16(&expected)),
+            }
+        }),
+        kernels_per_call: 1,
+        shape: json!({"m": spec.m(), "n": spec.n(), "k": spec.k()}),
+        fixture_id: GEMV_FIXTURE_ID,
+        fixture_digests: json!({
+            "activation": format!("{:016x}", digest_bf16(&activation_host)),
+            "weight_storage": format!("{:016x}", digest_bf16(&weight_host)),
         }),
         warmup_launches: config.warmup_launches,
         launches_per_sample: config.launches_per_sample,
@@ -1468,6 +1595,20 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     }
     if requested.contains(&"gemm") {
         benchmark_gemm(&context, &stream, &gemm_planner, config, &identity)?;
+    }
+    if requested.contains(&"gemv_m1") {
+        let selection = gemv_selection_from_env()?;
+        for dimensions in CENSUS_SHAPES {
+            benchmark_gemv_case(
+                &context,
+                &stream,
+                &gemm_planner,
+                selection,
+                dimensions,
+                config,
+                &identity,
+            )?;
+        }
     }
     if requested.contains(&"single_decode") {
         for case in [

--- a/crates/oxide-infer-lab/src/gates/oxide_sm90_simt_gemv.rs
+++ b/crates/oxide-infer-lab/src/gates/oxide_sm90_simt_gemv.rs
@@ -1,8 +1,6 @@
 use crate::comparison::{Comparison, compare_bf16};
 use crate::reporting::GateCase;
-use crate::support::gemm_fixture::{
-    CENSUS_SHAPES, MINIMUM_SHAPE, exact_activation_value, exact_weight_value,
-};
+use crate::support::gemm_fixture::{CENSUS_SHAPES, MINIMUM_SHAPE, exact_fixture};
 use cuda_core::{CudaContext, CudaStream, DeviceBuffer};
 use half::bf16;
 use oxide_infer::{Bf16DenseGemmSpec, bf16_dense_gemm_reference};
@@ -23,20 +21,6 @@ const OXIDE_TENSOR_ALIGNMENT_BYTES: u64 = 4;
 const OXIDE_WORKSPACE_ALIGNMENT_BYTES: u64 = 1;
 const GENERAL_MAX_ABS_ERROR: f32 = 3.125e-2;
 const GENERAL_MAX_REL_ERROR: f32 = 1.5625e-2;
-
-fn fixture(spec: Bf16DenseGemmSpec) -> (Vec<bf16>, Vec<bf16>) {
-    // Every product is an integer multiple of 2^-14. The largest possible
-    // partial sum has fewer than 24 significant integer bits for the covered
-    // census K range, so the F32 result is independent of reduction order.
-    let activation = (0..spec.k())
-        .map(|column| bf16::from_f32(exact_activation_value(column)))
-        .collect();
-    let mut weight = Vec::with_capacity(spec.weight_numel());
-    for row in 0..spec.n() {
-        weight.extend((0..spec.k()).map(|column| bf16::from_f32(exact_weight_value(row, column))));
-    }
-    (activation, weight)
-}
 
 fn cancellation_fixture(spec: Bf16DenseGemmSpec) -> (Vec<bf16>, Vec<bf16>) {
     let activation = (0..spec.k())
@@ -458,7 +442,7 @@ fn check_census_shape(
     let spec = Bf16DenseGemmSpec::new(dimensions.0, dimensions.1, dimensions.2)?;
     let plan = planner.plan_bf16_dense(spec, Bf16DenseGemmSelection::Oxide)?;
     check_plan_metadata(planner, &plan, spec)?;
-    let (activation_host, weight_host) = fixture(spec);
+    let (activation_host, weight_host) = exact_fixture(spec);
     let expected = reference(&activation_host, &weight_host, spec)?;
     let stream = queue.stream().clone();
     let activation = Arc::new(DeviceBuffer::from_host(&stream, &activation_host)?);
@@ -780,7 +764,7 @@ fn check_command_capacity(
     plan: &Bf16DenseGemmPlan,
 ) -> Result<(), Box<dyn Error>> {
     let spec = plan.spec();
-    let (activation_host, weight_host) = fixture(spec);
+    let (activation_host, weight_host) = exact_fixture(spec);
     let expected = reference(&activation_host, &weight_host, spec)?;
     let activation = Arc::new(DeviceBuffer::from_host(stream, &activation_host)?);
     let weight = Arc::new(DeviceBuffer::from_host(stream, &weight_host)?);

--- a/crates/oxide-infer-lab/src/support/gemm_fixture.rs
+++ b/crates/oxide-infer-lab/src/support/gemm_fixture.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "cuda")]
+use half::bf16;
+#[cfg(feature = "cuda")]
+use oxide_infer::Bf16DenseGemmSpec;
+
 pub(crate) const CENSUS_SHAPES: [(usize, usize, usize); 5] = [
     (1, 1_536, 1_536),
     (1, 256, 1_536),
@@ -13,6 +18,21 @@ pub(crate) fn exact_activation_value(column: usize) -> f32 {
 
 pub(crate) fn exact_weight_value(row: usize, column: usize) -> f32 {
     (((row * 3 + column * 5) % 16) + 1) as f32 / 256.0
+}
+
+#[cfg(feature = "cuda")]
+pub(crate) fn exact_fixture(spec: Bf16DenseGemmSpec) -> (Vec<bf16>, Vec<bf16>) {
+    // Every product is an integer multiple of 2^-14. The largest possible
+    // partial sum has fewer than 24 significant integer bits for the covered
+    // census K range, so the F32 result is independent of reduction order.
+    let activation = (0..spec.k())
+        .map(|column| bf16::from_f32(exact_activation_value(column)))
+        .collect();
+    let mut weight = Vec::with_capacity(spec.weight_numel());
+    for row in 0..spec.n() {
+        weight.extend((0..spec.k()).map(|column| bf16::from_f32(exact_weight_value(row, column))));
+    }
+    (activation, weight)
 }
 
 #[cfg(test)]

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -397,6 +397,13 @@ Keep eager and Graph samples in separate summaries. Keep different algorithms
 and run labels separate. Exclude a ranking when either provider's order median
 changes by more than five percent.
 
+The native M=1 GEMV decision uses two Oxide Infer benchmark targets rather
+than a FlashInfer script: `make bench-sm90-gemv-oxide` and
+`make bench-sm90-gemv-cublaslt`. Run them as Oxide/cuBLASLt and
+cuBLASLt/Oxide process pairs with distinct run labels. Those five-shape
+operator records still need a separate matched Mistral.rs custom-GEMV baseline
+before the algorithm can pass its promotion gate.
+
 ## Evidence records
 
 Store reviewed JSON records in [the evidence directory](../results/README.md).

--- a/tools/gemm/README.md
+++ b/tools/gemm/README.md
@@ -1,7 +1,7 @@
 # GEMM shape census tools
 
-These tools validate and summarize dense-linear call counts from a pinned model
-run. They do not measure latency and do not select a GEMM provider.
+`shape_census.py` validates and summarizes dense-linear call counts from a
+pinned model run. It does not measure latency or select a GEMM provider.
 
 The producer records resolved linear shapes before it selects Mistral.rs GEMV
 or Candle matmul. One JSON Lines record represents one complete model run. The
@@ -33,3 +33,22 @@ summary makes no provider performance claim.
 
 Raw model-runner records stay in the engine repository. A later Oxide selection
 record can reference a validated raw blob by SHA-256.
+
+## Matched M=1 benchmark
+
+The H20 benchmark runner reuses the five validated Qwen2.5-1.5B census shapes
+and one bit-exact dyadic fixture. Run the native provider and cuBLASLt in
+separate processes so their order can be reversed:
+
+```bash
+OXIDE_BENCH_RUN_LABEL=oxide_first make bench-sm90-gemv-oxide
+OXIDE_BENCH_RUN_LABEL=cublaslt_second make bench-sm90-gemv-cublaslt
+
+OXIDE_BENCH_RUN_LABEL=cublaslt_first make bench-sm90-gemv-cublaslt
+OXIDE_BENCH_RUN_LABEL=oxide_second make bench-sm90-gemv-oxide
+```
+
+Each JSON Lines record includes the selected provider and algorithm, provider
+version, workspace, fixture digests, CPU-reference correctness, and raw CUDA
+event samples. These operator records do not establish an engine-performance
+claim and do not replace the Mistral.rs custom GEMV baseline.


### PR DESCRIPTION
## What changed

- add opt-in five-shape M=1 BF16 GEMV benchmark targets for the native Oxide provider and cuBLASLt
- reuse one shared dyadic fixture across correctness gates and performance records
- validate every measured output bit-exactly against the CPU F32 sequential reference
- record the selected provider, algorithm, provider version, workspace, fixture digests, correctness, and raw CUDA-event samples
- document the paired process-order protocol and the remaining Mistral.rs baseline requirement

## Why

The experimental SM90 M=1 GEMV had correctness, eager, Graph, and sanitizer coverage, but no matched operator-level evidence across the five Qwen2.5-1.5B census shapes. These targets make the promotion decision reproducible without changing the default GEMM path.

## H20 diagnostic result

The table averages the two provider-order medians from 50 samples × 100 launches after 200 warmups, pinned to CPU 20. Positive delta means the native provider is faster.

| M × N × K | census calls | Oxide (us) | cuBLASLt (us) | Oxide delta |
| --- | ---: | ---: | ---: | ---: |
| 1 × 1536 × 1536 | 392 | 4.407 | 5.520 | +20.17% |
| 1 × 256 × 1536 | 392 | 4.150 | 5.487 | +24.38% |
| 1 × 17920 × 1536 | 196 | 20.318 | 17.912 | -13.43% |
| 1 × 1536 × 8960 | 196 | 14.905 | 10.088 | -47.76% |
| 1 × 151936 × 1536 | 8 | 139.033 | 132.436 | -4.98% |

All outputs were bit-exact. Maximum process-order drift was 2.65% for Oxide and 0.28% for cuBLASLt.

This result does **not** promote the native algorithm: it misses the >=10% every-shape gate against cuBLASLt on three shapes. A census-weighted operator-only projection is 4.67% slower when every shape uses the native provider; selective routing of only the first two shapes has a theoretical 8.84% upside, which still requires the separate Mistral.rs baseline and engine-level validation.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test --workspace --all-targets` (59 passed)
- `make cuda-check`
- `make h20-oxide-gemm` (all five eager and Graph shapes passed bit-exactly)
- both provider process orders with 200 warmups, 100 launches/sample, and 50 samples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated H20 GEMV benchmark commands for Oxide and cuBLASLt providers.
  * Benchmarks now emit comparable JSON results across five standard shapes with CPU-validated outputs and provider metadata.

* **Documentation**
  * Added instructions for running and comparing native GEMV benchmarks, including execution-order guidance and baseline requirements.
  * Clarified shape-census validation scope and benchmark record limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->