### PR TITLE
bench(cuda): diagnose batch-16 decode overhead

### DIFF
--- a/crates/oxide-infer-cuda/src/attention/decode.rs
+++ b/crates/oxide-infer-cuda/src/attention/decode.rs
@@ -1365,13 +1365,21 @@ impl DecodeProvider {
         &self,
         spec: Bf16PagedBatchDecodeSpec,
     ) -> Result<Bf16PagedBatchDecodePlan, PagedBatchDecodePlanError> {
+        self.plan_bf16_paged_batch_with_algorithm(spec, paged_batch_decode_algorithm(spec))
+    }
+
+    /// Creates one immutable BF16 paged batch-decode launch plan with an explicit algorithm.
+    pub fn plan_bf16_paged_batch_with_algorithm(
+        &self,
+        spec: Bf16PagedBatchDecodeSpec,
+        algorithm: Bf16PagedBatchDecodeAlgorithm,
+    ) -> Result<Bf16PagedBatchDecodePlan, PagedBatchDecodePlanError> {
         let states = spec
             .batch_size()
             .checked_mul(spec.num_query_heads())
             .ok_or(PagedBatchDecodePlanError::StateCountOutOfRange(usize::MAX))?;
         let states = u32::try_from(states)
             .map_err(|_| PagedBatchDecodePlanError::StateCountOutOfRange(states))?;
-        let algorithm = paged_batch_decode_algorithm(spec);
         let metadata_launch = self
             .module
             .prepare_validate_paged_batch_decode_metadata(LaunchConfig1D::new(1, 1, 0))?;

--- a/crates/oxide-infer-cuda/src/attention/decode.rs
+++ b/crates/oxide-infer-cuda/src/attention/decode.rs
@@ -1489,6 +1489,27 @@ pub enum Bf16PagedBatchDecodeAlgorithm {
     TokenParallel8,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct PagedBatchDecodeHostProfile {
+    preflight_host_nanoseconds: u64,
+    metadata_host_nanoseconds: u64,
+    attention_host_nanoseconds: u64,
+}
+
+impl PagedBatchDecodeHostProfile {
+    pub(crate) const fn preflight_host_nanoseconds(self) -> u64 {
+        self.preflight_host_nanoseconds
+    }
+
+    pub(crate) const fn metadata_host_nanoseconds(self) -> u64 {
+        self.metadata_host_nanoseconds
+    }
+
+    pub(crate) const fn attention_host_nanoseconds(self) -> u64 {
+        self.attention_host_nanoseconds
+    }
+}
+
 const fn paged_batch_decode_algorithm(
     spec: Bf16PagedBatchDecodeSpec,
 ) -> Bf16PagedBatchDecodeAlgorithm {
@@ -1543,6 +1564,26 @@ impl Bf16PagedBatchDecodePlan {
         scope: &mut CommandScope<'_>,
         args: Bf16PagedBatchDecodeArgs,
     ) -> Result<(), PagedBatchDecodeEnqueueError> {
+        self.enqueue_into_impl(scope, args, None)
+    }
+
+    pub(crate) fn enqueue_into_profiled(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: Bf16PagedBatchDecodeArgs,
+    ) -> Result<PagedBatchDecodeHostProfile, PagedBatchDecodeEnqueueError> {
+        let mut profile = PagedBatchDecodeHostProfile::default();
+        self.enqueue_into_impl(scope, args, Some(&mut profile))?;
+        Ok(profile)
+    }
+
+    fn enqueue_into_impl(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: Bf16PagedBatchDecodeArgs,
+        mut profile: Option<&mut PagedBatchDecodeHostProfile>,
+    ) -> Result<(), PagedBatchDecodeEnqueueError> {
+        let preflight_started = profile.is_some().then(std::time::Instant::now);
         let page_indices_len = {
             let resolved = scope.resolve_rrrrrrrww(
                 args.query,
@@ -1602,6 +1643,10 @@ impl Bf16PagedBatchDecodePlan {
                 PAGED_BATCH_DECODE_PAGE_SIZE,
             ),
         )?;
+        if let Some(profile) = profile.as_deref_mut() {
+            profile.preflight_host_nanoseconds = elapsed_nanoseconds(preflight_started);
+        }
+        let metadata_started = profile.is_some().then(std::time::Instant::now);
         let permit = scope.prepare_command()?;
         let (function, validation_result) = {
             let resolved = scope.resolve_rrrw(
@@ -1623,7 +1668,11 @@ impl Bf16PagedBatchDecodePlan {
             (self.metadata_launch.function().clone(), result)
         };
         record_paged_metadata_launch(scope, status, permit, function, validation_result)?;
+        if let Some(profile) = profile.as_deref_mut() {
+            profile.metadata_host_nanoseconds = elapsed_nanoseconds(metadata_started);
+        }
 
+        let attention_started = profile.is_some().then(std::time::Instant::now);
         let permit = scope.prepare_command()?;
         let (function, launch_result) = {
             let resolved = scope.resolve_rrrrrrrww(
@@ -1735,8 +1784,18 @@ impl Bf16PagedBatchDecodePlan {
                 }
             }
         };
-        record_paged_launch(scope, permit, function, launch_result)
+        let result = record_paged_launch(scope, permit, function, launch_result);
+        if let Some(profile) = profile {
+            profile.attention_host_nanoseconds = elapsed_nanoseconds(attention_started);
+        }
+        result
     }
+}
+
+fn elapsed_nanoseconds(started: Option<std::time::Instant>) -> u64 {
+    started
+        .map(|started| u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or_default()
 }
 
 /// Immutable partial-state and merge launches for split-K single decode.

--- a/crates/oxide-infer-cuda/src/attention/mod.rs
+++ b/crates/oxide-infer-cuda/src/attention/mod.rs
@@ -7,6 +7,8 @@
 mod decode;
 mod prefill;
 
+pub(crate) use decode::PagedBatchDecodeHostProfile;
+
 pub use decode::{
     Bf16PagedBatchDecodeAlgorithm, Bf16PagedBatchDecodeArgs, Bf16PagedBatchDecodePlan,
     Bf16SingleDecodeArgs, Bf16SingleDecodePlan, Bf16SingleDecodeSplitKArgs,

--- a/crates/oxide-infer-cuda/src/interop.rs
+++ b/crates/oxide-infer-cuda/src/interop.rs
@@ -24,6 +24,7 @@ use std::fmt::{self, Display, Formatter};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
 use thiserror::Error;
 
 const SPECIAL_STREAM_MAX_ADDRESS: usize = 2;
@@ -188,6 +189,43 @@ pub enum EngineBufferAddresses {
     PagedBatchDecode([CUdeviceptr; PAGED_BATCH_DECODE_BINDING_COUNT]),
 }
 
+/// Host-side enqueue timings collected by an engine interop queue.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EngineInteropHostProfile {
+    total_host_nanoseconds: u64,
+    setup_host_nanoseconds: u64,
+    pre_handoff_host_nanoseconds: u64,
+    provider_host_nanoseconds: u64,
+    status_readback_host_nanoseconds: u64,
+    post_handoff_host_nanoseconds: u64,
+}
+
+impl EngineInteropHostProfile {
+    pub const fn total_host_nanoseconds(self) -> u64 {
+        self.total_host_nanoseconds
+    }
+
+    pub const fn setup_host_nanoseconds(self) -> u64 {
+        self.setup_host_nanoseconds
+    }
+
+    pub const fn pre_handoff_host_nanoseconds(self) -> u64 {
+        self.pre_handoff_host_nanoseconds
+    }
+
+    pub const fn provider_host_nanoseconds(self) -> u64 {
+        self.provider_host_nanoseconds
+    }
+
+    pub const fn status_readback_host_nanoseconds(self) -> u64 {
+        self.status_readback_host_nanoseconds
+    }
+
+    pub const fn post_handoff_host_nanoseconds(self) -> u64 {
+        self.post_handoff_host_nanoseconds
+    }
+}
+
 impl EngineBufferAddresses {
     pub const fn as_slice(&self) -> &[CUdeviceptr] {
         match self {
@@ -208,6 +246,7 @@ pub struct EngineExecutionTrace {
     paged_kv_layout: Option<PagedKvLayout>,
     handoff: EngineStreamHandoff,
     adapter_device_to_device_copies: usize,
+    host_profile: Option<EngineInteropHostProfile>,
 }
 
 impl EngineExecutionTrace {
@@ -246,6 +285,10 @@ impl EngineExecutionTrace {
 
     pub const fn adapter_device_to_device_copies(&self) -> usize {
         self.adapter_device_to_device_copies
+    }
+
+    pub const fn host_profile(&self) -> Option<EngineInteropHostProfile> {
+        self.host_profile
     }
 
     /// Returns whether all operator buffers were external and this adapter
@@ -361,6 +404,7 @@ impl<A> std::error::Error for EngineExternalBindingsError<A> {
 pub struct EngineInteropQueue {
     shared: Arc<EngineInteropShared>,
     queue: CommandQueue,
+    host_profiling_enabled: bool,
 }
 
 const SINGLE_DECODE_BINDING_COUNT: usize = 5;
@@ -468,6 +512,7 @@ impl EngineCommand<'_> {
             paged_kv_layout,
             handoff: EngineStreamHandoff::ExternalEventBridge,
             adapter_device_to_device_copies: 0,
+            host_profile: None,
         })
     }
 
@@ -511,7 +556,13 @@ impl EngineInteropQueue {
                 poisoned: AtomicBool::new(false),
             }),
             queue,
+            host_profiling_enabled: false,
         })
+    }
+
+    /// Enables host-side timing evidence for subsequent enqueue traces.
+    pub fn set_host_profiling_enabled(&mut self, enabled: bool) {
+        self.host_profiling_enabled = enabled;
     }
 
     /// Returns checked binding storage for this exact Oxide execution queue.
@@ -545,6 +596,8 @@ impl EngineInteropQueue {
         command: EngineCommand<'_>,
         external_bindings: EngineExternalBindings<A>,
     ) -> Result<EngineSubmission<A>, EngineEnqueueError<A>> {
+        let total_started = self.host_profiling_enabled.then(Instant::now);
+        let setup_started = self.host_profiling_enabled.then(Instant::now);
         let EngineExternalBindings {
             bindings,
             authority,
@@ -574,7 +627,7 @@ impl EngineInteropQueue {
                 bindings,
             ));
         }
-        let Some(trace) = command.trace(memory, &bindings) else {
+        let Some(mut trace) = command.trace(memory, &bindings) else {
             let cause = EngineEnqueueCause::BindingShape {
                 operator: command.operator(),
                 expected: command.binding_count(),
@@ -614,6 +667,8 @@ impl EngineInteropQueue {
         };
         let oxide_stream = Arc::clone(&self.shared.oxide_stream);
         let external_raw = self.shared.external.raw;
+        let setup_host_nanoseconds = elapsed_nanoseconds(setup_started);
+        let pre_handoff_started = self.host_profiling_enabled.then(Instant::now);
 
         // SAFETY: ExternalCudaStream validated and retains `external_raw`.
         // `pre_event` belongs to the same primary context.
@@ -637,6 +692,8 @@ impl EngineInteropQueue {
                 authority,
             ));
         }
+        let pre_handoff_host_nanoseconds = elapsed_nanoseconds(pre_handoff_started);
+        let provider_started = self.host_profiling_enabled.then(Instant::now);
         if let Err(error) = command.enqueue_into(&mut scope) {
             return Err(settle_started_failure(
                 Arc::clone(&self.shared),
@@ -646,8 +703,12 @@ impl EngineInteropQueue {
                 authority,
             ));
         }
+        let provider_host_nanoseconds = elapsed_nanoseconds(provider_started);
 
+        let status_readback_started = self.host_profiling_enabled.then(Instant::now);
         scope.finalize_device_status();
+        let status_readback_host_nanoseconds = elapsed_nanoseconds(status_readback_started);
+        let post_handoff_started = self.host_profiling_enabled.then(Instant::now);
         if let Err(error) = slot.post_event.record(&oxide_stream) {
             self.shared.poisoned.store(true, Ordering::Release);
             return Err(settle_started_failure(
@@ -670,6 +731,17 @@ impl EngineInteropQueue {
                 EngineEnqueuePrimaryFailure::Bridge(error),
                 authority,
             ));
+        }
+        let post_handoff_host_nanoseconds = elapsed_nanoseconds(post_handoff_started);
+        if let Some(started) = total_started {
+            trace.host_profile = Some(EngineInteropHostProfile {
+                total_host_nanoseconds: duration_nanoseconds(started.elapsed()),
+                setup_host_nanoseconds,
+                pre_handoff_host_nanoseconds,
+                provider_host_nanoseconds,
+                status_readback_host_nanoseconds,
+                post_handoff_host_nanoseconds,
+            });
         }
 
         let completion = scope.finish();
@@ -1046,6 +1118,16 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+fn elapsed_nanoseconds(started: Option<Instant>) -> u64 {
+    started
+        .map(|started| duration_nanoseconds(started.elapsed()))
+        .unwrap_or_default()
+}
+
+fn duration_nanoseconds(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
+
 fn synchronize_external_stream_or_abort(stream: &ExternalCudaStream) -> Option<DriverError> {
     let stream_result = stream.context.bind_to_thread().and_then(|()| {
         // SAFETY: ExternalCudaStream retains this validated raw handle.
@@ -1146,6 +1228,7 @@ mod tests {
             paged_kv_layout: None,
             handoff: EngineStreamHandoff::ExternalEventBridge,
             adapter_device_to_device_copies: 0,
+            host_profile: None,
         };
         assert!(trace.is_adapter_zero_copy());
         assert_eq!(trace.provider(), "oxide-infer-cuda");

--- a/crates/oxide-infer-cuda/src/interop.rs
+++ b/crates/oxide-infer-cuda/src/interop.rs
@@ -9,7 +9,7 @@
 use crate::attention::{
     Bf16PagedBatchDecodeAlgorithm, Bf16PagedBatchDecodeArgs, Bf16PagedBatchDecodePlan,
     Bf16SingleDecodeArgs, Bf16SingleDecodePlan, PagedBatchDecodeEnqueueError,
-    SingleDecodeEnqueueError,
+    PagedBatchDecodeHostProfile, SingleDecodeEnqueueError,
 };
 use crate::command::{
     BindingMemorySummary, CheckedBindings, CommandCompletion, CommandCompletionError, CommandError,
@@ -196,6 +196,9 @@ pub struct EngineInteropHostProfile {
     setup_host_nanoseconds: u64,
     pre_handoff_host_nanoseconds: u64,
     provider_host_nanoseconds: u64,
+    provider_preflight_host_nanoseconds: u64,
+    provider_metadata_host_nanoseconds: u64,
+    provider_attention_host_nanoseconds: u64,
     status_readback_host_nanoseconds: u64,
     post_handoff_host_nanoseconds: u64,
 }
@@ -215,6 +218,18 @@ impl EngineInteropHostProfile {
 
     pub const fn provider_host_nanoseconds(self) -> u64 {
         self.provider_host_nanoseconds
+    }
+
+    pub const fn provider_preflight_host_nanoseconds(self) -> u64 {
+        self.provider_preflight_host_nanoseconds
+    }
+
+    pub const fn provider_metadata_host_nanoseconds(self) -> u64 {
+        self.provider_metadata_host_nanoseconds
+    }
+
+    pub const fn provider_attention_host_nanoseconds(self) -> u64 {
+        self.provider_attention_host_nanoseconds
     }
 
     pub const fn status_readback_host_nanoseconds(self) -> u64 {
@@ -519,13 +534,20 @@ impl EngineCommand<'_> {
     fn enqueue_into(
         self,
         scope: &mut crate::command::CommandScope<'_>,
-    ) -> Result<(), EngineProviderError> {
+        host_profiling_enabled: bool,
+    ) -> Result<Option<PagedBatchDecodeHostProfile>, EngineProviderError> {
         match self {
             Self::Bf16SingleDecode { plan, args } => {
-                plan.enqueue_into(scope, args).map_err(Into::into)
+                plan.enqueue_into(scope, args)?;
+                Ok(None)
             }
             Self::Bf16PagedBatchDecode { plan, args } => {
-                plan.enqueue_into(scope, args).map_err(Into::into)
+                if host_profiling_enabled {
+                    Ok(Some(plan.enqueue_into_profiled(scope, args)?))
+                } else {
+                    plan.enqueue_into(scope, args)?;
+                    Ok(None)
+                }
             }
         }
     }
@@ -694,15 +716,18 @@ impl EngineInteropQueue {
         }
         let pre_handoff_host_nanoseconds = elapsed_nanoseconds(pre_handoff_started);
         let provider_started = self.host_profiling_enabled.then(Instant::now);
-        if let Err(error) = command.enqueue_into(&mut scope) {
-            return Err(settle_started_failure(
-                Arc::clone(&self.shared),
-                slot,
-                scope.finish(),
-                EngineEnqueuePrimaryFailure::Provider(error),
-                authority,
-            ));
-        }
+        let provider_profile = match command.enqueue_into(&mut scope, self.host_profiling_enabled) {
+            Ok(profile) => profile.unwrap_or_default(),
+            Err(error) => {
+                return Err(settle_started_failure(
+                    Arc::clone(&self.shared),
+                    slot,
+                    scope.finish(),
+                    EngineEnqueuePrimaryFailure::Provider(error),
+                    authority,
+                ));
+            }
+        };
         let provider_host_nanoseconds = elapsed_nanoseconds(provider_started);
 
         let status_readback_started = self.host_profiling_enabled.then(Instant::now);
@@ -739,6 +764,9 @@ impl EngineInteropQueue {
                 setup_host_nanoseconds,
                 pre_handoff_host_nanoseconds,
                 provider_host_nanoseconds,
+                provider_preflight_host_nanoseconds: provider_profile.preflight_host_nanoseconds(),
+                provider_metadata_host_nanoseconds: provider_profile.metadata_host_nanoseconds(),
+                provider_attention_host_nanoseconds: provider_profile.attention_host_nanoseconds(),
                 status_readback_host_nanoseconds,
                 post_handoff_host_nanoseconds,
             });

--- a/crates/oxide-infer-lab/src/benchmarks/matched.rs
+++ b/crates/oxide-infer-lab/src/benchmarks/matched.rs
@@ -44,6 +44,22 @@ const ROPE_APPEND_TOKENS_FIXTURE_ID: &str =
     "xorshift64_mod2001_bf16_i32_rope_paged_append_tokens_v2";
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+const PAGED_DECODE_B8_L96_INDPTR: [i32; 9] = [0, 6, 12, 18, 24, 30, 36, 42, 48];
+const PAGED_DECODE_B8_L96_INDICES: [i32; 48] = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+];
+const PAGED_DECODE_B8_L96_LAST_PAGE_LEN: [i32; 8] = [16; 8];
+const PAGED_DECODE_B16_L96_INDPTR: [i32; 17] = [
+    0, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96,
+];
+const PAGED_DECODE_B16_L96_INDICES: [i32; 96] = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+    74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+];
+const PAGED_DECODE_B16_L96_LAST_PAGE_LEN: [i32; 16] = [16; 16];
 
 struct RunIdentity {
     provider_commit: String,
@@ -85,6 +101,7 @@ struct DecodeCase {
 #[derive(Clone, Copy)]
 struct PagedDecodeCase {
     name: &'static str,
+    algorithm: Bf16PagedBatchDecodeAlgorithm,
     layout: PagedKvLayout,
     batch_size: usize,
     max_num_pages: usize,
@@ -597,7 +614,7 @@ fn benchmark_paged_decode_case(
     )?;
     let table =
         spec.validate_page_table(case.page_indptr, case.page_indices, case.last_page_len)?;
-    let plan = provider.plan_bf16_paged_batch(spec)?;
+    let plan = provider.plan_bf16_paged_batch_with_algorithm(spec, case.algorithm)?;
     let algorithm = match plan.algorithm() {
         Bf16PagedBatchDecodeAlgorithm::Direct => "direct_one_warp_per_request_head",
         Bf16PagedBatchDecodeAlgorithm::TokenParallel8 => "token_parallel_8warp_block_local_merge",
@@ -1648,6 +1665,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         for case in [
             PagedDecodeCase {
                 name: "bf16_paged_mha_b1_l1_qh8_kvh8_d128_p16_nhd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
                 layout: PagedKvLayout::Nhd,
                 batch_size: 1,
                 max_num_pages: 2,
@@ -1660,6 +1678,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedDecodeCase {
                 name: "bf16_paged_mqa_b3_l16_23_48_qh8_kvh1_d128_p16_nhd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
                 layout: PagedKvLayout::Nhd,
                 batch_size: 3,
                 max_num_pages: 7,
@@ -1672,6 +1691,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedDecodeCase {
                 name: "bf16_paged_gqa4_b4_l3_32_17_41_qh16_kvh4_d128_p16_nhd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
                 layout: PagedKvLayout::Nhd,
                 batch_size: 4,
                 max_num_pages: 8,
@@ -1684,6 +1704,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedDecodeCase {
                 name: "bf16_paged_mha_b1_l1_qh8_kvh8_d128_p16_hnd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
                 layout: PagedKvLayout::Hnd,
                 batch_size: 1,
                 max_num_pages: 2,
@@ -1696,6 +1717,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedDecodeCase {
                 name: "bf16_paged_mqa_b3_l16_23_48_qh8_kvh1_d128_p16_hnd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
                 layout: PagedKvLayout::Hnd,
                 batch_size: 3,
                 max_num_pages: 7,
@@ -1708,6 +1730,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             },
             PagedDecodeCase {
                 name: "bf16_paged_gqa4_b4_l3_32_17_41_qh16_kvh4_d128_p16_hnd",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
                 layout: PagedKvLayout::Hnd,
                 batch_size: 4,
                 max_num_pages: 8,
@@ -1717,6 +1740,110 @@ pub fn run() -> Result<(), Box<dyn Error>> {
                 page_indices: &[7, 2, 6, 5, 1, 7, 0, 4],
                 last_page_len: &[3, 16, 1, 9],
                 salt: 0x4001,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen15b_b8_l96_qh12_kvh2_d128_p16_hnd_direct",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 8,
+                max_num_pages: 48,
+                query_heads: 12,
+                kv_heads: 2,
+                page_indptr: &PAGED_DECODE_B8_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B8_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B8_L96_LAST_PAGE_LEN,
+                salt: 0x1508,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen15b_b8_l96_qh12_kvh2_d128_p16_hnd_token_parallel8",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 8,
+                max_num_pages: 48,
+                query_heads: 12,
+                kv_heads: 2,
+                page_indptr: &PAGED_DECODE_B8_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B8_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B8_L96_LAST_PAGE_LEN,
+                salt: 0x1508,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen15b_b16_l96_qh12_kvh2_d128_p16_hnd_direct",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 16,
+                max_num_pages: 96,
+                query_heads: 12,
+                kv_heads: 2,
+                page_indptr: &PAGED_DECODE_B16_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B16_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B16_L96_LAST_PAGE_LEN,
+                salt: 0x1516,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen15b_b16_l96_qh12_kvh2_d128_p16_hnd_token_parallel8",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 16,
+                max_num_pages: 96,
+                query_heads: 12,
+                kv_heads: 2,
+                page_indptr: &PAGED_DECODE_B16_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B16_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B16_L96_LAST_PAGE_LEN,
+                salt: 0x1516,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen7b_b8_l96_qh28_kvh4_d128_p16_hnd_direct",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 8,
+                max_num_pages: 48,
+                query_heads: 28,
+                kv_heads: 4,
+                page_indptr: &PAGED_DECODE_B8_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B8_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B8_L96_LAST_PAGE_LEN,
+                salt: 0x7008,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen7b_b8_l96_qh28_kvh4_d128_p16_hnd_token_parallel8",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 8,
+                max_num_pages: 48,
+                query_heads: 28,
+                kv_heads: 4,
+                page_indptr: &PAGED_DECODE_B8_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B8_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B8_L96_LAST_PAGE_LEN,
+                salt: 0x7008,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen7b_b16_l96_qh28_kvh4_d128_p16_hnd_direct",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::Direct,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 16,
+                max_num_pages: 96,
+                query_heads: 28,
+                kv_heads: 4,
+                page_indptr: &PAGED_DECODE_B16_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B16_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B16_L96_LAST_PAGE_LEN,
+                salt: 0x7016,
+            },
+            PagedDecodeCase {
+                name: "bf16_paged_qwen7b_b16_l96_qh28_kvh4_d128_p16_hnd_token_parallel8",
+                algorithm: Bf16PagedBatchDecodeAlgorithm::TokenParallel8,
+                layout: PagedKvLayout::Hnd,
+                batch_size: 16,
+                max_num_pages: 96,
+                query_heads: 28,
+                kv_heads: 4,
+                page_indptr: &PAGED_DECODE_B16_L96_INDPTR,
+                page_indices: &PAGED_DECODE_B16_L96_INDICES,
+                last_page_len: &PAGED_DECODE_B16_L96_LAST_PAGE_LEN,
+                salt: 0x7016,
             },
         ] {
             benchmark_paged_decode_case(


### PR DESCRIPTION
## What changed

- add an explicit paged-decode algorithm planning entry point for controlled Direct versus TokenParallel8 comparisons
- extend the matched CUDA benchmark with Qwen2.5 1.5B and 7B batch-8/batch-16 decode shapes
- add opt-in host enqueue timing to engine interop traces, split across setup, pre-handoff, provider submission, status readback, and post-handoff

## Why

The concurrent Mistral.rs serving matrix showed a larger Oxide gap at batch 16. The matched H20 microbenchmark disproves a Direct-kernel crossover: TokenParallel8 remains 1.93x to 2.81x faster for the measured batch-8/batch-16 GQA shapes. The trace timing API makes the remaining engine-adapter overhead measurable without enabling timing cost by default.

## Validation

- `cargo fmt --all -- --check`
- `cargo +nightly-2026-04-03 check -p oxide-infer-cuda -p oxide-infer-lab`
- `cargo +nightly-2026-04-03 clippy -p oxide-infer-cuda -p oxide-infer-lab --all-targets -- -D warnings`
- `cargo +nightly-2026-04-03 test -p oxide-infer-cuda --lib`
- `cargo +nightly-2026-04-03 check -p oxide-infer-cuda --features cuda`
- `cargo +nightly-2026-04-03 clippy -p oxide-infer-cuda --features cuda --all-targets -- -D warnings`
- H20 matched paged-decode benchmark with forced Direct and TokenParallel8 at batch 8 and 16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional host-side profiling for CUDA engine execution, including detailed phase timings.
  * Added support for explicitly selecting the paged BF16 batch decode algorithm.
  * Execution traces can now include profiling information when enabled.

* **Improvements**
  * Preserved automatic algorithm selection and existing validation and execution behavior.
  * Expanded paged decode benchmarks across additional model sizes, batch sizes, and algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->