### PR TITLE
perf(cuda): add trusted paged metadata path

### DIFF
--- a/crates/oxide-infer-cuda/src/attention/decode.rs
+++ b/crates/oxide-infer-cuda/src/attention/decode.rs
@@ -1614,11 +1614,7 @@ impl Bf16PagedBatchDecodePlan {
         &self,
         trusted_spec: Bf16PagedBatchDecodeSpec,
     ) -> Result<(), PagedBatchDecodeEnqueueError> {
-        if trusted_spec == self.spec {
-            Ok(())
-        } else {
-            Err(PagedBatchDecodeEnqueueError::TrustedMetadataPlanMismatch)
-        }
+        require_trusted_spec_match(self.spec, trusted_spec)
     }
 
     fn enqueue_into_impl(
@@ -2043,10 +2039,21 @@ impl Bf16PagedBatchDecodeArgs {
 }
 
 /// Checked handles whose paged metadata validity is guaranteed by the adapter.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct TrustedBf16PagedBatchDecodeArgs {
     spec: Bf16PagedBatchDecodeSpec,
     args: Bf16PagedBatchDecodeArgs,
+}
+
+fn require_trusted_spec_match(
+    plan_spec: Bf16PagedBatchDecodeSpec,
+    trusted_spec: Bf16PagedBatchDecodeSpec,
+) -> Result<(), PagedBatchDecodeEnqueueError> {
+    if trusted_spec == plan_spec {
+        Ok(())
+    } else {
+        Err(PagedBatchDecodeEnqueueError::TrustedMetadataPlanMismatch)
+    }
 }
 
 impl TrustedBf16PagedBatchDecodeArgs {
@@ -2300,6 +2307,20 @@ mod tests {
                 address: 0x1002,
                 alignment: 4,
             }
+        ));
+    }
+
+    #[test]
+    fn trusted_metadata_requires_the_same_plan_spec() {
+        let plan_spec =
+            Bf16PagedBatchDecodeSpec::new(1, 4, 8, 2, 128, 16, PagedKvLayout::Hnd).unwrap();
+        let other_spec =
+            Bf16PagedBatchDecodeSpec::new(2, 4, 8, 2, 128, 16, PagedKvLayout::Hnd).unwrap();
+
+        assert!(require_trusted_spec_match(plan_spec, plan_spec).is_ok());
+        assert!(matches!(
+            require_trusted_spec_match(plan_spec, other_spec),
+            Err(PagedBatchDecodeEnqueueError::TrustedMetadataPlanMismatch)
         ));
     }
 }

