### PR TITLE
Clarify ragged benchmark cohorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Matched BF16 eager-provider timing against FlashInfer 0.6.17 produced stable
 rankings for all 14 baseline attention shapes on the recorded H20. Oxide Infer
 had lower combined median latency in 8 shapes; FlashInfer had lower latency in
 6. The two long GQA4 rows below are refreshed from their optimized paths; the
-other rows retain the full-matrix baseline.
+other rows retain the full-matrix baseline. Every row uses its matched
+provider-comparison cohort.
 
 | Contract | Shape | Oxide | FlashInfer | Lower latency |
 | --- | --- | ---: | ---: | --- |

--- a/docs/results/README.md
+++ b/docs/results/README.md
@@ -80,8 +80,9 @@ valid-output paged-decode Graph, and all GPUs other than the recorded H20.
   binds clean source `f9b95b0`, its source-bound parent, exact matched and gate
   runner hashes, both provider orders, 400 raw latency samples, correctness,
   fixed-address Graph replay, and all four Compute Sanitizer tools. The
-  dual-tile path reduces the parent median from 39.42 to 37.04 microseconds.
-  FlashInfer remains lower at 21.93 microseconds, a 1.68x gap.
+  parent/candidate cohort moves from 39.42 to 37.04 microseconds. In the
+  separate provider-comparison cohort, Oxide measures 36.94 microseconds and
+  FlashInfer 21.93 microseconds, a 1.68x gap.
 
 - [Native SM90a M=1 GEMV performance stop against Mistral.rs custom GEMV and cuBLASLt](h20-sm90a-m1-gemv-stop-ac2bd5a-20260812.json)
   binds the five-shape fixture, exact Oxide and Mistral.rs source commits,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -142,8 +142,9 @@ Oxide has lower combined median eager latency in eight and FlashInfer in six.
 The first paged long-context GQA4 optimization reduced the recorded Oxide
 latency from 265.66 to 57.60 microseconds. FlashInfer remains 2.47x lower on
 that exact eager contract. The current ragged optimization reduces its
-source-bound parent from 39.42 to 37.04 microseconds; FlashInfer remains 1.68x
-lower on that exact eager contract.
+source-bound parent from 39.42 to 37.04 microseconds. In the separate matched
+provider cohort, Oxide measures 36.94 microseconds and FlashInfer 21.93
+microseconds, a 1.68x gap.
 
 The current native candidate is `OxideSm90SimtGemvM1N16K64`. It admits BF16
 `M=1`, `N % 16 = 0`, `K % 64 = 0`, no post-operation, and zero workspace on

--- a/website/src/pages/evidence.astro
+++ b/website/src/pages/evidence.astro
@@ -93,9 +93,9 @@ import {
       <div class="doc-note">
         <strong>Ragged GQA4 pipelines K and V tile loads.</strong>
         <p>
-          The accepted path reduces its source-bound parent from 39.42 to
-          37.04 µs. FlashInfer 0.6.17 remains lower at 21.93 µs, a 1.68× gap
-          for this exact eager contract.
+          The source-bound cohort moves from 39.42 to 37.04 µs. In the
+          separate provider-comparison cohort, Oxide measures 36.94 µs and
+          FlashInfer 0.6.17 measures 21.93 µs, a 1.68× gap.
         </p>
         <a href={raggedPrefillOptimizationEvidenceUrl} target="_blank" rel="noreferrer">
           Optimized ragged-GQA4 performance record


### PR DESCRIPTION
## Summary

- distinguish the source-bound parent/candidate cohort from the matched Oxide/FlashInfer cohort
- keep the public comparison row on its matched provider measurements: Oxide 36.94 µs, FlashInfer 21.93 µs, 1.68× gap
- keep the optimization claim on its separate source-bound measurements: parent 39.42 µs, candidate 37.04 µs
- clarify the same distinction in the evidence index, roadmap, and website evidence note

This is the minimal follow-up to the two valid CodeRabbit comments posted after PR #114 had already merged. It does not change source code, raw evidence, or benchmark claims.

## Validation

- git diff --check
- website astro check: 0 diagnostics
- website static build: 5 pages