### PR TITLE
Record native M=1 GEMV performance stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ prove device correctness or performance.
 | Attention | Single decode, paged decode, ragged prefill, paged prefill | Declared runner paths device-qualified in R1 |
 | KV cache | Paged append and RoPE plus paged append | Exclusive-page runner path device-qualified in R1 |
 | GEMM | Contiguous BF16 dense through cuBLASLt | R1 correctness, Graph, and sanitizer qualified |
-| GEMV | Native BF16 M=1 SM90a algorithm | Experimental; R1-qualified but not performance-promoted |
+| GEMV | Native BF16 M=1 SM90a algorithm | Experimental; performance stop recorded, cuBLASLt remains selected |
 | Normalization | RMSNorm for F32, FP16, and BF16 | Declared runner paths device-qualified in R1 |
 | Position | BF16 NeoX RoPE with explicit positions | Declared runner path device-qualified in R1 |
 | Activation | SwiGLU and fused epilogues | Planned |
@@ -132,6 +132,12 @@ kernel, model, or serving results. See the [complete record and raw
 samples](docs/results/h20-flashinfer-v0.6.17-attention-eager-performance-7f3d08e-20260812.json).
 The [optimized paged-GQA4 record](docs/results/h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json)
 contains its source-bound two-order samples and before/after comparison.
+
+The experimental native M=1 GEMV met its 10% margin against both Mistral.rs
+custom GEMV and cuBLASLt on only one of five census shapes. Its
+[stop record](docs/results/h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json) keeps
+the per-order summaries and evidence limits; no engine rollout follows for
+that frozen candidate.
 
 ## Providers
 
@@ -231,7 +237,8 @@ The roadmap advances through measured vertical slices:
 
 1. Complete the Oxide Infer namespace and framework migration.
 2. Optimize the measured long-context prefill gaps.
-3. Compare native M=1 GEMV against Mistral.rs GEMV and cuBLASLt.
+3. Keep the stopped native M=1 GEMV experimental; evaluate a new design only
+   under a new algorithm identity.
 4. Close the Mistral.rs adapter and define a narrow vLLM C ABI boundary.
 5. Expand attention, KV-cache operations, and MLA from engine traces.
 6. Add activation, sampling, quantization, grouped GEMM, and MoE paths.

--- a/docs/development/h20-validation.md
+++ b/docs/development/h20-validation.md
@@ -400,9 +400,10 @@ changes by more than five percent.
 The native M=1 GEMV decision uses two Oxide Infer benchmark targets rather
 than a FlashInfer script: `make bench-sm90-gemv-oxide` and
 `make bench-sm90-gemv-cublaslt`. Run them as Oxide/cuBLASLt and
-cuBLASLt/Oxide process pairs with distinct run labels. Those five-shape
-operator records still need a separate matched Mistral.rs custom-GEMV baseline
-before the algorithm can pass its promotion gate.
+cuBLASLt/Oxide process pairs with distinct run labels. The separate matched
+Mistral.rs custom-GEMV pair is complete. Only one of five shapes passed both
+10% margins, so the exact native candidate is performance-stopped and does not
+advance to an engine gate.
 
 ## Evidence records
 

--- a/docs/development/sm90-simt-gemv-m1.md
+++ b/docs/development/sm90-simt-gemv-m1.md
@@ -2,12 +2,11 @@
 
 The first implemented Oxide dense-GEMM algorithm is
 `OxideSm90SimtGemvM1N16K64`. It remains experimental. This document fixes its
-contract and separates the implemented correctness boundary from the work
-needed for performance qualification.
+contract and records the completed performance stop decision.
 
 The source contains an explicit Oxide provider and cuda-oxide kernel. It does
-not select Oxide by default or fall back to cuBLASLt. Current H20 correctness
-does not establish a performance or production claim.
+not select Oxide by default or fall back to cuBLASLt. `CublasLtHeuristic`
+remains the selected production plan.
 
 ## Census basis
 
@@ -150,16 +149,12 @@ The pre-rename implementation passed these gates on one NVIDIA H20:
 - Standard RoPE passed its permanent H20 runner with both `sm_90` and
   `sm_90a` after the shared device-math compiler contract changed.
 
