### PR TITLE
docs: define TileLang inference engine architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ operator contracts, chooses an explicit provider and algorithm, freezes an
 immutable plan, checks runtime resources, and retains them until GPU work
 settles.
 
+The [accepted target architecture](docs/design/tilelang-engine-architecture.md)
+evolves this alpha into a complete Rust inference engine: a Mistral.rs
+control-plane shell, an Oxide-owned model and KV data plane, and offline
+TileLang artifacts as the only product custom compute kernels. That target is
+not yet the state of the current source; migration gates and the
+[engine benchmark plan](docs/development/engine-benchmark-plan.md) keep the
+distinction explicit.
+
 [cuda-oxide](https://github.com/NVlabs/cuda-oxide) compiles native Rust device
 code. Vendor providers such as cuBLASLt enter through the same checked command
 runtime without passing through the native-kernel toolchain.
@@ -236,18 +244,18 @@ New Oxide Infer records qualify only the source revision named by each record. S
 
 ## Roadmap
 
-The roadmap advances through measured vertical slices:
+The roadmap now advances one complete engine profile at a time:
 
-1. Complete the Oxide Infer namespace and framework migration.
-2. Optimize the measured long-context prefill gaps.
-3. Keep the stopped native M=1 GEMV experimental; evaluate a new design only
-   under a new algorithm identity.
-4. Close the Mistral.rs adapter and define a narrow vLLM C ABI boundary.
-5. Expand attention, KV-cache operations, and MLA from engine traces.
-6. Add activation, sampling, quantization, grouped GEMM, and MoE paths.
-7. Add Blackwell modules only with hardware-backed contracts and evidence.
-8. Qualify collectives and distributed integration after single-GPU ownership
-   is stable.
+1. Freeze the TileLang artifact ABI and checked Rust loader.
+2. Replace the current native and vendor paths for one BF16 model profile.
+3. Build the complete Qwen2.5-1.5B prefill and decode plan with no Candle CUDA
+   execution or silent provider fallback.
+4. Import the Mistral.rs shell and connect it through one `OxidePipeline`.
+5. Qualify continuous batching, KV paging, cancellation, Graphs, and recovery.
+6. Compare kernels with FlashInfer and the complete server with vLLM and
+   SGLang under matched workloads.
+7. Expand model, dtype, hardware, and distributed coverage only after the
+   first profile passes its release gate.
 
 Each milestone has admission, evidence, and stop conditions in the
 [full roadmap](docs/roadmap.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,10 @@
 # Oxide Infer documentation
 
-Oxide Infer is a Rust-native CUDA operator layer for LLM inference engines.
-It does not own model graphs, request scheduling, KV allocation policy, or
-serving APIs.
+The current source is a Rust-native CUDA operator layer. The accepted target
+is a complete Rust inference engine that embeds a Mistral.rs control-plane
+shell, owns model execution in Oxide, and uses offline TileLang artifacts as
+its only product custom compute kernels. The target does not describe a
+completed migration.
 
 The documentation separates three facts:
 
@@ -17,18 +19,22 @@ applies only to its recorded source, contract, artifact, hardware, and command.
 
 ## Core documents
 
-1. [Architecture](design/oxide-infer-architecture.md) defines product
-   ownership, provider paths, planning, execution, and hardware boundaries.
-2. [Repository layout](design/repository-layout.md) defines the three crates
-   and the operator family namespaces.
-3. [Operator catalog](operator-catalog.md) lists current, experimental, and
+1. [Target engine architecture](design/tilelang-engine-architecture.md)
+   defines the accepted Mistral.rs, Oxide, and TileLang ownership model.
+2. [Current operator architecture](design/oxide-infer-architecture.md)
+   defines the source that is being migrated.
+3. [Engine benchmark plan](development/engine-benchmark-plan.md) defines
+   kernel, model, and serving comparisons.
+4. [Repository layout](design/repository-layout.md) separates current and
+   target source trees.
+5. [Operator catalog](operator-catalog.md) lists current, experimental, and
    planned contracts.
-4. [Roadmap](roadmap.md) orders work and defines admission and exit gates.
-5. [FlashInfer parity](flashinfer-parity.md) tracks the pinned comparison
+6. [Roadmap](roadmap.md) orders work and defines admission and exit gates.
+7. [FlashInfer parity](flashinfer-parity.md) tracks the pinned comparison
    surface without claiming full parity.
-6. [Mistral.rs integration](integrations/mistralrs.md) records the first engine
+8. [Mistral.rs integration](integrations/mistralrs.md) records the first engine
    adapter boundary.
-7. [Evidence index](results/README.md) lists immutable device and benchmark
+9. [Evidence index](results/README.md) lists immutable device and benchmark
    records.
 
 The [rename provenance](design/rename-provenance.md) maps the former project
@@ -37,8 +43,10 @@ names.
 
 ## Development documents
 
-- [Environment](development/environment.md) pins Rust, CUDA, cuda-oxide, and
-  website toolchains.
+- [Environment](development/environment.md) pins the current transitional
+  Rust, CUDA, cuda-oxide, and website toolchains.
+- [Engine benchmark plan](development/engine-benchmark-plan.md) fixes the
+  future FlashInfer, vLLM, and SGLang comparison protocol.
 - [Current device validation](development/h20-validation.md) defines correctness,
   sanitizer, Graph, performance, and engine gates.
 - [Dense GEMM shape census](development/gemm-shape-census.md) defines the

--- a/docs/design/oxide-infer-architecture.md
+++ b/docs/design/oxide-infer-architecture.md
@@ -1,9 +1,15 @@
 # Oxide Infer architecture
 
-Oxide Infer provides checked GPU operator contracts and CUDA providers for LLM
-inference engines. A consumer engine retains its model graph, scheduler,
-continuous batching, KV allocation policy, distributed control, and serving
-API.
+This document describes the current transitional operator source. The
+[accepted target architecture](tilelang-engine-architecture.md) turns Oxide
+Infer into a complete engine with a Mistral.rs control-plane shell and
+TileLang-only product custom kernels. Current source and historical evidence
+remain accurately documented here until each migration gate is complete.
+
+The current source provides checked GPU operator contracts and CUDA providers
+for LLM inference engines. A consumer engine retains its model graph,
+scheduler, continuous batching, KV allocation policy, distributed control,
+and serving API.
 
 ## Status terms
 

--- a/docs/design/repository-layout.md
+++ b/docs/design/repository-layout.md
@@ -1,9 +1,11 @@
 # Repository layout
 
-Oxide Infer keeps three crates. A module or crate needs a functional,
-dependency, build, ownership, or safety boundary.
+The current source keeps three crates. The accepted engine target adds one
+model-execution crate, an embedded Mistral.rs shell, and an offline TileLang
+kernel tree. A module or crate still needs a functional, dependency, build,
+ownership, safety, or release boundary.
 
-## Top level
+## Current top level
 
 ```text
 oxide-infer/
@@ -27,7 +29,39 @@ oxide-infer/
 Generated PTX, cubins, profiler captures, model weights, `target/`, and website
 build output are not product source.
 
-## Three-crate rule
+## Accepted target layout
+
+```text
+oxide-infer/
+|-- crates/
+|   |-- oxide-infer/          contracts and CPU references
+|   |-- oxide-infer-cuda/     CUDA resources and checked artifact launch
+|   |-- oxide-infer-engine/   model IR, plans, KV pager, executor, sampling
+|   `-- oxide-infer-lab/      correctness and benchmark programs
+|-- engine/
+|   `-- mistralrs/            git-subtree fork and OxidePipeline wiring
+|-- kernels/
+|   `-- tilelang/             sources, build profiles, and manifests
+|-- benchmarks/
+|   |-- kernels/              matched FlashInfer comparisons
+|   `-- serving/              neutral vLLM and SGLang comparisons
+|-- docs/
+|-- website/
+`-- .github/
+```
+
+The root Cargo workspace excludes `engine/mistralrs`; CI addresses its Cargo
+workspace through `--manifest-path`. The imported shell depends on the Oxide
+engine crate through one adapter boundary. TileLang and Python run only in the
+artifact build and qualification environment, never in the serving process.
+
+The new `oxide-infer-engine` crate has a real boundary: it owns model and KV
+state and depends on execution facilities that the backend-independent
+contract crate must not acquire. The target structure and subtree-sync rules
+are defined in the
+[TileLang engine architecture](tilelang-engine-architecture.md).
+
+## Transitional three-crate rule
 
 ```text
 consumer engine or adapter
@@ -44,6 +78,10 @@ oxide-infer-lab
 `oxide-infer` builds without CUDA. Product crates do not depend on the lab,
 documentation, website, tools, or result records. The lab crate is a workspace
 member but not a default member.
+
+This rule describes current source only. The engine migration may add
+`oxide-infer-engine` after its first complete vertical slice; it does not add
+empty placeholder crates.
 
 GEMM, attention, KV-cache operations, and Graph execution remain modules in
 these crates. Do not add `oxide-gemm`, `oxide-runtime`, or

--- a/docs/design/tilelang-engine-architecture.md
+++ b/docs/design/tilelang-engine-architecture.md
@@ -1,0 +1,257 @@
+# TileLang engine architecture
+
+**Decision:** accepted target on 2026-08-14.
+
+Oxide Infer will become a Rust-first LLM inference engine. It will reuse the
+Mistral.rs fork as its control-plane shell, own model execution and GPU
+resource policy in Oxide crates, and use TileLang as the only source language
+for product custom compute kernels.
+
+This is a target architecture, not a statement about the current tree. The
+current source is still a checked operator runtime with cuda-oxide and
+cuBLASLt paths. Migration phases must remove those paths before the engine can
+claim the target state.
+
+## Product position
+
+Oxide Infer is not a Rust wrapper around another serving engine and not a
+general kernel DSL. Its intended position is:
+
+- one deployable Rust inference engine and OpenAI-compatible server;
+- Mistral.rs control-plane features without Candle CUDA execution in the
+  supported fast path;
+- Oxide-owned model plans, KV paging, memory, streams, Graphs, and sampling;
+- ahead-of-time TileLang kernels loaded by a checked Rust CUDA runtime;
+- evidence at both the operator and complete-serving levels.
+
+The first product profile is deliberately narrow: one dense decoder-only
+model family, BF16, one NVIDIA GPU, paged KV cache, continuous batching, and
+greedy sampling. Quantization, MoE, multimodal models, speculative decoding,
+and multi-GPU execution enter only after this profile is complete.
+
+## Current and target boundaries
+
+| Concern | Current source | Accepted target |
+| --- | --- | --- |
+| API, tokenizer, scheduler | External Mistral.rs fork | Embedded Mistral.rs shell |
+| Model forward | Candle model implementations | Oxide execution plan |
+| GPU tensors and weights | Candle storage | Oxide allocations and weight loader |
+| KV allocation and paging | Consumer engine | Oxide engine runtime |
+| Custom compute kernels | cuda-oxide | TileLang only |
+| General dense GEMM | cuBLASLt | TileLang GEMM |
+| Kernel compilation | Rust device build | Offline TileLang artifact build |
+| Runtime process | Rust plus native/vendor providers | Rust plus CUDA driver and prebuilt artifacts |
+| Engine evidence | Narrow decode adapter | Full model and serving workloads |
+
+CUDA Driver APIs, CUDA Graph APIs, and NCCL are infrastructure interfaces, not
+compute-kernel providers. Their use does not violate the TileLang-only kernel
+rule. Product GPU computation does violate the rule if it executes through
+FlashInfer, cuBLASLt, CUTLASS, Triton, handwritten CUDA, cuda-oxide, or Candle
+CUDA kernels.
+
+## System boundary
+
+```text
+OpenAI-compatible clients
+          |
+          v
+Mistral.rs control plane
+  HTTP, tokenizer, chat templates, request lifecycle,
+  model registry, continuous-batch scheduling
+          |
+          | EngineBatch / EngineResult
+          v
+OxidePipeline
+  the only Mistral-to-Oxide execution boundary
+          |
+          v
+Oxide engine data plane
+  weight loader -> model IR -> execution plan
+  KV pager -> batch metadata -> executor -> sampler
+  memory -> streams -> CUDA Graphs -> completions
+          |
+          v
+Tile artifact registry
+  contract + algorithm + ABI + target + artifact hash
+          |
+          v
+prebuilt TileLang cubin/PTX -> CUDA Driver -> NVIDIA GPU
+```
+
+Mistral.rs currently exposes `Pipeline::forward_inputs` and
+`NormalModel::forward`. The migration adds an `OxidePipeline` at the pipeline
+boundary. A supported model's entire forward enters an Oxide-owned execution
+plan there. It does not wrap every Candle layer or replace Candle operations
+one call at a time.
+
+This boundary keeps the fork patch small and makes provider coverage
+auditable. If an admitted model cannot build a complete Oxide plan, startup
+fails with a typed unsupported-model or unsupported-shape error. The product
+profile never silently runs part of the model through Candle CUDA.
+
+## Control-plane ownership
+
+The embedded Mistral.rs fork keeps:
+
+- OpenAI-compatible routes, streaming responses, and request validation;
+- tokenizer, chat-template, and Hugging Face metadata handling;
+- request lifecycle, cancellation, and continuous-batch scheduling;
+- model selection and user-facing configuration;
+- response assembly, telemetry hooks, and server process management.
+
+The shell submits engine-neutral batches. It does not own GPU tensor classes,
+kernel dispatch, model-layer execution, or product KV pages.
+
+The first adapter should be one new pipeline implementation plus the minimum
+loader and CLI registration needed to select it. Changes scattered through
+Mistral.rs model files are an architecture failure because they expand the
+fork diff and permit mixed Candle/Oxide execution.
+
+## Oxide data-plane ownership
+
+The Oxide engine owns:
+
+- direct safetensors loading into Oxide-managed host and device regions;
+- a small model IR and immutable prefill and decode execution plans;
+- tensor layout, workspace, stream, event, and completion lifetimes;
+- paged KV allocation, sharing, copy-on-write, eviction, and block tables;
+- fused layer and model segments rather than eager operator-by-operator
+  dispatch;
+- logits processing, sampling state, and token outputs;
+- CUDA Graph capture for admitted fixed-address decode plans;
+- artifact selection, compatibility checks, and provider-hit telemetry.
+
+The model IR is not a general framework. It represents only the admitted
+model profiles and operations. Narrow IR coverage is a maintenance feature:
+an unsupported architecture is rejected instead of partially interpreted.
+
+## TileLang kernel rule
+
+TileLang is a build-time kernel factory, not a runtime dependency.
+
+```text
+kernels/tilelang/src/*.py
+        |
+        v
+pinned compiler + deterministic build profiles
+        |
+        v
+cubin/PTX + artifact manifest + correctness report
+        |
+        v
+release package
+        |
+        v
+Rust artifact registry -> checked launch
+```
+
+Production servers must not import Python, compile a kernel, auto-tune, access
+the network, or mutate the artifact registry. Development builds may tune
+candidate schedules, but promotion converts the selected schedule into an
+immutable artifact.
+
+Each artifact manifest records at least:
+
+- operator contract version and algorithm identity;
+- TileLang source and compiler versions;
+- CUDA toolkit, target compute capability, and required driver version;
+- dtype, layout, shape domain, numerical limits, and determinism policy;
+- parameter ABI, alignment, alias rules, launch geometry, and workspace;
+- cubin or PTX SHA-256 and source-tree identity;
+- correctness, sanitizer, Graph, and benchmark record identities.
+
+The Rust runtime verifies the manifest, artifact hash, target device, ABI, and
+shape domain before load. Enqueue cannot tune, switch algorithms, or fall back.
+
+## Repository target
+
+The Mistral.rs fork will be imported with `git subtree` under
+`engine/mistralrs`. It remains a separate Cargo workspace excluded from the
+root workspace, and CI builds it with an explicit manifest path. A subtree
+gives users one clone and one release source tree while preserving a
+repeatable upstream-sync command and an auditable fork patch.
+
+```text
+oxide-infer/
+|-- crates/
+|   |-- oxide-infer/          contracts and CPU references
+|   |-- oxide-infer-cuda/     CUDA resources and artifact launcher
+|   |-- oxide-infer-engine/   model IR, planner, KV pager, executor, sampling
+|   `-- oxide-infer-lab/      correctness and benchmark programs
+|-- engine/
+|   `-- mistralrs/            subtree fork and OxidePipeline shell wiring
+|-- kernels/
+|   `-- tilelang/
+|       |-- src/              kernel definitions and fixed schedules
+|       |-- build/            compiler and manifest generator
+|       `-- profiles/         admitted target and shape matrices
+|-- benchmarks/
+|   |-- kernels/              matched FlashInfer comparisons
+|   `-- serving/              neutral OpenAI-compatible workload driver
+|-- docs/results/             immutable evidence and artifact manifests
+`-- tools/                    development-only analysis utilities
+```
+
+`oxide-infer-engine` is a justified fourth product crate: it has model and KV
+state, a different dependency boundary, and a release surface that the
+backend-independent contract crate must not acquire.
+
+Subtree updates are reviewed separately from Oxide feature work. The sync
+commit contains only the upstream import; a following commit reapplies or
+updates the small shell adapter. A growing cross-tree patch is a stop signal.
+
+## Supported-path policy
+
+The server exposes two distinct build profiles:
+
+- `oxide-production`: admitted models only, complete Oxide execution,
+  TileLang artifacts only, and fail-closed startup;
+- `mistral-reference`: test and comparison profile used to validate output
+  behavior, never packaged as the product fast path.
+
+There is no automatic runtime fallback between them. Benchmark records name
+the selected profile and include provider-hit counters. A full request must
+report zero Candle CUDA, FlashInfer, cuBLASLt, cuda-oxide, and unregistered
+kernel hits before it can count as Oxide engine evidence.
+
+## Maintenance consequences
+
+This architecture reduces maintenance in four places:
+
+- one kernel source language instead of Rust device code, C++/CUDA, and vendor
+  provider wrappers;
+- one model execution boundary instead of modifications across Candle layers;
+- offline immutable artifacts instead of production JIT and tuning failures;
+- one repository, pinned shell source, and reproducible engine evidence.
+
+It does not make kernel work free. Oxide becomes responsible for every
+admitted GEMM, attention, KV, normalization, activation, and sampling
+algorithm and for their target-specific tuning. Maintenance remains tractable
+only while model, dtype, layout, and hardware coverage stay explicit and
+fail-closed.
+
+## Initial implementation slice
+
+The first complete slice is BF16 Qwen2.5-1.5B on one GPU because the repository
+already has Mistral.rs traces and paged-attention evidence for that model
+family. The slice includes:
+
+1. safetensors loading and embeddings;
+2. RMSNorm, RoPE, dense GEMM, SwiGLU, and residual operations;
+3. paged prefill, paged decode, and KV append;
+4. final norm, logits projection, and greedy token selection;
+5. continuous batching through `OxidePipeline`;
+6. one OpenAI-compatible streaming endpoint.
+
+Completion requires exact greedy-token agreement with the reference profile,
+complete provider-hit accounting, no device copies at the shell boundary, and
+the benchmark gates in the engine evidence plan.
+
+## Non-goals for the first release
+
+- preserving all Mistral.rs model and modality coverage;
+- exposing TileLang or Python as a user runtime API;
+- accepting arbitrary eager graphs;
+- claiming every TileLang kernel beats every FlashInfer kernel;
+- claiming engine leadership from a single operator or single concurrency;
+- multi-GPU, quantized, MoE, speculative, diffusion, vision, or audio serving.

--- a/docs/development/engine-benchmark-plan.md
+++ b/docs/development/engine-benchmark-plan.md
@@ -1,0 +1,182 @@
+# Engine benchmark and evidence plan
+
+Oxide Infer needs two independent performance proofs:
+
+1. matched kernel comparisons against FlashInfer where contracts overlap;
+2. complete inference and serving comparisons against vLLM and SGLang.
+
+A faster kernel does not prove a faster engine. A faster unloaded server does
+not prove production goodput. Correctness, kernel timing, model execution, and
+serving results remain separate records.
+
+## Evidence ladder
+
+```text
+operator reference and negative cases
+  -> device correctness and sentinels
+  -> sanitizer and lifetime checks
+  -> CUDA Graph qualification or exclusion
+  -> matched kernel benchmark
+  -> full-model output and provider trace
+  -> offline engine benchmark
+  -> online serving and SLO goodput benchmark
+```
+
+Each record pins source commits, container or environment hashes, model files,
+tokenizer, kernel artifacts, CUDA and driver versions, hardware identity,
+clock policy, command line, warmup, samples, and exclusions.
+
+## Kernel comparison with FlashInfer
+
+Compare semantic contracts, not wrapper names. Oxide and FlashInfer receive
+the same tensor bits, page tables, sequence metadata, dtype, layout, stream,
+and caller-owned outputs. Compilation, tuning, allocations, page
+materialization, and correctness copies stay outside the timed interval.
+
+The primary matrix covers:
+
+| Family | Workloads |
+| --- | --- |
+| Attention | single and paged decode; ragged and paged prefill; MHA, GQA, short and long context |
+| KV cache | RoPE, paged append, gather, scatter, and compaction as implemented |
+| Sampling | logits transforms, top-k/top-p/min-p, and token selection as implemented |
+| GEMM | model-census M=1 decode and larger prefill shapes; FlashInfer where available and cuBLASLt as a diagnostic baseline |
+
+For each row:
+
+- validate finite output against an independent reference before timing;
+- report maximum absolute and relative error and stable output digests;
+- use CUDA events on one caller-owned stream;
+- run complementary balanced provider orders;
+- report median, p95, dispersion, workspace, and effective bandwidth or FLOPS;
+- fail the ranking if order drift exceeds 5%;
+- record the loaded artifact hash and provider-hit identity.
+
+The first TileLang spike is not a promotion result. On its fixed paged-prefill
+shape, TileLang measured 31.83 microseconds, the current Oxide path 47.01
+microseconds, and FlashInfer 25.90 microseconds. TileLang improved the current
+path by 32.3% but remained 22.9% slower than FlashInfer. It proves that the
+toolchain can express and run this contract, not that the engine migration has
+already won.
+
+Kernel promotion gates for the first release are:
+
+- all admitted shapes pass correctness and safety gates;
+- no critical-path row is more than 15% slower than its matched comparison;
+- the latency geometric mean across the model-weighted matrix is no more than
+  5% slower than the matched comparison;
+- no hidden allocation, JIT, tuning, synchronization, or provider fallback
+  occurs in enqueue;
+- a slower admitted row has a measured engine-level reason to remain.
+
+## Full-model correctness
+
+Before performance ranking, run the Oxide and Mistral reference profiles with
+the same local weights and tokenizer.
+
+The first gate uses deterministic greedy decoding with fixed prompt token IDs,
+fixed output lengths, EOS ignored for the timed interval, and prefix caching,
+speculation, and quantization disabled. It records:
+
+- prompt and generated token IDs;
+- selected logits slices and numerical limits at layer checkpoints;
+- KV page hashes and page-allocation events;
+- provider hits for every GPU operation;
+- host-to-device and device-to-device copy counts;
+- peak device memory and clean teardown.
+
+The Oxide path must produce the same greedy tokens and zero unregistered GPU
+provider hits. Numerical equality is contract-specific; bitwise equality is
+not assumed unless the contract requires it.
+
+## Neutral engine comparison
+
+The primary vLLM and SGLang comparison uses one repository-owned workload
+driver against each engine's OpenAI-compatible HTTP endpoint. A frozen JSONL
+trace supplies prompt token IDs, requested output lengths, arrival times, and
+request identifiers. This avoids ranking servers with different client-side
+load generation or tokenization.
+
+The official benchmark clients remain secondary reproduction checks:
+
+- vLLM documents `vllm bench serve`, `vllm bench throughput`, and
+  `vllm bench latency` in its benchmark CLI;
+- SGLang documents `python -m sglang.bench_serving` as the HTTP and scheduler
+  benchmark and recommends at least five times the maximum concurrency in
+  prompt count.
+
+Pinned references:
+
+- <https://github.com/vllm-project/vllm/blob/main/docs/benchmarking/cli.md>
+- <https://github.com/vllm-project/vllm/blob/main/benchmarks/README.md>
+- <https://github.com/sgl-project/sglang/blob/main/docs/developer_guide/bench_serving.md>
+- <https://github.com/sgl-project/sglang/blob/main/docs/developer_guide/benchmark_and_profiling.md>
+
+## Workload matrix
+
+Start with one identical model, BF16 weights, BF16 KV cache, one GPU, the same
+maximum context, greedy decoding, and no prefix cache or speculative decode.
+Use local model files so network and cache state cannot change a run.
+
+| Profile | Input / output tokens | Concurrency | Purpose |
+| --- | ---: | ---: | --- |
+| Interactive | 128 / 128 | 1, 4 | TTFT and decode latency |
+| Balanced | 1,024 / 256 | 1, 4, 16, 32 | common serving throughput |
+| Prefill-heavy | 8,192 / 256 | 1, 4, 8 | long-context prefill |
+| Long context | 32,768 / 256 | 1, 2 | memory and attention scaling |
+| Decode-heavy | 128 / 1,024 | 1, 8, 32 | KV and decode efficiency |
+| Mixed trace | fixed distribution of all rows | arrival-rate sweep | scheduler behavior and goodput |
+
+Run at least `5 * max_concurrency` requests after warmup and enough requests to
+stabilize p99. Sweep offered load rather than reporting only the saturation
+point.
+
+## Metrics
+
+Online records report:
+
+- time to first token (TTFT) p50, p95, and p99;
+- inter-token latency or time per output token p50, p95, and p99;
+- end-to-end request latency p50, p95, and p99;
+- request, input-token, output-token, and total-token throughput;
+- goodput under declared TTFT and inter-token SLOs;
+- error, cancellation, and timeout counts;
+- peak and steady device memory, KV utilization, and host CPU usage;
+- startup, weight-load, and artifact-load time separately from steady state.
+
+Offline records report prefill tokens per second, decode tokens per second,
+total tokens per second, per-step batch composition, peak memory, and Graph hit
+rate.
+
+## Fairness controls
+
+All three engines use:
+
+- the same GPU and exclusive host allocation;
+- the same local model and tokenizer file hashes;
+- the same dtype, KV dtype, maximum sequence length, and output token counts;
+- the same prefix-cache, speculation, quantization, and tensor-parallel policy;
+- fixed clocks or a recorded clock and power trace;
+- pinned engine commits and container digests;
+- identical warmup traces and a rotated engine run order;
+- no compilation, model download, or tuning in the steady-state interval.
+
+Engine-native optimizations may be enabled only in a separately named
+"best configured" cohort. The primary cohort isolates the core engine under
+matched semantics.
+
+## Competitive claim gate
+
+The first production-shaped claim requires all of the following on the frozen
+matrix:
+
+- complete correctness and provider-coverage gates;
+- no more than 10% regression in p50 TTFT, p50 inter-token latency, peak
+  memory, or saturated output throughput against both pinned engines;
+- at least one repeatable advantage outside the 5% noise band;
+- no p99, error-rate, or goodput regression hidden by an average;
+- results reproduced from a clean release artifact, not a development tree.
+
+This gate supports a "competitive Rust inference engine" claim. A claim that
+Oxide Infer is faster than vLLM or SGLang requires the named workloads and
+metrics to show that result; it is never generalized beyond the evidence.

--- a/docs/integrations/mistralrs.md
+++ b/docs/integrations/mistralrs.md
@@ -1,16 +1,24 @@
 # Mistral.rs integration
 
-The Mistral.rs adapter is an experimental paired-repository proof of concept.
-It stays in the Mistral.rs fork because the engine owns model execution, storage, streams, and forward lifecycle.
-Oxide Infer does not vendor, snapshot, or submodule the full engine.
+The current Mistral.rs adapter is an experimental paired-repository proof of
+concept. The accepted target imports the fork under `engine/mistralrs` with
+`git subtree` and replaces the paired operator adapter with one
+`OxidePipeline` full-model boundary. See the
+[target engine architecture](../design/tilelang-engine-architecture.md).
+
+Until that migration lands, the adapter stays in the separate Mistral.rs fork
+because the current engine owns model execution, storage, streams, and forward
+lifecycle. The current Oxide Infer tree does not yet vendor, snapshot,
+submodule, or subtree the full engine.
 
 ## Repository boundary
 
 Oxide Infer contains engine-neutral contracts, checked bindings, provider plans, stream handoff, and qualification rules.
 The Mistral.rs fork contains Candle storage adaptation, feature wiring, model-runner calls, completion drain, and raw integration evidence.
 
-This split keeps the operator API independent from one engine release cycle.
-It also lets the adapter change with Mistral.rs types without adding engine code to Oxide Infer.
+This split keeps the current operator API independent from one engine release
+cycle. The target replaces the split with a pinned subtree while keeping the
+fork diff localized to shell registration and `OxidePipeline` wiring.
 
 The historical records use these sources:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,388 +1,325 @@
 # Oxide Infer roadmap
 
-Oxide Infer is a Rust operator layer for LLM inference engines. The roadmap
-stabilizes the framework and current evidence before it expands the operator
-surface.
+Oxide Infer is migrating from a checked Rust GPU operator runtime to a complete
+Rust inference engine. The accepted target embeds a Mistral.rs control-plane
+shell, moves model execution and KV policy into Oxide, and uses TileLang as the
+only source language for product custom compute kernels.
 
-The complete target stays within `oxide-infer`, `oxide-infer-cuda`, and
-`oxide-infer-lab`. A fourth crate needs an independent dependency, artifact,
-safety, or release boundary.
+The current source still contains cuda-oxide and cuBLASLt execution paths and
+does not yet own a full model or server. Historical evidence remains valid only
+for its recorded source and provider. It does not transfer to the new engine.
 
-## Global admission rules
+The [target architecture](design/tilelang-engine-architecture.md) defines
+ownership. The [engine benchmark plan](development/engine-benchmark-plan.md)
+defines how kernel and serving claims are admitted.
 
-Every new vertical slice needs a real consumer or measured workload. A design
-idea alone does not justify a public API or empty module.
+## Global rules
+
+Every phase produces one usable vertical slice. Planned names do not justify
+empty modules, manifests, or public APIs.
+
+### Supported fast path
+
+An admitted product model must execute all GPU computation through registered
+TileLang artifacts. It cannot silently use Candle CUDA, FlashInfer, cuBLASLt,
+CUTLASS, Triton, handwritten CUDA, or cuda-oxide.
+
+CUDA Driver APIs, CUDA Graph APIs, and NCCL are infrastructure interfaces, not
+compute-kernel providers. Every request records provider and artifact hits so
+that the rule is testable.
 
 ### Contract gate
 
-Before CUDA work starts, record:
+Before kernel work starts, record:
 
-- engine call site and tensor roles
-- shape, dtype, layout, masking, and post-operations
-- numerical and determinism limits
-- alias, workspace, page-table, and stream ownership
-- independent CPU reference or external oracle
-- unsupported cases and typed errors
+- model call site and tensor roles;
+- shape, dtype, layout, masking, and post-operations;
+- numerical and determinism limits;
+- alias, workspace, page-table, and stream ownership;
+- an independent CPU or framework reference;
+- unsupported cases and typed errors;
+- the model-census frequency and expected engine impact.
 
-### Provider gate
+### Artifact gate
 
-Every provider exposes one named algorithm through this lifecycle:
+Every promoted kernel has:
 
-```text
-Spec -> Provider -> Algorithm -> Plan -> Operands -> CommandScope -> Completion
-```
+- one named contract and algorithm;
+- pinned TileLang, CUDA, and target identities;
+- a fixed ABI, launch geometry, workspace, and shape domain;
+- a cubin or PTX hash and generated manifest;
+- correctness, sentinel, lifetime, and applicable sanitizer evidence;
+- fixed-address CUDA Graph proof or an explicit exclusion;
+- a matched performance record with balanced provider order.
 
-Planning fixes provider, algorithm, artifact, workspace, launch, and Graph
-policy. Enqueue cannot tune, switch providers, or fall back.
+Runtime enqueue cannot compile, tune, allocate hidden workspace, switch
+algorithms, or fall back.
 
-### Device gate
+### Model gate
 
-An admitted device algorithm needs:
+A supported model needs:
 
-- positive and negative host cases
-- device correctness with sentinels
-- asynchronous lifetime and completion tests
-- Compute Sanitizer for all applicable tools
-- artifact hash and target identity
-- SASS and spill review for a performance candidate
-- fixed-address Graph proof or an explicit exclusion
-
-### Performance gate
-
-Performance records need identical fixtures, contracts, and timed boundaries.
-Run each provider order separately. Reject a ranking when order drift exceeds
-the recorded stability limit.
-
-Operator speed alone does not promote an engine route. Measure TTFT, TPOT,
-throughput, and memory in the real consumer path.
+- direct weight loading into Oxide-owned storage;
+- one immutable prefill plan and one immutable decode plan;
+- paged KV allocation and mutation owned by Oxide;
+- deterministic output comparison with a pinned reference;
+- provider-hit coverage for every GPU operation;
+- cancellation, invalid-input, out-of-memory, and teardown recovery;
+- peak-memory, offline throughput, and serving evidence.
 
 ### Release gate
 
-A stable public surface needs:
+A release is built from pinned kernel artifacts. It contains no Python runtime,
+compiler, tuner, model weights, generated caches, or unregistered kernel path.
+All current claims link to source-bound evidence from that release candidate.
 
-- current-source evidence for each claimed target
-- no compatibility alias or duplicate execution path
-- complete API and safety documentation
-- one external engine integration at a pinned version
-- package contents, CI, and installation checks
+## F0: Preserve the operator foundation
 
-## R0: Rename and normalize the framework
+**State:** complete historical foundation.
 
-**State:** complete.
+Completed work includes:
 
-The rename changes current identifiers to Oxide Infer. Historical records,
-tags, and commit links keep their original names.
+- the Oxide Infer rename and contract normalization;
+- checked resources, command scopes, completion lifetimes, and stream handoff;
+- BF16 attention, KV append, RMSNorm, RoPE, and GEMM source paths;
+- current-source H20 correctness, Graph, and sanitizer qualification;
+- matched FlashInfer attention records;
+- a stopped native M=1 GEMV experiment with immutable evidence;
+- a Mistral.rs paged-decode proof of concept;
+- a fixed-shape TileLang paged-prefill admission spike.
 
-Work:
+The first TileLang spike measured 31.83 microseconds against 47.01
+microseconds for the current Oxide path and 25.90 microseconds for FlashInfer
+on its exact fixed shape. It admits the toolchain for further work, not a
+production provider or full migration performance claim.
 
-- Rename the repository and three crates to `oxide-infer`,
-  `oxide-infer-cuda`, and `oxide-infer-lab`.
-- Rename the native provider to `Oxide`.
-- Rename current CLI programs and environment variables to `oxide_*` and
-  `OXIDE_*`.
-- Keep old result JSON files byte-for-byte unchanged.
-- Use the final operator families: attention, GEMM, KV cache, normalization,
-  position, activation, sampling, speculation, quantization, MoE, and
-  communication.
-- Move implemented domains directly to their final namespaces.
-- Rename remaining `*Args` types to `*Operands` without aliases.
-- Keep one public execution path per operator.
-- Keep runtime memory, command, status, Graph, driver, and interop code inside
-  `oxide-infer-cuda`.
+Historical cuda-oxide, cuBLASLt, and adapter results stay readable. They are
+baselines and design input, not target-engine qualification.
 
-Exit gate:
-
-- All current source, Cargo metadata, CI, tools, website, and live docs use the
-  new identifiers.
-- Historical provenance remains readable and unmodified.
-- Host tests, strict Clippy, formatting, documentation links, and package
-  checks pass.
-- No empty family, architecture, or provider module exists.
-
-## R1: Requalify current source
+## E0: Freeze the engine decision
 
 **State:** complete.
 
-The phase 2 device record binds clean source `477b47a`, all nine permanent
-`sm_90a` runners, 89 machine-readable passing case lines, 12 named Graph case
-lines, and 36 of 36 Compute Sanitizer cells. The record names its H20 test host;
-that hardware identity is evidence scope, not the project identity. Performance
-and real-model engine claims remain outside R1.
-
-The rename and namespace migration change source identity. Historical device
-records do not qualify the new tree.
-
 Work:
 
-- Requalify RMSNorm, RoPE, dense cuBLASLt GEMM, decode, prefill, and fused
-  append on the declared device target.
-- Cover host errors, device correctness, sentinels, lifecycle, and resource
-  recovery.
-- Run memcheck, racecheck, synccheck, and initcheck over permanent runners.
-- Rebuild fixed-address Graph records with poisoned outputs and lease checks.
-- Record the exact `sm_90a` artifact and source hashes.
-- Keep engine evidence separate from the simulated-engine gate.
+- accept the Mistral.rs shell, Oxide data plane, and TileLang-only kernel rule;
+- separate current source facts from target statements;
+- freeze the target repository and ownership boundaries;
+- define the FlashInfer, vLLM, and SGLang evidence protocol;
+- remove obsolete Loom and cuda-oxide installations and global Cargo redirects
+  from the development host without deleting historical evidence;
+- choose the first complete model profile and non-goals.
 
 Exit gate:
 
-- Each current operator has one reviewed device correctness record for the renamed
-  source or an explicit source-level exclusion.
-- Each performance-relevant plan has sanitizer and Graph evidence or a written
-  exclusion.
-- Dynamic metadata rejection preserves outputs and leaves the queue reusable.
-- Paged append passes the exclusive-target-page contract.
+- design, repository layout, benchmark plan, and roadmap agree;
+- current docs do not claim the target is implemented;
+- the first profile is BF16 Qwen2.5-1.5B on one NVIDIA GPU;
+- implementation work can proceed without another provider-boundary decision.
 
-## R2: Performance baseline and native M=1 GEMV decision
+## E1: Build the TileLang artifact boundary
 
-**State:** active; the frozen native M=1 GEMV decision is complete with a stop.
+**State:** planned.
 
-The first current-source matched baseline covers 14 BF16 attention shapes
-against FlashInfer 0.6.17. All 14 pass the provider-order stability gate;
-Oxide has lower combined median eager latency in eight and FlashInfer in six.
-The current paged long-context GQA4 path measures 46.60 microseconds against
-FlashInfer at 23.21 microseconds, a 2.01x gap on that exact eager contract. In
-the separate source cohort it is 18.45% lower latency than source `49290b5`.
-The current ragged optimization reduces its
-source-bound parent from 39.42 to 37.04 microseconds. In the separate matched
-provider cohort, Oxide measures 36.94 microseconds and FlashInfer 21.93
-microseconds, a 1.68x gap.
-
-The current native candidate is `OxideSm90SimtGemvM1N16K64`. It admits BF16
-`M=1`, `N % 16 = 0`, `K % 64 = 0`, no post-operation, and zero workspace on
-the currently recorded `sm_90a` target. Its matched decision run passed the
-10% margin against both Mistral.rs custom GEMV and cuBLASLt on only one of five
-declared shapes. Four shapes triggered the stop gate, so it remains
-experimental and `CublasLtHeuristic` remains selected.
+This phase establishes the product kernel supply chain before translating the
+whole operator catalog.
 
 Work:
 
-- Continue reducing the long ragged and paged GQA4 prefill gaps without
-  regressing the current short paths.
-- Keep eager-provider, Graph, engine, and serving measurements separate.
-- Retain the five-shape census and the stopped algorithm identity as immutable
-  evidence; do not add shape-aware production routing for it.
-- Give any new M=1 design or larger-M experiment a new algorithm identity and
-  workload census.
+- move the current spike into `kernels/tilelang` build tooling;
+- define a versioned artifact manifest and parameter ABI;
+- compile fixed schedules into cubin or PTX outside the Rust server;
+- add hash, target, driver, shape, dtype, layout, and alignment validation;
+- load and launch the first artifact through the checked Rust CUDA runtime;
+- retain stream, memory, Graph, status, and completion safety from the current
+  runtime without retaining cuda-oxide device compilation;
+- package an artifact into a clean release and load it with no Python present.
 
-Promotion gate:
+First vertical slice:
 
-- Every declared shape has at least 10% lower combined median latency than
-  each baseline.
-- Provider-order median drift is at most 5%.
-- No spill, local-memory regression, overread, overwrite, Graph failure, or
-  lease failure occurs.
-- TPOT and throughput improve beyond measured engine noise.
+- BF16 paged prefill for the existing batch-2 long GQA4 contract;
+- same inputs, outputs, stream, and timed interval as the FlashInfer record;
+- eager and fixed-address Graph execution;
+- typed rejection for incompatible artifacts and unsupported shapes.
+
+Exit gate:
+
+- one immutable artifact passes correctness, sanitizer, lifecycle, Graph, and
+  matched performance gates;
+- the release loader detects a changed hash, ABI, or target before launch;
+- the serving-process dependency graph contains no TileLang or Python package;
+- enqueue performs no JIT, tuning, hidden allocation, or fallback.
+
+## E2: Complete one Oxide model data plane
+
+**State:** planned.
+
+Work:
+
+- add `oxide-infer-engine` with model IR, execution plans, KV pager, and
+  sampling state;
+- load safetensors directly into Oxide-owned storage;
+- implement TileLang artifacts for embedding, RMSNorm, RoPE, dense GEMM,
+  SwiGLU, residuals, paged attention, KV append, logits, and greedy sampling;
+- derive the admitted GEMM matrix from the recorded model shape census;
+- build immutable prefill and decode plans;
+- record every artifact hit and reject incomplete coverage at startup;
+- add cancellation, invalid page, out-of-memory, and clean-teardown tests.
+
+Exit gate:
+
+- Qwen2.5-1.5B BF16 generates the same greedy token IDs as the pinned reference
+  over the declared prompt matrix;
+- provider telemetry reports only registered TileLang artifacts for GPU
+  computation;
+- the path uses no Candle CUDA tensor or kernel and no old provider fallback;
+- peak memory, prefill throughput, decode throughput, and Graph hit rate are
+  recorded;
+- all critical kernel rows meet the first-release promotion policy or have a
+  measured engine-level admission reason.
+
+## E3: Embed the Mistral.rs shell
+
+**State:** planned.
+
+Work:
+
+- import the pinned fork under `engine/mistralrs` with `git subtree`;
+- exclude its Cargo workspace from the Oxide root workspace;
+- add one `OxidePipeline` implementation at the full-model forward boundary;
+- reuse HTTP routes, streaming, tokenization, chat templates, request
+  lifecycle, and continuous-batch scheduling;
+- translate scheduler batches into `EngineBatch` and results into
+  `EngineResult` without exposing Candle GPU storage;
+- add an `oxide-production` profile that fails closed and a separate
+  `mistral-reference` test profile;
+- document and automate subtree upstream sync.
+
+Exit gate:
+
+- the production profile serves the E2 model through the OpenAI-compatible
+  endpoint;
+- a complete request has zero Candle CUDA, FlashInfer, cuBLASLt, cuda-oxide,
+  and unregistered provider hits;
+- the shell boundary issues no device-to-device copy;
+- streaming, cancellation, malformed requests, and engine failures settle all
+  resources and keep the server reusable;
+- the maintained fork diff is localized to pipeline registration, adapter
+  wiring, and build configuration.
 
 Stop gate:
 
-- A safety failure removes the artifact from selectable plans until full
-  requalification.
-- A performance failure keeps the algorithm experimental. `CublasLt` remains
-  the selected production plan.
-- A larger-M WGMMA experiment gets a new algorithm identity and workload
-  census. It cannot modify this frozen algorithm.
+- if support requires edits distributed through Mistral.rs model layers, move
+  the missing behavior into the Oxide pipeline or data plane before proceeding;
+- if the subtree cannot be updated independently of feature changes, repair
+  the import process before adding model coverage.
 
-Exit gate:
-
-- The frozen M=1 algorithm exited through its recorded stop result; retain the
-  vendor route.
-
-## R3: Stabilize engine adapters
-
-**State:** experimental paired-repository work exists.
-
-The consumer engine owns model execution, scheduling, batching, KV policy,
-sampling, and serving. The adapter owns type conversion and stream handoff.
-
-Work:
-
-- Requalify the Mistral.rs decode path against renamed source.
-- Bind engine allocations through typed external regions.
-- Use the engine's non-default CUDA stream without adopting it.
-- Prove that Q, KV, output, workspace, and metadata cross no adapter device
-  copy.
-- Record provider hits and algorithm identities.
-- Compare model outputs or selected tokens with the engine baseline.
-- Define fail-closed behavior for panic and abandoned forward execution.
-- Replace local path dependencies with immutable source identities.
-- Define a checked C ABI only when a non-Rust engine needs it.
-
-Mistral.rs exit gate:
-
-- At least two model configurations pass output, no-copy, stream-order,
-  completion, and typed-recovery checks.
-- The adapter has no process-global runtime state.
-- The complete engine interval has TTFT, TPOT, throughput, and memory records.
-
-vLLM admission gate:
-
-- The Rust API and any C ABI have a versioned ownership contract.
-- Pin one vLLM release and one attention or linear call site.
-- The adapter remains outside the three core crates.
-- PyTorch and vLLM types do not enter `oxide-infer` or
-  `oxide-infer-cuda`.
-
-vLLM exit gate:
-
-- A real vLLM request records provider hits, unchanged tensor addresses,
-  current-stream ordering, output comparison, and clean teardown.
-- The adapter defines behavior for unsupported shapes without native-provider
-  fallback during enqueue.
-- Engine-level performance exceeds measured noise before a speed claim.
-
-## R4: Complete attention and KV-cache contracts
-
-**State:** current narrow contracts, broader work planned.
-
-Work:
-
-- Requalify direct, split-K, token-parallel, and tiled attention algorithms.
-- Add paged-decode and split-K fixed-address Graph coverage.
-- Replace average-only ragged selection with measured shape classes when data
-  supports the change.
-- Add sliding-window attention from a pinned engine call site.
-- Add broader head dimensions and page sizes from measured model demand.
-- Scope mixed-batch attention from the engine scheduler contract.
-- Scope MLA from one exact model and cache layout.
-- Add KV gather, scatter, compaction, and remapping after pager ownership is
-  fixed.
-
-Attention admission gate:
-
-- The engine trace fixes mask, layout, head mapping, sequence distribution,
-  and workspace requirements.
-- The independent reference covers the exact contract.
-- The plan selects one named algorithm before enqueue.
-
-KV mutation admission gate:
-
-- Specify read sharing, write ownership, copy-on-write owner, metadata epoch,
-  and completion lifetime first.
-- A failure preserves all cache pages and returns the writable capability.
-
-Exit gate:
-
-- Each new contract passes current-source correctness, lifecycle, sanitizer,
-  Graph, matched performance, and one engine invocation where applicable.
-- The catalog contains no generic claim beyond recorded shape classes.
-
-## R5: Add activation, sampling, and speculation
-
-**State:** planned.
-
-Activation work:
-
-- Start with a measured SwiGLU or gated-activation call.
-- Define a standalone contract and reference before fusion.
-- Fuse RMSNorm, GEMM, bias, or activation only when the complete path wins.
-
-Sampling work:
-
-- Define logits dtype, transforms, penalties, Top-K, Top-P, Min-P, logprobs,
-  and output ordering.
-- Bind deterministic RNG state to request and token position.
-- Test finite behavior, ties, degenerate distributions, and reproducibility.
-
-Speculation work:
-
-- Define draft and target token spans.
-- Bind accepted-token count, pending token, RNG state, and grammar state in one
-  commit contract.
-- Cover greedy, stochastic, and tree verification separately.
-
-Exit gate:
-
-- Each family starts with one real engine call and no empty sibling modules.
-- Sampling matches its declared deterministic or statistical limits.
-- Speculative decoding preserves baseline token output or the declared
-  stochastic distribution.
-- Engine TPOT improves beyond measured noise.
-
-## R6: Add quantization and MoE
-
-**State:** planned.
-
-Quantization work:
-
-- Pin scale granularity, packing format, zero-point policy, accumulator type,
-  and quality limit.
-- Add conversion and dequantization before fused compute.
-- Keep FP8 and FP4 native kernels out until cuda-oxide supports the required
-  types and instructions or the project contributes that support upstream.
-
-MoE work:
-
-- Pin routing, capacity, permutation, expert input, and weighted-combine
-  semantics.
-- Add grouped GEMM only after the routing trace fixes expert size
-  distributions.
-- Keep dense, grouped, and quantized GEMM as separate contracts.
-
-Exit gate:
-
-- Quantized outputs pass numerical and model-quality limits.
-- Grouped GEMM passes per-expert correctness and end-to-end MoE output checks.
-- Native and vendor providers use one plan and command lifecycle per contract.
-- Real-engine throughput and memory improve beyond measured noise.
-
-## R7: Add hardware targets
-
-**State:** `sm_90a` is current. Future work targets `sm_100a` and `sm_120`.
-
-Work:
-
-- Keep H20 `sm_90a` as the first qualified architecture row.
-- Add `sm_100a` as a separate provider artifact and evidence row.
-- Add `sm_120` only from a measured consumer workload.
-- Give TMA, WGMMA, and tcgen05 matrix algorithms stable names.
-- Publish hashes for every admitted PTX or cubin.
-- Reject incompatible devices before module load.
-
-Target admission gate:
-
-- Hardware is available for correctness, sanitizer, SASS, Graph, and
-  performance work.
-- cuda-oxide supports every required type and instruction with a pinned
-  revision.
-- One engine workload justifies the target-specific algorithm.
-
-Exit gate:
-
-- Each architecture has independent host, device, sanitizer, Graph,
-  performance, and engine rows.
-- No target inherits qualification from PTX forward compatibility.
-- No empty `sm100` or `sm120` directory exists.
-
-## R8: Add communication and release a stable API
+## E4: Qualify scheduling and serving behavior
 
 **State:** planned.
 
 Work:
 
-- Start collectives from one measured tensor-parallel or expert-parallel
-  workload.
-- Define communicator ownership, stream order, topology, timeout, failure, and
-  recovery boundaries.
-- Use an explicit vendor provider unless a measured native alternative exists.
-- Stabilize the Rust API after the first production-shaped engine adapter.
-- Audit package contents, CI targets, documentation, and registry access.
+- connect continuous batches to Oxide prefill and decode plans;
+- implement paged KV allocation, sharing, copy-on-write, eviction, and
+  compaction in the Oxide engine;
+- qualify mixed prefill/decode batches and dynamic sequence completion;
+- add fixed-address decode Graph pools with explicit miss behavior;
+- measure prefix caching in a separate, named cohort;
+- add request admission, memory watermarks, backpressure, and overload errors;
+- expose provider, artifact, batch, KV, Graph, and latency telemetry.
 
-Communication exit gate:
+Exit gate:
 
-- Multi-GPU correctness covers ordering, partial failure, and teardown.
-- Performance uses the same topology and payload distribution as the engine.
-- A collective failure cannot release live device resources early.
+- concurrency sweeps preserve token correctness and request isolation;
+- cancellation and overload do not leak pages, events, graphs, or buffers;
+- Graph misses and unsupported batch shapes return to a registered eager
+  TileLang plan, not another provider;
+- p50, p95, and p99 latency, throughput, goodput, memory, and errors are
+  recorded over the frozen workload matrix.
 
-Stable release exit gate:
+## E5: Compare and make the first competitive claim
 
-- All documented current rows have current-source evidence.
-- Public names follow one lifecycle and final family namespaces.
-- The release contains no experimental default selection or silent fallback.
-- A clean downstream install and one pinned engine integration pass.
+**State:** planned.
+
+Kernel work:
+
+- compare admitted attention, KV, sampling, and applicable GEMM contracts with
+  pinned FlashInfer;
+- keep the same tensors, metadata, stream, outputs, and timed boundary;
+- publish raw balanced-order samples and artifact hashes.
+
+Engine work:
+
+- run one neutral OpenAI-compatible trace against Oxide Infer, vLLM, and
+  SGLang;
+- pin identical local model and tokenizer files, dtype, KV dtype, maximum
+  context, sampling, cache, and speculation settings;
+- cover interactive, balanced, prefill-heavy, long-context, decode-heavy, and
+  mixed-arrival workloads;
+- publish TTFT, inter-token latency, end-to-end latency, token throughput,
+  SLO goodput, peak memory, CPU usage, and error rates;
+- reproduce secondary runs with the official vLLM and SGLang benchmark clients.
+
+Exit gate:
+
+- all correctness and provider-coverage gates pass;
+- no primary p50 latency, peak-memory, or saturated-throughput metric regresses
+  by more than 10% against either pinned engine;
+- at least one useful metric wins beyond the 5% noise band;
+- p99, goodput, and error rates do not invalidate the average result;
+- a clean release artifact reproduces the record.
+
+The first acceptable wording is "competitive Rust inference engine" for the
+named profile. A general "faster than vLLM and SGLang" claim requires broader
+workloads and hardware and is not implied by this phase.
+
+## E6: Remove transitional providers
+
+**State:** planned after E2 and E3 evidence.
+
+Work:
+
+- remove cuda-oxide from Cargo manifests, lockfiles, build scripts, and CI;
+- remove product cuBLASLt and native-provider implementations;
+- move any still-useful current provider code to immutable historical tags,
+  not a disabled production fallback;
+- replace current environment and CUDA validation documents with the TileLang
+  artifact toolchain;
+- remove legacy Mistral operator-adapter feature paths;
+- retain old JSON evidence unchanged and label its source as historical.
+
+Exit gate:
+
+- repository searches find no live product dependency or build command for
+  cuda-oxide, cuBLASLt, or the paired operator adapter;
+- the clean release builds, tests, and serves without those toolchains present;
+- historical records and links remain understandable;
+- the product has exactly one registered custom compute-kernel source:
+  TileLang.
+
+## E7: Expand only from measured demand
+
+**State:** planned after the first competitive release.
+
+Candidate order:
+
+1. larger dense Llama, Qwen, and Mistral profiles using the same IR;
+2. FP8 or weight-only quantization with explicit quality gates;
+3. prefix caching and speculative decoding;
+4. MLA and one measured MoE model with grouped GEMM;
+5. tensor parallelism and NCCL lifecycle qualification;
+6. additional NVIDIA architecture artifacts with independent evidence;
+7. multimodal models only after their preprocessing and GPU contracts fit the
+   same fail-closed boundary.
+
+Each addition repeats contract, artifact, model, serving, and release gates.
+Mistral.rs feature breadth does not automatically become Oxide product
+coverage.
 
 ## Evidence rule
 
 Every result states its contract, source, provider, algorithm, artifact,
 hardware, timed region, accepted claims, and excluded claims. Reviewed records
 remain immutable. A faster kernel never proves a faster model or server by
-itself.
+itself, and a target design never changes the state of current source.

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -89,9 +89,9 @@ export const evidenceLevels = [
 ]
 
 export const milestones = [
-  { milestone: "NOW", name: "Optimize measured gaps", reason: "Long-context GQA prefill is the clearest current bottleneck." },
-  { milestone: "NEXT", name: "Close one engine adapter", reason: "Measure provider hits, output parity, TTFT, TPOT, throughput, and memory." },
-  { milestone: "THEN", name: "Expand measured contracts", reason: "Add operators only after a workload census and explicit evidence gate." },
+  { milestone: "NOW", name: "Freeze the artifact boundary", reason: "Load one immutable TileLang cubin through the checked Rust runtime." },
+  { milestone: "NEXT", name: "Complete one model data plane", reason: "Run Qwen2.5-1.5B without Candle CUDA or a silent provider fallback." },
+  { milestone: "THEN", name: "Embed and benchmark the server", reason: "Wire one OxidePipeline, then compare kernels and complete serving workloads." },
 ]
 
 export const performanceSummary = [

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -11,10 +11,11 @@ import { executionStages, repositoryUrl } from "../../data/site";
 >
   <header class="page-hero">
     <p class="eyebrow">Documentation / Start</p>
-    <h1>Start at the operator boundary.</h1>
+    <h1>Start with the engine boundary.</h1>
     <p>
-      Oxide Infer owns planning, GPU submission, and completion. The engine
-      retains its model graph, scheduler, request lifecycle, and distributed policy.
+      Current source is an operator runtime. The accepted target combines a
+      Mistral.rs control plane, an Oxide data plane, and offline TileLang
+      kernel artifacts into one Rust inference engine.
     </p>
   </header>
 
@@ -24,22 +25,32 @@ import { executionStages, repositoryUrl } from "../../data/site";
       <h2>Read in this order</h2>
       <div class="doc-grid">
         <div class="doc-card">
-          <span>01 / DESIGN</span><h3>Architecture</h3>
-          <p>Review ownership, planning, submission, and completion.</p>
-          <a href={`${repositoryUrl}/blob/main/docs/design/oxide-infer-architecture.md`}>Open architecture →</a>
+          <span>01 / TARGET</span><h3>Engine architecture</h3>
+          <p>Review Mistral.rs, Oxide, TileLang, and fail-closed ownership.</p>
+          <a href={`${repositoryUrl}/blob/main/docs/design/tilelang-engine-architecture.md`}>Open target architecture →</a>
         </div>
         <div class="doc-card">
-          <span>02 / SURFACE</span><h3>Operator catalog</h3>
+          <span>02 / CURRENT</span><h3>Operator architecture</h3>
+          <p>Inspect the transitional source that the engine plan will replace.</p>
+          <a href={`${repositoryUrl}/blob/main/docs/design/oxide-infer-architecture.md`}>Open current architecture →</a>
+        </div>
+        <div class="doc-card">
+          <span>03 / BENCHMARK</span><h3>Engine evidence</h3>
+          <p>Compare kernels with FlashInfer and serving with vLLM and SGLang.</p>
+          <a href={`${repositoryUrl}/blob/main/docs/development/engine-benchmark-plan.md`}>Open benchmark plan →</a>
+        </div>
+        <div class="doc-card">
+          <span>04 / SURFACE</span><h3>Operator catalog</h3>
           <p>Check admitted dtypes, layouts, algorithms, and open gates.</p>
           <a href={`${repositoryUrl}/blob/main/docs/operator-catalog.md`}>Open catalog →</a>
         </div>
         <div class="doc-card">
-          <span>03 / PROOF</span><h3>Evidence index</h3>
+          <span>05 / PROOF</span><h3>Evidence index</h3>
           <p>Inspect source revisions, methods, raw samples, and exclusions.</p>
           <a href={`${repositoryUrl}/blob/main/docs/results/README.md`}>Open evidence →</a>
         </div>
         <div class="doc-card">
-          <span>04 / DEVICE</span><h3>Device validation</h3>
+          <span>06 / DEVICE</span><h3>Device validation</h3>
           <p>Run correctness, sanitizer, Graph, and performance gates separately. The current recorded target is H20.</p>
           <a href={`${repositoryUrl}/blob/main/docs/development/h20-validation.md`}>Open validation guide →</a>
         </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -219,8 +219,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 
   <section class="section roadmap-section" id="roadmap">
     <header class="section-heading">
-      <div><p class="eyebrow">Roadmap</p><h2>Close evidence gates in order.</h2></div>
-      <p>More surface follows current qualification, one real adapter, and measured serving impact.</p>
+      <div><p class="eyebrow">Engine roadmap</p><h2>Complete one model before adding breadth.</h2></div>
+      <p>The accepted target uses a Mistral.rs shell, an Oxide data plane, and offline TileLang artifacts.</p>
     </header>
     <div class="milestone-list">
       {milestones.map((item) => (


### PR DESCRIPTION
## What changed

- accept the target product architecture: Mistral.rs control-plane shell, Oxide-owned model/KV data plane, and TileLang as the only product custom compute-kernel source
- define a single full-model `OxidePipeline` boundary instead of replacing Candle operators one by one
- define offline cubin/PTX artifacts, versioned manifests, runtime hash/ABI checks, and fail-closed provider coverage
- define the target monorepo layout, including a pinned Mistral.rs git subtree and a justified `oxide-infer-engine` crate
- replace the adapter-oriented roadmap with complete model, scheduling, serving, comparison, and legacy-provider removal phases
- add a matched kernel benchmark plan against FlashInfer and a neutral OpenAI-compatible engine benchmark against vLLM and SGLang
- update documentation and website entry points while keeping current operator source and historical evidence clearly labeled as transitional

## Why

The existing operator-layer architecture could validate isolated providers but did not define a maintainable route to a complete inference engine. The new boundary keeps the Mistral.rs fork diff small, makes complete TileLang coverage auditable, removes silent mixed-provider execution, and separates kernel performance from serving performance claims.

This PR is stacked on the TileLang admission spike in #122. It describes the accepted target and migration gates; it does not claim that the current source already implements the engine.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets` (59 tests)
- `cargo check --workspace --release`
- `cargo package -p oxide-infer --allow-dirty`
- `make check-tools` (26 tests)
- `npm --prefix website ci --include=dev`
- `npm --prefix website run check`
- `npm --prefix website run build`
- `npm --prefix website audit` (0 vulnerabilities)