--- a/crates/oxide-infer-cuda/src/attention/decode.rs
+++ b/crates/oxide-infer-cuda/src/attention/decode.rs
@@ -225,6 +225,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -241,6 +242,7 @@ mod kernels {
             num_query_heads,
             num_kv_heads,
             softmax_scale_log2,
+            metadata_is_trusted,
             query,
             key_pages,
             value_pages,
@@ -282,6 +284,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -298,6 +301,7 @@ mod kernels {
             num_query_heads,
             num_kv_heads,
             softmax_scale_log2,
+            metadata_is_trusted,
             query,
             key_pages,
             value_pages,
@@ -445,6 +449,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -460,7 +465,7 @@ mod kernels {
         let state_count = batch_size * num_query_heads;
         if state_index >= state_count
             || lane >= WARP_THREADS as usize
-            || metadata_status[0] != STATUS_SUCCESS
+            || (!metadata_is_trusted && metadata_status[0] != STATUS_SUCCESS)
         {
             return;
         }
@@ -601,6 +606,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -617,7 +623,9 @@ mod kernels {
         let warp_in_block = thread_in_block / WARP_THREADS as usize;
         let lane = thread_in_block % WARP_THREADS as usize;
         let state_count = batch_size * num_query_heads;
-        if state_index >= state_count || metadata_status[0] != STATUS_SUCCESS {
+        if state_index >= state_count
+            || (!metadata_is_trusted && metadata_status[0] != STATUS_SUCCESS)
+        {
             return;
         }
         let request = state_index / num_query_heads;
@@ -860,6 +868,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -880,6 +889,7 @@ mod kernels {
             num_query_heads,
             num_kv_heads,
             softmax_scale_log2,
+            metadata_is_trusted,
             query,
             key_pages,
             value_pages,
@@ -922,6 +932,7 @@ mod kernels {
         num_query_heads: usize,
         num_kv_heads: usize,
         softmax_scale_log2: f32,
+        metadata_is_trusted: bool,
         query: &[bf16],
         key_pages: &[bf16],
         value_pages: &[bf16],
@@ -942,6 +953,7 @@ mod kernels {
             num_query_heads,
             num_kv_heads,
             softmax_scale_log2,
+            metadata_is_trusted,
             query,
             key_pages,
             value_pages,
@@ -1564,7 +1576,7 @@ impl Bf16PagedBatchDecodePlan {
         scope: &mut CommandScope<'_>,
         args: Bf16PagedBatchDecodeArgs,
     ) -> Result<(), PagedBatchDecodeEnqueueError> {
-        self.enqueue_into_impl(scope, args, None)
+        self.enqueue_into_impl(scope, args, false, None)
     }
 
     pub(crate) fn enqueue_into_profiled(
@@ -1573,14 +1585,47 @@ impl Bf16PagedBatchDecodePlan {
         args: Bf16PagedBatchDecodeArgs,
     ) -> Result<PagedBatchDecodeHostProfile, PagedBatchDecodeEnqueueError> {
         let mut profile = PagedBatchDecodeHostProfile::default();
-        self.enqueue_into_impl(scope, args, Some(&mut profile))?;
+        self.enqueue_into_impl(scope, args, false, Some(&mut profile))?;
         Ok(profile)
+    }
+
+    /// Enqueues after a trusted adapter has established metadata validity.
+    pub fn enqueue_trusted_metadata_into(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: TrustedBf16PagedBatchDecodeArgs,
+    ) -> Result<(), PagedBatchDecodeEnqueueError> {
+        self.require_trusted_spec(args.spec)?;
+        self.enqueue_into_impl(scope, args.args, true, None)
+    }
+
+    pub(crate) fn enqueue_trusted_metadata_into_profiled(
+        &self,
+        scope: &mut CommandScope<'_>,
+        args: TrustedBf16PagedBatchDecodeArgs,
+    ) -> Result<PagedBatchDecodeHostProfile, PagedBatchDecodeEnqueueError> {
+        self.require_trusted_spec(args.spec)?;
+        let mut profile = PagedBatchDecodeHostProfile::default();
+        self.enqueue_into_impl(scope, args.args, true, Some(&mut profile))?;
+        Ok(profile)
+    }
+
+    fn require_trusted_spec(
+        &self,
+        trusted_spec: Bf16PagedBatchDecodeSpec,
+    ) -> Result<(), PagedBatchDecodeEnqueueError> {
+        if trusted_spec == self.spec {
+            Ok(())
+        } else {
+            Err(PagedBatchDecodeEnqueueError::TrustedMetadataPlanMismatch)
+        }
     }
 
     fn enqueue_into_impl(
         &self,
         scope: &mut CommandScope<'_>,
         args: Bf16PagedBatchDecodeArgs,
+        metadata_is_trusted: bool,
         mut profile: Option<&mut PagedBatchDecodeHostProfile>,
     ) -> Result<(), PagedBatchDecodeEnqueueError> {
         let preflight_started = profile.is_some().then(std::time::Instant::now);
@@ -1633,43 +1678,45 @@ impl Bf16PagedBatchDecodePlan {
             resolved.fifth.len()
         };
 
-        scope.require_command_capacity(3)?;
-        let status = scope.reserve_device_status(
-            args.metadata_status.read(),
-            DeviceStatusDecoder::paged_batch_decode(
-                self.spec.batch_size(),
-                self.spec.max_num_pages(),
-                page_indices_len,
-                PAGED_BATCH_DECODE_PAGE_SIZE,
-            ),
-        )?;
+        scope.require_command_capacity(if metadata_is_trusted { 1 } else { 3 })?;
         if let Some(profile) = profile.as_deref_mut() {
             profile.preflight_host_nanoseconds = elapsed_nanoseconds(preflight_started);
         }
-        let metadata_started = profile.is_some().then(std::time::Instant::now);
-        let permit = scope.prepare_command()?;
-        let (function, validation_result) = {
-            let resolved = scope.resolve_rrrw(
-                args.page_indptr,
-                args.page_indices,
-                args.last_page_len,
-                args.metadata_status.write(),
+        if !metadata_is_trusted {
+            let metadata_started = profile.is_some().then(std::time::Instant::now);
+            let status = scope.reserve_device_status(
+                args.metadata_status.read(),
+                DeviceStatusDecoder::paged_batch_decode(
+                    self.spec.batch_size(),
+                    self.spec.max_num_pages(),
+                    page_indices_len,
+                    PAGED_BATCH_DECODE_PAGE_SIZE,
+                ),
             )?;
-            let operation = self.module.validate_paged_batch_decode_metadata_async(
-                &self.metadata_launch,
-                self.spec.batch_size(),
-                self.spec.max_num_pages(),
-                resolved.first,
-                resolved.second,
-                resolved.third,
-                resolved.fourth,
-            );
-            let result = enqueue_region_launch(resolved.stream, operation);
-            (self.metadata_launch.function().clone(), result)
-        };
-        record_paged_metadata_launch(scope, status, permit, function, validation_result)?;
-        if let Some(profile) = profile.as_deref_mut() {
-            profile.metadata_host_nanoseconds = elapsed_nanoseconds(metadata_started);
+            let permit = scope.prepare_command()?;
+            let (function, validation_result) = {
+                let resolved = scope.resolve_rrrw(
+                    args.page_indptr,
+                    args.page_indices,
+                    args.last_page_len,
+                    args.metadata_status.write(),
+                )?;
+                let operation = self.module.validate_paged_batch_decode_metadata_async(
+                    &self.metadata_launch,
+                    self.spec.batch_size(),
+                    self.spec.max_num_pages(),
+                    resolved.first,
+                    resolved.second,
+                    resolved.third,
+                    resolved.fourth,
+                );
+                let result = enqueue_region_launch(resolved.stream, operation);
+                (self.metadata_launch.function().clone(), result)
+            };
+            record_paged_metadata_launch(scope, status, permit, function, validation_result)?;
+            if let Some(profile) = profile.as_deref_mut() {
+                profile.metadata_host_nanoseconds = elapsed_nanoseconds(metadata_started);
+            }
         }
 
         let attention_started = profile.is_some().then(std::time::Instant::now);
@@ -1702,6 +1749,7 @@ impl Bf16PagedBatchDecodePlan {
                         common.2,
                         common.3,
                         common.4,
+                        metadata_is_trusted,
                         resolved.first,
                         resolved.second,
                         resolved.third,
@@ -1723,6 +1771,7 @@ impl Bf16PagedBatchDecodePlan {
                         common.2,
                         common.3,
                         common.4,
+                        metadata_is_trusted,
                         resolved.first,
                         resolved.second,
                         resolved.third,
@@ -1746,6 +1795,7 @@ impl Bf16PagedBatchDecodePlan {
                             common.2,
                             common.3,
                             common.4,
+                            metadata_is_trusted,
                             resolved.first,
                             resolved.second,
                             resolved.third,
@@ -1769,6 +1819,7 @@ impl Bf16PagedBatchDecodePlan {
                             common.2,
                             common.3,
                             common.4,
+                            metadata_is_trusted,
                             resolved.first,
                             resolved.second,
                             resolved.third,
@@ -1991,6 +2042,32 @@ impl Bf16PagedBatchDecodeArgs {
     }
 }
 
+/// Checked handles whose paged metadata validity is guaranteed by the adapter.
+#[derive(Clone, Copy, Debug)]
+pub struct TrustedBf16PagedBatchDecodeArgs {
+    spec: Bf16PagedBatchDecodeSpec,
+    args: Bf16PagedBatchDecodeArgs,
+}
+
+impl TrustedBf16PagedBatchDecodeArgs {
+    /// Marks paged metadata as valid for the complete lifetime of this command.
+    ///
+    /// # Safety
+    ///
+    /// The bound CSR page table must satisfy the paged-decode contract for
+    /// `spec`: indptr starts at zero and is monotonic, every request has at
+    /// least one page, each last-page length is within the page size, the
+    /// terminal indptr equals the exposed page-index length, and every page
+    /// index is below `spec.max_num_pages()`. The adapter must prevent mutation
+    /// of these buffers until command completion.
+    pub unsafe fn assume_metadata_valid(
+        spec: Bf16PagedBatchDecodeSpec,
+        args: Bf16PagedBatchDecodeArgs,
+    ) -> Self {
+        Self { spec, args }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum SingleDecodePlanError {
     #[error("single-decode query-head count {0} exceeds the CUDA grid range")]
@@ -2041,6 +2118,8 @@ pub enum PagedBatchDecodeEnqueueError {
     },
     #[error("page_indices requires at least {minimum} entries, got {actual}")]
     PageIndicesTooShort { minimum: usize, actual: usize },
+    #[error("trusted paged metadata belongs to a different decode plan")]
+    TrustedMetadataPlanMismatch,
     #[error(transparent)]
     Command(#[from] CommandError),
     #[error(transparent)]

--- a/crates/oxide-infer-cuda/src/attention/mod.rs
+++ b/crates/oxide-infer-cuda/src/attention/mod.rs
@@ -14,6 +14,7 @@ pub use decode::{
     Bf16SingleDecodeArgs, Bf16SingleDecodePlan, Bf16SingleDecodeSplitKArgs,
     Bf16SingleDecodeSplitKPlan, DecodeProvider, PagedBatchDecodeEnqueueError,
     PagedBatchDecodePlanError, SingleDecodeEnqueueError, SingleDecodePlanError,
+    TrustedBf16PagedBatchDecodeArgs,
 };
 pub use prefill::{
     Bf16PagedPrefillAlgorithm, Bf16PagedPrefillArgs, Bf16PagedPrefillPlan,

--- a/crates/oxide-infer-cuda/src/interop.rs
+++ b/crates/oxide-infer-cuda/src/interop.rs
@@ -28,6 +28,8 @@ use std::time::Instant;
 use thiserror::Error;
 
 const SPECIAL_STREAM_MAX_ADDRESS: usize = 2;
+const PAGED_BATCH_DECODE_CHECKED_COMMANDS: usize = 3;
+const PAGED_BATCH_DECODE_TRUSTED_COMMANDS: usize = 1;
 
 /// A validated, retained borrow of an engine-owned CUDA stream.
 pub struct ExternalCudaStream {
@@ -168,6 +170,15 @@ pub enum EngineAlgorithm {
 pub enum EngineMetadataValidation {
     DeviceChecked,
     TrustedByAdapter,
+}
+
+const fn paged_batch_decode_required_commands(
+    metadata_validation: EngineMetadataValidation,
+) -> usize {
+    match metadata_validation {
+        EngineMetadataValidation::DeviceChecked => PAGED_BATCH_DECODE_CHECKED_COMMANDS,
+        EngineMetadataValidation::TrustedByAdapter => PAGED_BATCH_DECODE_TRUSTED_COMMANDS,
+    }
 }
 
 /// Contract dimensions recorded without retaining a plan or allocating.
@@ -451,7 +462,6 @@ struct EngineHandoffSlot {
 }
 
 /// One immutable plan and its checked argument handles.
-#[derive(Clone, Copy)]
 pub enum EngineCommand<'a> {
     Bf16SingleDecode {
         plan: &'a Bf16SingleDecodePlan,
@@ -468,7 +478,7 @@ pub enum EngineCommand<'a> {
 }
 
 impl EngineCommand<'_> {
-    const fn operator(self) -> EngineOperator {
+    const fn operator(&self) -> EngineOperator {
         match self {
             Self::Bf16SingleDecode { .. } => EngineOperator::Bf16SingleDecode,
             Self::Bf16PagedBatchDecode { .. }
@@ -478,7 +488,7 @@ impl EngineCommand<'_> {
         }
     }
 
-    const fn binding_count(self) -> usize {
+    const fn binding_count(&self) -> usize {
         match self {
             Self::Bf16SingleDecode { .. } => SINGLE_DECODE_BINDING_COUNT,
             Self::Bf16PagedBatchDecode { .. }
@@ -486,78 +496,77 @@ impl EngineCommand<'_> {
         }
     }
 
-    const fn required_commands(self) -> usize {
+    const fn required_commands(&self) -> usize {
         match self {
             Self::Bf16SingleDecode { .. } => 1,
-            Self::Bf16PagedBatchDecode { .. } => 3,
-            Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => 1,
+            Self::Bf16PagedBatchDecode { .. } => {
+                paged_batch_decode_required_commands(EngineMetadataValidation::DeviceChecked)
+            }
+            Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => {
+                paged_batch_decode_required_commands(EngineMetadataValidation::TrustedByAdapter)
+            }
         }
     }
 
     fn trace(
-        self,
+        &self,
         memory: BindingMemorySummary,
         bindings: &CheckedBindings,
     ) -> Option<EngineExecutionTrace> {
-        let (addresses, algorithm, shape, paged_kv_layout, metadata_validation) = match self {
+        let (plan, metadata_validation) = match self {
             Self::Bf16SingleDecode { plan, .. } => {
                 let spec = plan.spec();
-                (
-                    EngineBufferAddresses::SingleDecode(bindings.exact_device_addresses()?),
-                    EngineAlgorithm::SingleDecodeDirect,
-                    EngineExecutionShape::SingleDecode {
+                return Some(EngineExecutionTrace {
+                    memory,
+                    buffer_addresses: EngineBufferAddresses::SingleDecode(
+                        bindings.exact_device_addresses()?,
+                    ),
+                    operator: EngineOperator::Bf16SingleDecode,
+                    algorithm: EngineAlgorithm::SingleDecodeDirect,
+                    shape: EngineExecutionShape::SingleDecode {
                         kv_len: spec.kv_len(),
                         query_heads: spec.num_query_heads(),
                         kv_heads: spec.num_kv_heads(),
                         head_dim: spec.head_dim(),
                     },
-                    None,
-                    None,
-                )
+                    paged_kv_layout: None,
+                    metadata_validation: None,
+                    handoff: EngineStreamHandoff::ExternalEventBridge,
+                    adapter_device_to_device_copies: 0,
+                    host_profile: None,
+                });
             }
-            Self::Bf16PagedBatchDecode { plan, .. }
-            | Self::Bf16PagedBatchDecodeTrustedMetadata { plan, .. } => {
-                let spec = plan.spec();
-                let algorithm = match plan.algorithm() {
-                    Bf16PagedBatchDecodeAlgorithm::Direct => {
-                        EngineAlgorithm::PagedBatchDecodeDirect
-                    }
-                    Bf16PagedBatchDecodeAlgorithm::TokenParallel8 => {
-                        EngineAlgorithm::PagedBatchDecodeTokenParallel8
-                    }
-                };
-                (
-                    EngineBufferAddresses::PagedBatchDecode(bindings.exact_device_addresses()?),
-                    algorithm,
-                    EngineExecutionShape::PagedBatchDecode {
-                        batch_size: spec.batch_size(),
-                        max_num_pages: spec.max_num_pages(),
-                        query_heads: spec.num_query_heads(),
-                        kv_heads: spec.num_kv_heads(),
-                        head_dim: spec.head_dim(),
-                        page_size: spec.page_size(),
-                    },
-                    Some(spec.kv_layout()),
-                    Some(match self {
-                        Self::Bf16PagedBatchDecode { .. } => {
-                            EngineMetadataValidation::DeviceChecked
-                        }
-                        Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => {
-                            EngineMetadataValidation::TrustedByAdapter
-                        }
-                        Self::Bf16SingleDecode { .. } => unreachable!(),
-                    }),
-                )
+            Self::Bf16PagedBatchDecode { plan, .. } => {
+                (plan, EngineMetadataValidation::DeviceChecked)
+            }
+            Self::Bf16PagedBatchDecodeTrustedMetadata { plan, .. } => {
+                (plan, EngineMetadataValidation::TrustedByAdapter)
+            }
+        };
+        let spec = plan.spec();
+        let algorithm = match plan.algorithm() {
+            Bf16PagedBatchDecodeAlgorithm::Direct => EngineAlgorithm::PagedBatchDecodeDirect,
+            Bf16PagedBatchDecodeAlgorithm::TokenParallel8 => {
+                EngineAlgorithm::PagedBatchDecodeTokenParallel8
             }
         };
         Some(EngineExecutionTrace {
             memory,
-            buffer_addresses: addresses,
-            operator: self.operator(),
+            buffer_addresses: EngineBufferAddresses::PagedBatchDecode(
+                bindings.exact_device_addresses()?,
+            ),
+            operator: EngineOperator::Bf16PagedBatchDecode,
             algorithm,
-            shape,
-            paged_kv_layout,
-            metadata_validation,
+            shape: EngineExecutionShape::PagedBatchDecode {
+                batch_size: spec.batch_size(),
+                max_num_pages: spec.max_num_pages(),
+                query_heads: spec.num_query_heads(),
+                kv_heads: spec.num_kv_heads(),
+                head_dim: spec.head_dim(),
+                page_size: spec.page_size(),
+            },
+            paged_kv_layout: Some(spec.kv_layout()),
+            metadata_validation: Some(metadata_validation),
             handoff: EngineStreamHandoff::ExternalEventBridge,
             adapter_device_to_device_copies: 0,
             host_profile: None,
@@ -1305,5 +1314,17 @@ mod tests {
         assert!(trace.is_adapter_zero_copy());
         assert_eq!(trace.provider(), "oxide-infer-cuda");
         assert_eq!(trace.operator(), EngineOperator::Bf16SingleDecode);
+    }
+
+    #[test]
+    fn trusted_paged_decode_reserves_one_command() {
+        assert_eq!(
+            paged_batch_decode_required_commands(EngineMetadataValidation::DeviceChecked),
+            PAGED_BATCH_DECODE_CHECKED_COMMANDS
+        );
+        assert_eq!(
+            paged_batch_decode_required_commands(EngineMetadataValidation::TrustedByAdapter),
+            PAGED_BATCH_DECODE_TRUSTED_COMMANDS
+        );
     }
 }

--- a/crates/oxide-infer-cuda/src/interop.rs
+++ b/crates/oxide-infer-cuda/src/interop.rs
@@ -9,7 +9,7 @@
 use crate::attention::{
     Bf16PagedBatchDecodeAlgorithm, Bf16PagedBatchDecodeArgs, Bf16PagedBatchDecodePlan,
     Bf16SingleDecodeArgs, Bf16SingleDecodePlan, PagedBatchDecodeEnqueueError,
-    PagedBatchDecodeHostProfile, SingleDecodeEnqueueError,
+    PagedBatchDecodeHostProfile, SingleDecodeEnqueueError, TrustedBf16PagedBatchDecodeArgs,
 };
 use crate::command::{
     BindingMemorySummary, CheckedBindings, CommandCompletion, CommandCompletionError, CommandError,
@@ -163,6 +163,13 @@ pub enum EngineAlgorithm {
     PagedBatchDecodeTokenParallel8,
 }
 
+/// Metadata validation used by one paged operator submission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EngineMetadataValidation {
+    DeviceChecked,
+    TrustedByAdapter,
+}
+
 /// Contract dimensions recorded without retaining a plan or allocating.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EngineExecutionShape {
@@ -259,6 +266,7 @@ pub struct EngineExecutionTrace {
     algorithm: EngineAlgorithm,
     shape: EngineExecutionShape,
     paged_kv_layout: Option<PagedKvLayout>,
+    metadata_validation: Option<EngineMetadataValidation>,
     handoff: EngineStreamHandoff,
     adapter_device_to_device_copies: usize,
     host_profile: Option<EngineInteropHostProfile>,
@@ -283,6 +291,10 @@ impl EngineExecutionTrace {
 
     pub const fn paged_kv_layout(&self) -> Option<PagedKvLayout> {
         self.paged_kv_layout
+    }
+
+    pub const fn metadata_validation(&self) -> Option<EngineMetadataValidation> {
+        self.metadata_validation
     }
 
     pub const fn memory(&self) -> BindingMemorySummary {
@@ -449,20 +461,28 @@ pub enum EngineCommand<'a> {
         plan: &'a Bf16PagedBatchDecodePlan,
         args: Bf16PagedBatchDecodeArgs,
     },
+    Bf16PagedBatchDecodeTrustedMetadata {
+        plan: &'a Bf16PagedBatchDecodePlan,
+        args: TrustedBf16PagedBatchDecodeArgs,
+    },
 }
 
 impl EngineCommand<'_> {
     const fn operator(self) -> EngineOperator {
         match self {
             Self::Bf16SingleDecode { .. } => EngineOperator::Bf16SingleDecode,
-            Self::Bf16PagedBatchDecode { .. } => EngineOperator::Bf16PagedBatchDecode,
+            Self::Bf16PagedBatchDecode { .. }
+            | Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => {
+                EngineOperator::Bf16PagedBatchDecode
+            }
         }
     }
 
     const fn binding_count(self) -> usize {
         match self {
             Self::Bf16SingleDecode { .. } => SINGLE_DECODE_BINDING_COUNT,
-            Self::Bf16PagedBatchDecode { .. } => PAGED_BATCH_DECODE_BINDING_COUNT,
+            Self::Bf16PagedBatchDecode { .. }
+            | Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => PAGED_BATCH_DECODE_BINDING_COUNT,
         }
     }
 
@@ -470,6 +490,7 @@ impl EngineCommand<'_> {
         match self {
             Self::Bf16SingleDecode { .. } => 1,
             Self::Bf16PagedBatchDecode { .. } => 3,
+            Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => 1,
         }
     }
 
@@ -478,7 +499,7 @@ impl EngineCommand<'_> {
         memory: BindingMemorySummary,
         bindings: &CheckedBindings,
     ) -> Option<EngineExecutionTrace> {
-        let (addresses, algorithm, shape, paged_kv_layout) = match self {
+        let (addresses, algorithm, shape, paged_kv_layout, metadata_validation) = match self {
             Self::Bf16SingleDecode { plan, .. } => {
                 let spec = plan.spec();
                 (
@@ -491,9 +512,11 @@ impl EngineCommand<'_> {
                         head_dim: spec.head_dim(),
                     },
                     None,
+                    None,
                 )
             }
-            Self::Bf16PagedBatchDecode { plan, .. } => {
+            Self::Bf16PagedBatchDecode { plan, .. }
+            | Self::Bf16PagedBatchDecodeTrustedMetadata { plan, .. } => {
                 let spec = plan.spec();
                 let algorithm = match plan.algorithm() {
                     Bf16PagedBatchDecodeAlgorithm::Direct => {
@@ -515,6 +538,15 @@ impl EngineCommand<'_> {
                         page_size: spec.page_size(),
                     },
                     Some(spec.kv_layout()),
+                    Some(match self {
+                        Self::Bf16PagedBatchDecode { .. } => {
+                            EngineMetadataValidation::DeviceChecked
+                        }
+                        Self::Bf16PagedBatchDecodeTrustedMetadata { .. } => {
+                            EngineMetadataValidation::TrustedByAdapter
+                        }
+                        Self::Bf16SingleDecode { .. } => unreachable!(),
+                    }),
                 )
             }
         };
@@ -525,6 +557,7 @@ impl EngineCommand<'_> {
             algorithm,
             shape,
             paged_kv_layout,
+            metadata_validation,
             handoff: EngineStreamHandoff::ExternalEventBridge,
             adapter_device_to_device_copies: 0,
             host_profile: None,
@@ -546,6 +579,16 @@ impl EngineCommand<'_> {
                     Ok(Some(plan.enqueue_into_profiled(scope, args)?))
                 } else {
                     plan.enqueue_into(scope, args)?;
+                    Ok(None)
+                }
+            }
+            Self::Bf16PagedBatchDecodeTrustedMetadata { plan, args } => {
+                if host_profiling_enabled {
+                    Ok(Some(
+                        plan.enqueue_trusted_metadata_into_profiled(scope, args)?,
+                    ))
+                } else {
+                    plan.enqueue_trusted_metadata_into(scope, args)?;
                     Ok(None)
                 }
             }
@@ -1254,6 +1297,7 @@ mod tests {
                 head_dim: 128,
             },
             paged_kv_layout: None,
+            metadata_validation: None,
             handoff: EngineStreamHandoff::ExternalEventBridge,
             adapter_device_to_device_copies: 0,
             host_profile: None,


### PR DESCRIPTION
## What changed

- add an unsafe-to-construct, single-use trusted paged-metadata capability around checked decode bindings
- make the enclosing engine command non-cloneable so the capability cannot be replayed
- add a dedicated engine command variant that records `TrustedByAdapter` in its execution trace
- skip the metadata validator kernel and status readback only for that capability
- keep the existing `DeviceChecked` command and typed rejection path unchanged

## Why

The R7 H20 profile measured 6.343 us per layer in repeated metadata validation and status readback, 26.0% of the complete Mistral adapter enqueue path. The engine already constructs the page table from validated scheduler state, so an explicit unsafe capability lets that engine state cross the provider boundary without globally weakening the default checked API.

## Validation

- `cargo +nightly-2026-04-03 fmt --all -- --check`
- `cargo +nightly-2026-04-03 test -p oxide-infer-cuda --features cuda --lib`: 40 passed
- `cargo +nightly-2026-04-03 clippy -p oxide-infer-cuda --features cuda --all-targets -- -D warnings`
- `cargo +nightly-2026-04-03 check -p oxide-infer-cuda --features cuda --all-targets`
- H20 matched checked benchmark over every existing case, with three commands, one validator, and one status readback retained
- dependent Mistral H20 recovery gate passed on final commit: one typed rejection, exact valid outputs, runtime reuse
- dependent profiled c16 run: 26,460 trusted submissions, zero failures, host enqueue 24.435 to 18.245 us (-25.3%)

The dependent Mistral integration is feichai0017/mistral.rs#9.