-Those records remain historical. The renamed Oxide provider must rerun the
-same matrix on its exact source and artifact.
-
-The following gates still block promotion:
-
-- Compute Sanitizer memcheck with leak checking, racecheck, synccheck, and
-  initcheck over the permanent runner.
-- SASS and compiler reports that show no register spill or unexpected local
-  memory.
-- Matched performance against both baselines and real-engine performance.
+Those records remain historical. The current-source R1 phase 2 record reran
+the five shapes under the Oxide identity and passed correctness,
+fixed-address Graph replay, and all four Compute Sanitizer tools. The R2
+matched comparison then triggered the performance stop gate. SASS review and
+real-engine performance were not run because they cannot promote this frozen
+candidate after the operator-level stop.
 
 ### Contract evidence boundaries
 
@@ -183,12 +178,31 @@ For each shape, the candidate's combined median must be at least 10% lower
 than each baseline's combined median. Every timed interval must include all
 provider-private device work required by the declared operator boundary.
 
+The 2026-08-12 paired runs used 200 warmups, 100 launches per CUDA-event
+sample, 50 samples per order, and both process orders. Positive percentages
+below mean lower Oxide latency. All provider-order median drift was at most
+2.66%, below the 5% limit.
+
+| M | N | K | Versus Mistral.rs | Versus cuBLASLt | Both gates |
+| ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | 1,536 | 1,536 | +20.49% | +20.17% | Pass |
+| 1 | 256 | 1,536 | -30.39% | +24.38% | Fail |
+| 1 | 17,920 | 1,536 | +63.99% | -13.43% | Fail |
+| 1 | 1,536 | 8,960 | -45.11% | -47.76% | Fail |
+| 1 | 151,936 | 1,536 | +69.47% | -4.98% | Fail |
+
+Only one of five declared shapes beats both baselines by the required margin.
+The [machine-readable stop record](../results/h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json)
+retains per-order summaries, fixture digests, source identities, and artifact
+hashes. Its raw samples were reviewed but not archived, so it supports the
+conservative stop decision rather than a full performance qualification.
+
 ### Engine performance
 
-The paired Mistral engine gate holds model, requests, scheduler, and output
-checks constant. Define the noise method before execution, then require lower
-TPOT and higher throughput beyond that bound. Record TTFT, peak memory,
-provider hits, and non-Oxide dense-linear routes.
+The paired Mistral engine gate was not run. The operator gate already stopped
+this exact algorithm, so engine routing, TPOT, throughput, and peak-memory work
+would not change its promotion result. A future algorithm identity must define
+its own engine gate after it passes operator performance.
 
 ## Stop conditions
 
@@ -205,3 +219,8 @@ Any condition in this list stops promotion:
 After a hard safety failure, the artifact cannot remain selectable. A corrected
 artifact requires the full gate matrix again. After a performance failure, the
 algorithm remains experimental and `CublasLt` remains the selected plan.
+
+The 2026-08-12 comparison triggered the performance stop: four of five shapes
+missed the required margin against at least one baseline. Do not add
+shape-aware production routing for this candidate. A future M=1 design or a
+larger-M experiment needs a new algorithm identity and evidence matrix.

--- a/docs/operator-catalog.md
+++ b/docs/operator-catalog.md
@@ -64,7 +64,7 @@ The migration moves source directly. It adds no compatibility module.
 | --- | --- | --- | --- |
 | RMSNorm | Contiguous F32, FP16, and BF16. Scalar and packed algorithms. | Current source under `rms_norm`; family migration pending | Current R1 device correctness, lifecycle, and sanitizer for the permanent runner; no standalone Graph. |
 | Dense BF16 GEMM, vendor | Contiguous `D=A*W^T`, BF16 storage, F32 accumulation, explicit `CublasLtHeuristic` | Current | Current R1 device correctness, RMSNorm-to-GEMM Graph, and sanitizer. |
