### PR TITLE
Reuse settled engine interop bindings

### DIFF
--- a/crates/oxide-infer-cuda/src/command/binding.rs
+++ b/crates/oxide-infer-cuda/src/command/binding.rs
@@ -84,6 +84,16 @@ impl CheckedBindings {
         summary
     }
 
+    pub(crate) fn prepare_for_reuse(&mut self) -> Result<(), CommandError> {
+        assert!(
+            self.status.is_empty(),
+            "only settled bindings may be prepared for reuse"
+        );
+        self.leases.clear();
+        self.set_id = super::submission::fresh_id()?;
+        Ok(())
+    }
+
     pub(crate) fn live_regions(&self) -> usize {
         self.leases
             .iter()

--- a/crates/oxide-infer-cuda/src/command/submission.rs
+++ b/crates/oxide-infer-cuda/src/command/submission.rs
@@ -649,7 +649,7 @@ pub(crate) struct CapturedCommandSet {
     pub(crate) submitted: usize,
 }
 
-fn fresh_id() -> Result<u64, CommandError> {
+pub(super) fn fresh_id() -> Result<u64, CommandError> {
     NEXT_ID
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
         .map_err(|_| CommandError::IdentifierSpaceExhausted)

--- a/crates/oxide-infer-cuda/src/interop.rs
+++ b/crates/oxide-infer-cuda/src/interop.rs
@@ -370,6 +370,7 @@ struct EngineInteropShared {
     external: Arc<ExternalCudaStream>,
     oxide_stream: Arc<CudaStream>,
     free_slots: Mutex<Vec<EngineHandoffSlot>>,
+    free_bindings: Mutex<Vec<CheckedBindings>>,
     poisoned: AtomicBool,
 }
 
@@ -506,14 +507,24 @@ impl EngineInteropQueue {
                 external: Arc::new(external),
                 oxide_stream,
                 free_slots: Mutex::new(free_slots),
+                free_bindings: Mutex::new(Vec::with_capacity(max_in_flight)),
                 poisoned: AtomicBool::new(false),
             }),
             queue,
         })
     }
 
-    /// Creates checked binding storage for this exact Oxide execution queue.
+    /// Returns checked binding storage for this exact Oxide execution queue.
+    /// Successfully settled storage is reused when its capacity matches.
     pub fn bindings(&self, capacity: usize) -> Result<CheckedBindings, CommandError> {
+        let mut free_bindings = lock_or_recover(&self.shared.free_bindings);
+        if let Some(index) = free_bindings
+            .iter()
+            .position(|bindings| bindings.capacity() == capacity)
+        {
+            return Ok(free_bindings.swap_remove(index));
+        }
+        drop(free_bindings);
         self.queue.bindings(capacity)
     }
 
@@ -882,16 +893,19 @@ impl EngineCommandCompletion {
             .command
             .take()
             .expect("live engine completion has a command");
-        let result = sanitize_completion(command.wait());
-        self.return_slot();
-        self.complete = true;
-        match result {
-            Ok(()) => Ok(self.trace.clone()),
+        let result = match sanitize_completion(command.wait()) {
+            Ok(bindings) => {
+                recycle_bindings(&self.shared, bindings);
+                Ok(self.trace.clone())
+            }
             Err(cause) => Err(EngineCommandCompletionError {
                 cause: Box::new(cause),
                 trace: Box::new(self.trace.clone()),
             }),
-        }
+        };
+        self.return_slot();
+        self.complete = true;
+        result
     }
 
     fn return_slot(&mut self) {
@@ -943,12 +957,9 @@ impl Drop for EngineCommandCompletion {
 
 fn sanitize_completion(
     result: Result<CheckedBindings, CommandCompletionError>,
-) -> Result<(), EngineCommandFailure> {
+) -> Result<CheckedBindings, EngineCommandFailure> {
     match result {
-        Ok(bindings) => {
-            drop(bindings);
-            Ok(())
-        }
+        Ok(bindings) => Ok(bindings),
         Err(CommandCompletionError::Execution(error)) => {
             Err(EngineCommandFailure::Execution(error))
         }
@@ -961,6 +972,14 @@ fn sanitize_completion(
             Err(EngineCommandFailure::StatusProtocol(error))
         }
     }
+}
+
+fn recycle_bindings(shared: &EngineInteropShared, mut bindings: CheckedBindings) {
+    if bindings.prepare_for_reuse().is_err() {
+        shared.poisoned.store(true, Ordering::Release);
+        return;
+    }
+    lock_or_recover(&shared.free_bindings).push(bindings);
 }
 
 fn settle_started_failure<A: StreamOrderedEngineAuthority>(


### PR DESCRIPTION
## What changed

- pool successfully settled `CheckedBindings` inside `EngineInteropQueue`
- reuse only entries with the requested capacity
- clear retained leases and refresh the binding-set ID before reuse so stale handles remain invalid
- keep rejection and failure paths unchanged

## Why

The Mistral.rs adapter previously created a new binding arena and pinned host status packet for every decode layer. That repeated allocation dominated the otherwise fast Oxide paged-decode path.

## Impact

In a local H20 Mistral.rs steady-state benchmark with 3 interleaved provider blocks, 20 measured requests per block, and 64 generated tokens:

- Qwen2.5-1.5B: Oxide decode increased from 155.51 to 193.20 tok/s and reached 93.9% of the standard paged-attention baseline; P50 TPOT fell from 6.430 to 5.176 ms
- Qwen2.5-7B: Oxide decode increased from 90.46 to 101.75 tok/s and reached 96.1% of baseline; P50 TPOT fell from 11.054 to 9.827 ms
- 211,680 measured layer-decode submissions completed with zero failures and zero adapter D2D copies; generated responses matched the baseline

The change does not alter kernels, provider selection, metadata validation, stream handoff, or device-to-host status checks.

## Validation

- `CARGO_HOME=/workspace/.cargo-online cargo +nightly-2026-04-03 clippy -p oxide-infer-cuda --all-targets --features cuda -- -D warnings`
- `OXIDE_CARGO_HOME=/workspace/.cargo-online make h20-engine-interop`
- local Mistral.rs H20 steady-state suites for Qwen2.5-1.5B and Qwen2.5-7B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved GPU command processing by reusing completed binding resources when capacity matches.
  * Reduced unnecessary resource allocation during queue operations.

* **Reliability**
  * Added safeguards to invalidate queues when resources cannot be safely prepared for reuse.
  * Preserved successfully completed bindings for future operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->