-| Dense BF16 GEMM, native | Same `Spec`, explicit `OxideSm90SimtGemvM1N16K64`, zero workspace | Experimental | Current R1 device correctness, five Graph shapes, and sanitizer. SASS, matched performance, and engine gates remain open. |
+| Dense BF16 GEMM, native | Same `Spec`, explicit `OxideSm90SimtGemvM1N16K64`, zero workspace | Experimental, performance-stopped | Current R1 device correctness, five Graph shapes, and sanitizer. The R2 matched comparison passed both baselines on only one of five shapes; SASS and engine gates were not run after the stop. |
 | Single decode | BF16 NHD D128, direct MHA, MQA, and GQA | Current | Current R1 device correctness, lifecycle, and sanitizer. No Graph or current performance claim. |
 | Single decode split-K | Explicit partitions and caller-owned F32 workspace | Current | Current R1 runner covers declared MQA and GQA shapes plus sanitizer. MHA, Graph, and current performance remain open. |
 | Paged batch decode | BF16 NHD or HND D128, page size 16. Direct MHA and eight-warp MQA or GQA. | Current | Current R1 device correctness, rejection Graph, simulated-engine boundary, and sanitizer. Current R2 matched eager performance covers six shapes; valid-output Graph remains open. |
@@ -94,7 +94,7 @@ path, completion, and Graph path.
 | Provider | Algorithm | State | Role |
 | --- | --- | --- | --- |
 | `CublasLt` | `CublasLtHeuristic` | Current | General vendor BF16 dense baseline |
-| `Oxide` | `OxideSm90SimtGemvM1N16K64` | Experimental | Native cuda-oxide M=1 algorithm for the currently admitted H20 `sm_90a` target |
+| `Oxide` | `OxideSm90SimtGemvM1N16K64` | Experimental, performance-stopped | Native cuda-oxide M=1 algorithm retained for evidence; not selected for production |
 
 `GemmPlanner` accepts explicit provider selection. Unsupported native shapes
 return a planning error. Enqueue does not switch to cuBLASLt.

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -76,6 +76,14 @@ valid-output paged-decode Graph, and all GPUs other than the recorded H20.
 
 ## Current-source R2 matched performance
 
+- [Native SM90a M=1 GEMV performance stop against Mistral.rs custom GEMV and cuBLASLt](h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json)
+  binds the five-shape fixture, exact Oxide and Mistral.rs source commits,
+  runner hashes, bit-exact output digests, and both process orders. Only one
+  shape met the required 10% margin against both baselines, so the frozen
+  native algorithm remains experimental and cuBLASLt remains selected. The
+  record retains per-order summaries but not raw samples; it supports the
+  conservative stop decision, not a complete performance qualification.
+
 - [Optimized long paged-GQA4 eager performance against FlashInfer 0.6.17](h20-flashinfer-v0.6.17-paged-prefill-tiled-gqa4-eager-performance-49290b5-20260812.json)
   binds clean source `49290b5`, exact paged and ragged tiled-GQA4 runners, both
   provider orders, correctness and Graph limits, and all four Compute

--- a/docs/results/h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json
+++ b/docs/results/h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json
@@ -1,0 +1,339 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-12",
+  "claim_level": "experimental_operator_performance_stop_decision",
+  "operator": "bf16_dense_gemv_m1",
+  "algorithm": "OxideSm90SimtGemvM1N16K64",
+  "status": "stopped",
+  "decision": {
+    "promotion_threshold": "candidate combined median latency must be at least 10 percent lower than both baselines on every declared shape",
+    "provider_order_drift_limit_percent": 5.0,
+    "declared_shapes": 5,
+    "shapes_passing_both_baselines": 1,
+    "shapes_failing_at_least_one_baseline": 4,
+    "outcome": "retain the native algorithm as experimental and keep CublasLtHeuristic selected",
+    "engine_gate": "not_run_after_operator_stop"
+  },
+  "evidence_boundary": {
+    "runner_output": "JSON Lines with one record and 50 CUDA-event samples per shape and provider order",
+    "raw_samples_reviewed_during_run": true,
+    "raw_samples_archived_in_this_repository": false,
+    "retained_measurements": "per-order median, minimum, and maximum summaries",
+    "supports": "a conservative no-promotion decision",
+    "does_not_support": "a complete raw-sample performance qualification or independent recomputation"
+  },
+  "source": {
+    "oxide_infer": {
+      "repository": "feichai0017/oxide-infer",
+      "benchmark_commit": "ac2bd5a70e651cae25bc2b308578959e0ffc1ea0",
+      "benchmark_pull_request": "https://github.com/feichai0017/oxide-infer/pull/112",
+      "merged_commit": "b7bbd79100c3e78e917232fbc109649ef9ed453a",
+      "cargo_lock_sha256": "46011524357470cbad8877e81b4ca8dc8731ee82e03cd553803d9cbe9601c01c"
+    },
+    "mistral_rs": {
+      "repository": "feichai0017/mistral.rs",
+      "benchmark_commit": "44349cef5a3854a0aec3e39db00484a8f3fd9811",
+      "benchmark_pull_request": "https://github.com/feichai0017/mistral.rs/pull/2",
+      "merged_commit": "7964856bfde43a354dcbaf7628ec054c5c7f9e4c",
+      "cargo_lock_sha256": "b6633fe80d1b25471900a928076312e831d8029be000a203ab2ea89ee06b0143"
+    }
+  },
+  "environment": {
+    "gpu": "NVIDIA H20",
+    "gpu_uuid": "GPU-3a35e57b-fc54-5620-56ee-deaf5a9c40d3",
+    "compute_capability": "9.0",
+    "artifact_target": "sm_90a",
+    "driver": "535.161.08",
+    "cuda_toolkit": "13.1.115",
+    "sm_clock_mhz": 1980,
+    "memory_clock_mhz": 2619,
+    "power_limit_w": 500.0,
+    "memory_total_mib": 97871,
+    "cpu_affinity": "CPU 20",
+    "omp_num_threads": 1,
+    "mkl_num_threads": 1
+  },
+  "toolchain": {
+    "oxide_rustc": "1.96.0-nightly (55e86c996 2026-04-02)",
+    "oxide_cargo": "1.96.0-nightly (888f67534 2026-03-30)",
+    "oxide_llvm": "22.1.2",
+    "mistral_rustc": "1.97.1 (8bab26f4f 2026-07-14)",
+    "mistral_cargo": "1.97.1 (c980f4866 2026-06-30)",
+    "mistral_llvm": "22.1.6",
+    "oxide_infer_version": "1.0.0-alpha.1",
+    "mistralrs_quant_version": "0.9.0"
+  },
+  "artifacts": {
+    "oxide_matched_runner_sha256": "2bc875b81b68e64a8ba0eed69684b20403ada53244a6369d82b4777b7eaca9cc",
+    "mistral_custom_gemv_runner_sha256": "a7304ea083a71fa3e0a4a76611d8e2f1da27226ec3e7c7ed1e76c67ef0268832"
+  },
+  "contract": {
+    "equation": "D[1,N] = A[1,K] * W[N,K]^T",
+    "storage": "BF16",
+    "accumulation": "F32",
+    "rounding": "one BF16 rounding at output",
+    "layout": "row-major contiguous",
+    "post_operations": "none",
+    "workspace_bytes": 0,
+    "fixture_id": "dyadic_exact_qwen25_15b_gemv_census_v1",
+    "fixture_oracle": "sequential CPU F32 accumulation",
+    "correctness": "bit_exact",
+    "timed_boundary": "launches into a preallocated output on the current CUDA stream; construction, copies, CPU reference, readback, and comparison excluded"
+  },
+  "protocol": {
+    "warmup_launches": 200,
+    "launches_per_sample": 100,
+    "samples_per_shape_per_order": 50,
+    "timing": "CUDA events",
+    "mistral_pair_orders": [
+      ["mistral_first", "oxide_second"],
+      ["oxide_first", "mistral_second"]
+    ],
+    "cublaslt_pair_orders": [
+      ["oxide_first", "cublaslt_second"],
+      ["cublaslt_first", "oxide_second"]
+    ]
+  },
+  "commands": [
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 CUDA_COMPUTE_CAP=90 MISTRALRS_SOURCE_COMMIT=44349cef5a3854a0aec3e39db00484a8f3fd9811 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_RUN_LABEL=mistral_first /workspace/mistral.rs/target/release/oxide_gemv_bench",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=oxide OXIDE_BENCH_RUN_LABEL=oxide_second target/release/oxide_matched_bench_h20",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=oxide OXIDE_BENCH_RUN_LABEL=oxide_first target/release/oxide_matched_bench_h20",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 CUDA_COMPUTE_CAP=90 MISTRALRS_SOURCE_COMMIT=44349cef5a3854a0aec3e39db00484a8f3fd9811 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_RUN_LABEL=mistral_second /workspace/mistral.rs/target/release/oxide_gemv_bench",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=oxide OXIDE_BENCH_RUN_LABEL=oxide_first target/release/oxide_matched_bench_h20",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=cublaslt OXIDE_BENCH_RUN_LABEL=cublaslt_second target/release/oxide_matched_bench_h20",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=cublaslt OXIDE_BENCH_RUN_LABEL=cublaslt_first target/release/oxide_matched_bench_h20",
+    "taskset -c 20 env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OXIDE_SOURCE_COMMIT=ac2bd5a70e651cae25bc2b308578959e0ffc1ea0 OXIDE_BENCH_WARMUP=200 OXIDE_BENCH_LAUNCHES=100 OXIDE_BENCH_SAMPLES=50 OXIDE_BENCH_OPERATORS=gemv_m1 OXIDE_BENCH_GEMV_PROVIDER=oxide OXIDE_BENCH_RUN_LABEL=oxide_second target/release/oxide_matched_bench_h20"
+  ],
+  "fixtures": [
+    {
+      "m": 1,
+      "n": 1536,
+      "k": 1536,
+      "activation_digest": "2aa894b86b52bb25",
+      "weight_digest": "93bdd123b8e62325",
+      "output_digest": "935b6e87e0589b25"
+    },
+    {
+      "m": 1,
+      "n": 256,
+      "k": 1536,
+      "activation_digest": "2aa894b86b52bb25",
+      "weight_digest": "91584bf1b7982325",
+      "output_digest": "870cf57b14ff3725"
+    },
+    {
+      "m": 1,
+      "n": 17920,
+      "k": 1536,
+      "activation_digest": "2aa894b86b52bb25",
+      "weight_digest": "6ed9ca7096662325",
+      "output_digest": "63c28563cffd9b25"
+    },
+    {
+      "m": 1,
+      "n": 1536,
+      "k": 8960,
+      "activation_digest": "455e60d8c6bfaf25",
+      "weight_digest": "c7b559d4e1ec2325",
+      "output_digest": "619b99e592890125"
+    },
+    {
+      "m": 1,
+      "n": 151936,
+      "k": 1536,
+      "activation_digest": "2aa894b86b52bb25",
+      "weight_digest": "b08e2fa552332325",
+      "output_digest": "9512b7aff50e4125"
+    }
+  ],
+  "mistral_custom_gemv_pair": {
+    "maximum_order_drift_percent": 0.4439572690044322,
+    "measurements": [
+      {
+        "shape_m_n_k": [1, 1536, 1536],
+        "oxide_order_medians_us": [4.474399983882904, 4.483519941568375],
+        "oxide_order_min_us": [4.4547200202941895, 4.461759924888611],
+        "oxide_order_max_us": [4.550719857215881, 4.639360010623932],
+        "baseline_order_medians_us": [5.627840161323547, 5.639039874076843],
+        "baseline_order_min_us": [5.609920024871826, 5.613120198249817],
+        "baseline_order_max_us": [5.712640285491943, 5.666559934616089],
+        "oxide_combined_median_us": 4.478959962725639,
+        "baseline_combined_median_us": 5.633440017700195,
+        "oxide_improvement_percent": 20.49334068255266,
+        "passes_10_percent": true
+      },
+      {
+        "shape_m_n_k": [1, 256, 1536],
+        "oxide_order_medians_us": [4.221760034561157, 4.208959937095642],
+        "oxide_order_min_us": [4.204480051994324, 4.189440011978149],
+        "oxide_order_max_us": [4.382399916648865, 4.259200096130371],
+        "baseline_order_medians_us": [3.2393600046634674, 3.2262401282787323],
+        "baseline_order_min_us": [2.765760123729706, 2.778240144252777],
+        "baseline_order_max_us": [3.609600067138672, 3.5385599732398987],
+        "oxide_combined_median_us": 4.2153599858284,
+        "baseline_combined_median_us": 3.2328000664711,
+        "oxide_improvement_percent": -30.393463844173162,
+        "passes_10_percent": false
+      },
+      {
+        "shape_m_n_k": [1, 17920, 1536],
+        "oxide_order_medians_us": [20.360159873962402, 20.376160144805908],
+        "oxide_order_min_us": [20.303359031677246, 20.322880744934082],
+        "oxide_order_max_us": [20.41152000427246, 20.42975902557373],
+        "baseline_order_medians_us": [56.55359983444214, 56.566879749298096],
+        "baseline_order_min_us": [56.52512073516846, 56.544318199157715],
+        "baseline_order_max_us": [56.640000343322754, 56.601600646972656],
+        "oxide_combined_median_us": 20.368160009384155,
+        "baseline_combined_median_us": 56.56023979187012,
+        "oxide_improvement_percent": 63.98855435490597,
+        "passes_10_percent": true
+      },
+      {
+        "shape_m_n_k": [1, 1536, 8960],
+        "oxide_order_medians_us": [14.95360016822815, 14.961439967155457],
+        "oxide_order_min_us": [14.92576003074646, 14.941120147705078],
+        "oxide_order_max_us": [14.993599653244019, 15.03648042678833],
+        "baseline_order_medians_us": [10.284479856491089, 10.3302401304245],
+        "baseline_order_min_us": [10.271680355072021, 10.315840244293213],
+        "baseline_order_max_us": [10.315840244293213, 10.357120037078857],
+        "oxide_combined_median_us": 14.957520067691803,
+        "baseline_combined_median_us": 10.307359993457794,
+        "oxide_improvement_percent": -45.11494773817468,
+        "passes_10_percent": false
+      },
+      {
+        "shape_m_n_k": [1, 151936, 1536],
+        "oxide_order_medians_us": [139.08576011657715, 139.0931224822998],
+        "oxide_order_min_us": [139.02624130249023, 139.017915725708],
+        "oxide_order_max_us": [139.25151824951172, 139.18047904968262],
+        "baseline_order_medians_us": [455.60272216796875, 455.6097602844238],
+        "baseline_order_min_us": [455.50304412841797, 455.5660629272461],
+        "baseline_order_max_us": [455.66017150878906, 455.7718276977539],
+        "oxide_combined_median_us": 139.08944129943848,
+        "baseline_combined_median_us": 455.6062412261963,
+        "oxide_improvement_percent": 69.47156805290902,
+        "passes_10_percent": true
+      }
+    ]
+  },
+  "cublaslt_pair": {
+    "provider": "CublasLt",
+    "algorithm": "CublasLtHeuristic",
+    "maximum_order_drift_percent": 2.6540791057626203,
+    "measurements": [
+      {
+        "shape_m_n_k": [1, 1536, 1536],
+        "oxide_order_medians_us": [4.3483200669288635, 4.4652800261974335],
+        "oxide_order_min_us": [4.324800074100494, 4.447680115699768],
+        "oxide_order_max_us": [4.863680005073547, 4.520959854125977],
+        "baseline_order_medians_us": [5.521439909934998, 5.518560111522675],
+        "baseline_order_min_us": [5.412799715995789, 5.392320156097412],
+        "baseline_order_max_us": [6.087679862976074, 6.1609601974487305],
+        "oxide_combined_median_us": 4.4068000465631485,
+        "baseline_combined_median_us": 5.520000010728836,
+        "oxide_improvement_percent": 20.16666597829781,
+        "passes_10_percent": true
+      },
+      {
+        "shape_m_n_k": [1, 256, 1536],
+        "oxide_order_medians_us": [4.097279906272888, 4.2022401094436646],
+        "oxide_order_min_us": [4.082880020141602, 4.1865599155426025],
+        "oxide_order_max_us": [4.472639858722687, 4.251199960708618],
+        "baseline_order_medians_us": [5.48224002122879, 5.4926398396492],
+        "baseline_order_min_us": [5.409280061721802, 5.367680191993713],
+        "baseline_order_max_us": [5.804160237312317, 5.746240019798279],
+        "oxide_combined_median_us": 4.149760007858276,
+        "baseline_combined_median_us": 5.487439930438995,
+        "oxide_improvement_percent": 24.37712192821589,
+        "passes_10_percent": true
+      },
+      {
+        "shape_m_n_k": [1, 17920, 1536],
+        "oxide_order_medians_us": [20.25328040122986, 20.381920337677002],
+        "oxide_order_min_us": [20.193920135498047, 20.3385591506958],
+        "oxide_order_max_us": [20.324161052703857, 20.432000160217285],
+        "baseline_order_medians_us": [17.90784001350403, 17.916640043258667],
+        "baseline_order_min_us": [17.846720218658447, 17.87328004837036],
+        "baseline_order_max_us": [18.024959564208984, 17.969919443130493],
+        "oxide_combined_median_us": 20.31760036945343,
+        "baseline_combined_median_us": 17.912240028381348,
+        "oxide_improvement_percent": -13.428584795987936,
+        "passes_10_percent": false
+      },
+      {
+        "shape_m_n_k": [1, 1536, 8960],
+        "oxide_order_medians_us": [14.840160012245178, 14.969760179519653],
+        "oxide_order_min_us": [14.81600046157837, 14.95136022567749],
+        "oxide_order_max_us": [14.928319454193115, 15.029759407043457],
+        "baseline_order_medians_us": [10.101919770240784, 10.073280334472656],
+        "baseline_order_min_us": [10.08512020111084, 10.050560235977173],
+        "baseline_order_max_us": [10.18880009651184, 10.164159536361694],
+        "oxide_combined_median_us": 14.904960095882416,
+        "baseline_combined_median_us": 10.08760005235672,
+        "oxide_improvement_percent": -47.75526407195573,
+        "passes_10_percent": false
+      },
+      {
+        "shape_m_n_k": [1, 151936, 1536],
+        "oxide_order_medians_us": [138.96416187286377, 139.10111904144287],
+        "oxide_order_min_us": [138.86207580566406, 139.02496337890625],
+        "oxide_order_max_us": [139.05887603759766, 139.16671752929688],
+        "baseline_order_medians_us": [132.4390411376953, 132.43263721466064],
+        "baseline_order_min_us": [132.3692798614502, 132.3526382446289],
+        "baseline_order_max_us": [132.5276756286621, 132.50847816467285],
+        "oxide_combined_median_us": 139.03264045715332,
+        "baseline_combined_median_us": 132.43583917617798,
+        "oxide_improvement_percent": -4.981129973586445,
+        "passes_10_percent": false
+      }
+    ]
+  },
+  "shape_decisions": [
+    {
+      "shape_m_n_k": [1, 1536, 1536],
+      "oxide_improvement_vs_mistral_percent": 20.49,
+      "oxide_improvement_vs_cublaslt_percent": 20.17,
+      "passes_both": true
+    },
+    {
+      "shape_m_n_k": [1, 256, 1536],
+      "oxide_improvement_vs_mistral_percent": -30.39,
+      "oxide_improvement_vs_cublaslt_percent": 24.38,
+      "passes_both": false
+    },
+    {
+      "shape_m_n_k": [1, 17920, 1536],
+      "oxide_improvement_vs_mistral_percent": 63.99,
+      "oxide_improvement_vs_cublaslt_percent": -13.43,
+      "passes_both": false
+    },
+    {
+      "shape_m_n_k": [1, 1536, 8960],
+      "oxide_improvement_vs_mistral_percent": -45.11,
+      "oxide_improvement_vs_cublaslt_percent": -47.76,
+      "passes_both": false
+    },
+    {
+      "shape_m_n_k": [1, 151936, 1536],
+      "oxide_improvement_vs_mistral_percent": 69.47,
+      "oxide_improvement_vs_cublaslt_percent": -4.98,
+      "passes_both": false
+    }
+  ],
+  "accepted_claims": [
+    "all three runners report bit-exact BF16 output with identical output digests on the five declared fixtures",
+    "both matched pairs have provider-order median drift below five percent",
+    "only one of five shapes meets the declared ten-percent threshold against both baselines",
+    "the frozen native algorithm triggers its performance stop gate and remains experimental",
+    "CublasLtHeuristic remains the selected production dense plan"
+  ],
+  "excluded_claims": [
+    "a complete raw-sample performance qualification or independently recomputable ranking",
+    "promotion or production selection of the native GEMV algorithm",
+    "SASS, register, spill, local-memory, occupancy, or hardware-counter qualification for the measured artifact",
+    "real Mistral.rs model execution, provider hits, TTFT, TPOT, throughput, peak memory, or serving performance",
+    "performance on any GPU other than the recorded NVIDIA H20",
+    "performance for shapes, dtypes, layouts, post-operations, or algorithms outside the declared contract",
+    "an overall ranking of Oxide Infer, Mistral.rs, cuBLASLt, or any inference engine"
+  ]
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -134,7 +134,7 @@ Exit gate:
 
 ## R2: Performance baseline and native M=1 GEMV decision
 
-**State:** active.
+**State:** active; the frozen native M=1 GEMV decision is complete with a stop.
 
 The first current-source matched baseline covers 14 BF16 attention shapes
 against FlashInfer 0.6.17. All 14 pass the provider-order stability gate;
@@ -145,21 +145,20 @@ that exact eager contract, and long ragged GQA4 remains a related target.
 
 The current native candidate is `OxideSm90SimtGemvM1N16K64`. It admits BF16
 `M=1`, `N % 16 = 0`, `K % 64 = 0`, no post-operation, and zero workspace on
-H20 `sm_90a`.
+the currently recorded `sm_90a` target. Its matched decision run passed the
+10% margin against both Mistral.rs custom GEMV and cuBLASLt on only one of five
+declared shapes. Four shapes triggered the stop gate, so it remains
+experimental and `CublasLtHeuristic` remains selected.
 
 Work:
 
 - Continue reducing the long ragged and paged GQA4 prefill gaps without
   regressing the current short paths.
 - Keep eager-provider, Graph, engine, and serving measurements separate.
-- Preserve the five-shape Qwen2.5-1.5B census identity.
-- Re-run correctness and fixed-address Graph gates under the Oxide provider
-  identity.
-- Run all Compute Sanitizer tools.
-- Inspect SASS, registers, local memory, memory traffic, and scheduler stalls.
-- Compare against Mistral.rs custom GEMV and cuBLASLt.
-- Run each matched pair in both provider orders.
-- Measure provider hits, TTFT, TPOT, throughput, and peak memory in the engine.
+- Retain the five-shape census and the stopped algorithm identity as immutable
+  evidence; do not add shape-aware production routing for it.
+- Give any new M=1 design or larger-M experiment a new algorithm identity and
+  workload census.
 
 Promotion gate:
 
@@ -181,8 +180,8 @@ Stop gate:
 
 Exit gate:
 
-- Promote the exact algorithm with complete evidence, or record the stop
-  result and retain the vendor route.
+- The frozen M=1 algorithm exited through its recorded stop result; retain the
+  vendor route.
 
 ## R3: Stabilize engine adapters
 

--- a/tools/gemm/README.md
+++ b/tools/gemm/README.md
@@ -51,4 +51,6 @@ OXIDE_BENCH_RUN_LABEL=oxide_second make bench-sm90-gemv-oxide
 Each JSON Lines record includes the selected provider and algorithm, provider
 version, workspace, fixture digests, CPU-reference correctness, and raw CUDA
 event samples. These operator records do not establish an engine-performance
-claim and do not replace the Mistral.rs custom GEMV baseline.
+claim. The paired Mistral.rs baseline and the resulting no-promotion decision
+are summarized in the
+[reviewed stop record](../../docs/results/h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json).


### PR DESCRIPTION
## Summary

- record the five-shape native M=1 GEMV stop decision against Mistral.rs custom GEMV and cuBLASLt
- keep the candidate experimental and retain CublasLtHeuristic as the selected production plan
- update the README, roadmap, operator catalog, validation guide, and evidence index so no engine rollout is implied

## Result

Only M=1, N=1536, K=1536 clears the required 10% margin against both baselines. The other four declared shapes fail at least one comparison. All provider-order median drift is below the 5% stability limit.

The machine-readable record retains per-order median/min/max summaries, exact source commits, lock hashes, fixture digests, and runner hashes. Raw samples were reviewed during execution but were not archived, so this is deliberately a conservative stop decision rather than a complete performance qualification.

## Validation

- jq structural and arithmetic assertions
- git diff --check
- cargo fmt --all -- --check
- CARGO_HOME=/workspace/oxide-r1-evidence/.work-477b47-phase2-20260812/cargo-home cargo test --workspace --all-targets --locked --offline (59 passed)

Related: oxide-infer #112 and feichai0017/mistral.rs #2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the performance evaluation and stop decision for native BF16 M=1 GEMV.
  * Added benchmark evidence covering five shapes and comparisons with established implementations.
  * Clarified that the native implementation remains experimental and is not selected for production routing.
  * Updated the roadmap and operator catalog to retain the current vendor implementation and guide future experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->