### PR TITLE
Add checked TileLang artifact ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,9 @@ dependencies = [
  "cudarc",
  "half",
  "oxide-infer",
+ "serde",
+ "serde_json",
+ "sha2",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ homepage = "https://feichai0017.github.io/oxide-infer/"
 half = "2.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "2.0"
 
 [workspace.lints.rust]

--- a/crates/oxide-infer-cuda/Cargo.toml
+++ b/crates/oxide-infer-cuda/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Rust CUDA kernels for Oxide Infer, compiled with cuda-oxide"
+description = "Checked CUDA runtime and artifact launcher for Oxide Infer"
 readme = "README.md"
 publish = false
 
@@ -16,6 +16,9 @@ cuda = ["dep:cuda-core", "dep:cuda-device", "dep:cuda-host", "dep:cudarc"]
 [dependencies]
 half.workspace = true
 oxide-infer = { path = "../oxide-infer" }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 cuda-core = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "868f8ec4ef900bae7e67e7f9508b2da66eee5472", optional = true }
 cuda-device = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "868f8ec4ef900bae7e67e7f9508b2da66eee5472", optional = true }

--- a/crates/oxide-infer-cuda/src/artifact.rs
+++ b/crates/oxide-infer-cuda/src/artifact.rs
@@ -902,9 +902,11 @@ mod tests {
 
     #[test]
     fn rejects_changed_artifact_bytes_and_size() {
-        let hash_error = manifest()
-            .verify(b"oxide tile artifacU".to_vec(), &device())
-            .unwrap_err();
+        let mut changed_bytes = ARTIFACT_BYTES.to_vec();
+        *changed_bytes
+            .last_mut()
+            .expect("the artifact fixture must not be empty") ^= 1;
+        let hash_error = manifest().verify(changed_bytes, &device()).unwrap_err();
         assert!(matches!(
             hash_error,
             TileArtifactError::ArtifactHashMismatch { .. }

--- a/crates/oxide-infer-cuda/src/artifact.rs
+++ b/crates/oxide-infer-cuda/src/artifact.rs
@@ -1,0 +1,1060 @@
+//! Versioned, fail-closed contracts for offline TileLang artifacts.
+//!
+//! This module deliberately has no CUDA dependency. Artifact selection and
+//! validation happen before bytes are passed to the CUDA driver.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{Display, Formatter, Write as _};
+use std::path::{Component, Path};
+use thiserror::Error;
+
+pub const TILE_ARTIFACT_SCHEMA_VERSION: u32 = 1;
+pub const TILE_LAUNCH_ABI_VERSION: u32 = 1;
+pub const OXIDE_TILE_PROVIDER: &str = "oxide_tile";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TileArtifactManifest {
+    pub schema_version: u32,
+    pub provider: String,
+    pub contract: ContractIdentity,
+    pub algorithm: String,
+    pub artifact: ArtifactDescriptor,
+    pub toolchain: TileToolchain,
+    pub target: CudaTarget,
+    pub launch_abi_version: u32,
+    pub entry_points: Vec<KernelEntryPoint>,
+    pub numerics: NumericalContract,
+    pub qualification: QualificationRecords,
+    #[serde(default)]
+    pub properties: BTreeMap<String, String>,
+    #[serde(default)]
+    pub dimensions: BTreeMap<String, DimensionConstraint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContractIdentity {
+    pub name: String,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDescriptor {
+    pub file_name: String,
+    pub format: ArtifactFormat,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactFormat {
+    Cubin,
+    Ptx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TileToolchain {
+    pub tilelang_version: String,
+    pub source_revision: String,
+    pub cuda_toolkit_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CudaTarget {
+    pub architecture: String,
+    pub minimum_driver: CudaVersion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CudaVersion {
+    pub major: u16,
+    pub minor: u16,
+    #[serde(default)]
+    pub patch: u16,
+}
+
+impl Display for CudaVersion {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KernelEntryPoint {
+    pub symbol: String,
+    pub parameters: Vec<KernelParameter>,
+    #[serde(default)]
+    pub allowed_aliases: Vec<AllowedAlias>,
+    pub launch: LaunchRequirements,
+    pub workspace: WorkspaceRequirement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AllowedAlias {
+    pub first: String,
+    pub second: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LaunchRequirements {
+    pub grid_dimensions: [u32; 3],
+    pub block_dimensions: [u32; 3],
+    #[serde(default)]
+    pub cluster_dimensions: Option<[u32; 3]>,
+    #[serde(default)]
+    pub dynamic_shared_memory_bytes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KernelParameter {
+    pub name: String,
+    pub parameter_type: KernelParameterType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum KernelParameterType {
+    DevicePointer {
+        element: String,
+        access: AccessMode,
+        alignment: u32,
+    },
+    Scalar {
+        scalar: ScalarType,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessMode {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScalarType {
+    U32,
+    U64,
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceRequirement {
+    pub bytes: u64,
+    pub alignment: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DimensionConstraint {
+    pub min: u64,
+    pub max: u64,
+    pub multiple_of: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NumericalContract {
+    pub accumulation: String,
+    pub output: String,
+    pub determinism: Determinism,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Determinism {
+    Required,
+    NotRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QualificationRecords {
+    pub correctness: String,
+    pub sanitizer: String,
+    pub graph: String,
+    pub benchmark: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceCompatibility {
+    pub architecture: String,
+    pub driver: CudaVersion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactRequest {
+    pub contract: String,
+    pub contract_version: u32,
+    pub algorithm: String,
+    pub architecture: String,
+    pub properties: BTreeMap<String, String>,
+    pub dimensions: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VerifiedTileArtifact {
+    manifest: TileArtifactManifest,
+    bytes: Vec<u8>,
+}
+
+impl VerifiedTileArtifact {
+    #[must_use]
+    pub fn manifest(&self) -> &TileArtifactManifest {
+        &self.manifest
+    }
+
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TileArtifactRegistry {
+    artifacts: BTreeMap<ArtifactKey, VerifiedTileArtifact>,
+}
+
+impl TileArtifactManifest {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, TileArtifactError> {
+        let manifest: Self = serde_json::from_slice(bytes)
+            .map_err(|error| TileArtifactError::InvalidJson(error.to_string()))?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> Result<(), TileArtifactError> {
+        if self.schema_version != TILE_ARTIFACT_SCHEMA_VERSION {
+            return Err(TileArtifactError::UnsupportedSchema {
+                found: self.schema_version,
+                supported: TILE_ARTIFACT_SCHEMA_VERSION,
+            });
+        }
+        if self.provider != OXIDE_TILE_PROVIDER {
+            return Err(TileArtifactError::UnsupportedProvider {
+                found: self.provider.clone(),
+            });
+        }
+        if self.launch_abi_version != TILE_LAUNCH_ABI_VERSION {
+            return Err(TileArtifactError::UnsupportedLaunchAbi {
+                found: self.launch_abi_version,
+                supported: TILE_LAUNCH_ABI_VERSION,
+            });
+        }
+
+        validate_identifier("contract.name", &self.contract.name)?;
+        validate_identifier("algorithm", &self.algorithm)?;
+        validate_identifier("target.architecture", &self.target.architecture)?;
+        validate_metadata(
+            "toolchain.tilelang_version",
+            &self.toolchain.tilelang_version,
+        )?;
+        validate_metadata("toolchain.source_revision", &self.toolchain.source_revision)?;
+        validate_metadata(
+            "toolchain.cuda_toolkit_version",
+            &self.toolchain.cuda_toolkit_version,
+        )?;
+        validate_file_name(&self.artifact.file_name, self.artifact.format)?;
+        validate_sha256(&self.artifact.sha256)?;
+        validate_identifier("numerics.accumulation", &self.numerics.accumulation)?;
+        validate_identifier("numerics.output", &self.numerics.output)?;
+        validate_metadata("qualification.correctness", &self.qualification.correctness)?;
+        validate_metadata("qualification.sanitizer", &self.qualification.sanitizer)?;
+        validate_metadata("qualification.graph", &self.qualification.graph)?;
+        validate_metadata("qualification.benchmark", &self.qualification.benchmark)?;
+
+        if self.entry_points.is_empty() {
+            return Err(TileArtifactError::NoEntryPoints);
+        }
+        let mut symbols = BTreeSet::new();
+        for entry_point in &self.entry_points {
+            validate_identifier("entry_points[].symbol", &entry_point.symbol)?;
+            if !symbols.insert(entry_point.symbol.as_str()) {
+                return Err(TileArtifactError::DuplicateEntryPoint {
+                    symbol: entry_point.symbol.clone(),
+                });
+            }
+            validate_launch(&entry_point.symbol, entry_point.launch)?;
+            validate_alignment(
+                "entry_points[].workspace.alignment",
+                entry_point.workspace.alignment,
+            )?;
+
+            let mut parameter_names = BTreeSet::new();
+            for parameter in &entry_point.parameters {
+                validate_identifier("entry_points[].parameters[].name", &parameter.name)?;
+                if !parameter_names.insert(parameter.name.as_str()) {
+                    return Err(TileArtifactError::DuplicateParameter {
+                        symbol: entry_point.symbol.clone(),
+                        parameter: parameter.name.clone(),
+                    });
+                }
+                if let KernelParameterType::DevicePointer {
+                    element, alignment, ..
+                } = &parameter.parameter_type
+                {
+                    validate_identifier("entry_points[].parameters[].element", element)?;
+                    validate_alignment("entry_points[].parameters[].alignment", *alignment)?;
+                }
+            }
+
+            let pointer_names: BTreeSet<&str> = entry_point
+                .parameters
+                .iter()
+                .filter_map(|parameter| {
+                    matches!(
+                        parameter.parameter_type,
+                        KernelParameterType::DevicePointer { .. }
+                    )
+                    .then_some(parameter.name.as_str())
+                })
+                .collect();
+            let mut aliases = BTreeSet::new();
+            for alias in &entry_point.allowed_aliases {
+                let valid = alias.first != alias.second
+                    && pointer_names.contains(alias.first.as_str())
+                    && pointer_names.contains(alias.second.as_str());
+                let pair = if alias.first < alias.second {
+                    (alias.first.as_str(), alias.second.as_str())
+                } else {
+                    (alias.second.as_str(), alias.first.as_str())
+                };
+                if !valid || !aliases.insert(pair) {
+                    return Err(TileArtifactError::InvalidAlias {
+                        symbol: entry_point.symbol.clone(),
+                        first: alias.first.clone(),
+                        second: alias.second.clone(),
+                    });
+                }
+            }
+        }
+
+        for (name, value) in &self.properties {
+            validate_identifier("properties key", name)?;
+            validate_metadata("properties value", value)?;
+        }
+        for (name, constraint) in &self.dimensions {
+            validate_identifier("dimensions key", name)?;
+            if constraint.min == 0 || constraint.min > constraint.max || constraint.multiple_of == 0
+            {
+                return Err(TileArtifactError::InvalidDimensionConstraint {
+                    name: name.clone(),
+                    min: constraint.min,
+                    max: constraint.max,
+                    multiple_of: constraint.multiple_of,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn verify(
+        &self,
+        bytes: Vec<u8>,
+        device: &DeviceCompatibility,
+    ) -> Result<VerifiedTileArtifact, TileArtifactError> {
+        self.validate()?;
+        if device.architecture != self.target.architecture {
+            return Err(TileArtifactError::IncompatibleArchitecture {
+                required: self.target.architecture.clone(),
+                found: device.architecture.clone(),
+            });
+        }
+        if device.driver < self.target.minimum_driver {
+            return Err(TileArtifactError::DriverTooOld {
+                required: self.target.minimum_driver,
+                found: device.driver,
+            });
+        }
+
+        let actual_size = bytes.len() as u64;
+        if actual_size != self.artifact.size_bytes {
+            return Err(TileArtifactError::ArtifactSizeMismatch {
+                expected: self.artifact.size_bytes,
+                found: actual_size,
+            });
+        }
+        let actual_digest = sha256(&bytes);
+        if actual_digest != self.artifact.sha256 {
+            return Err(TileArtifactError::ArtifactHashMismatch {
+                expected: self.artifact.sha256.clone(),
+                found: actual_digest,
+            });
+        }
+
+        Ok(VerifiedTileArtifact {
+            manifest: self.clone(),
+            bytes,
+        })
+    }
+
+    fn supports(&self, request: &ArtifactRequest) -> Result<(), TileArtifactError> {
+        for (name, expected) in &self.properties {
+            match request.properties.get(name) {
+                Some(found) if found == expected => {}
+                Some(found) => {
+                    return Err(TileArtifactError::PropertyMismatch {
+                        name: name.clone(),
+                        expected: expected.clone(),
+                        found: found.clone(),
+                    });
+                }
+                None => return Err(TileArtifactError::MissingProperty { name: name.clone() }),
+            }
+        }
+        if let Some(name) = request
+            .properties
+            .keys()
+            .find(|name| !self.properties.contains_key(*name))
+        {
+            return Err(TileArtifactError::UnexpectedProperty { name: name.clone() });
+        }
+
+        for (name, constraint) in &self.dimensions {
+            let Some(value) = request.dimensions.get(name).copied() else {
+                return Err(TileArtifactError::MissingDimension { name: name.clone() });
+            };
+            if value < constraint.min || value > constraint.max {
+                return Err(TileArtifactError::DimensionOutOfRange {
+                    name: name.clone(),
+                    value,
+                    min: constraint.min,
+                    max: constraint.max,
+                });
+            }
+            if value % constraint.multiple_of != 0 {
+                return Err(TileArtifactError::DimensionNotMultiple {
+                    name: name.clone(),
+                    value,
+                    multiple_of: constraint.multiple_of,
+                });
+            }
+        }
+        if let Some(name) = request
+            .dimensions
+            .keys()
+            .find(|name| !self.dimensions.contains_key(*name))
+        {
+            return Err(TileArtifactError::UnexpectedDimension { name: name.clone() });
+        }
+        Ok(())
+    }
+}
+
+impl TileArtifactRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, artifact: VerifiedTileArtifact) -> Result<(), TileArtifactError> {
+        let key = ArtifactKey::from_manifest(artifact.manifest());
+        if self.artifacts.contains_key(&key) {
+            return Err(TileArtifactError::DuplicateArtifact {
+                contract: key.contract,
+                contract_version: key.contract_version,
+                algorithm: key.algorithm,
+                architecture: key.architecture,
+            });
+        }
+        self.artifacts.insert(key, artifact);
+        Ok(())
+    }
+
+    pub fn resolve(
+        &self,
+        request: &ArtifactRequest,
+    ) -> Result<&VerifiedTileArtifact, TileArtifactError> {
+        let key = ArtifactKey::from_request(request);
+        let artifact =
+            self.artifacts
+                .get(&key)
+                .ok_or_else(|| TileArtifactError::ArtifactNotFound {
+                    contract: key.contract.clone(),
+                    contract_version: key.contract_version,
+                    algorithm: key.algorithm.clone(),
+                    architecture: key.architecture.clone(),
+                })?;
+        artifact.manifest.supports(request)?;
+        Ok(artifact)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ArtifactKey {
+    contract: String,
+    contract_version: u32,
+    algorithm: String,
+    architecture: String,
+}
+
+impl ArtifactKey {
+    fn from_manifest(manifest: &TileArtifactManifest) -> Self {
+        Self {
+            contract: manifest.contract.name.clone(),
+            contract_version: manifest.contract.version,
+            algorithm: manifest.algorithm.clone(),
+            architecture: manifest.target.architecture.clone(),
+        }
+    }
+
+    fn from_request(request: &ArtifactRequest) -> Self {
+        Self {
+            contract: request.contract.clone(),
+            contract_version: request.contract_version,
+            algorithm: request.algorithm.clone(),
+            architecture: request.architecture.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TileArtifactError {
+    #[error("invalid TileLang artifact manifest JSON: {0}")]
+    InvalidJson(String),
+    #[error("unsupported artifact schema {found}; runtime supports {supported}")]
+    UnsupportedSchema { found: u32, supported: u32 },
+    #[error("unsupported artifact provider {found:?}")]
+    UnsupportedProvider { found: String },
+    #[error("unsupported launch ABI {found}; runtime supports {supported}")]
+    UnsupportedLaunchAbi { found: u32, supported: u32 },
+    #[error("invalid identifier in {field}: {value:?}")]
+    InvalidIdentifier { field: &'static str, value: String },
+    #[error("empty or whitespace-only metadata in {field}")]
+    InvalidMetadata { field: &'static str },
+    #[error("artifact file name must be one local file: {file_name:?}")]
+    InvalidFileName { file_name: String },
+    #[error("artifact format {format:?} does not match file name {file_name:?}")]
+    ArtifactFormatMismatch {
+        file_name: String,
+        format: ArtifactFormat,
+    },
+    #[error("artifact sha256 must be 64 lowercase hexadecimal characters")]
+    InvalidSha256,
+    #[error("manifest must contain at least one kernel entry point")]
+    NoEntryPoints,
+    #[error("duplicate kernel entry point {symbol:?}")]
+    DuplicateEntryPoint { symbol: String },
+    #[error("duplicate parameter {parameter:?} in entry point {symbol:?}")]
+    DuplicateParameter { symbol: String, parameter: String },
+    #[error("invalid or duplicate alias ({first:?}, {second:?}) in entry point {symbol:?}")]
+    InvalidAlias {
+        symbol: String,
+        first: String,
+        second: String,
+    },
+    #[error("invalid {field} for entry point {symbol:?}: {dimensions:?}")]
+    InvalidLaunchDimensions {
+        symbol: String,
+        field: &'static str,
+        dimensions: [u32; 3],
+    },
+    #[error("{field} must be a non-zero power of two, found {value}")]
+    InvalidAlignment { field: &'static str, value: u32 },
+    #[error("invalid dimension {name:?}: min={min}, max={max}, multiple_of={multiple_of}")]
+    InvalidDimensionConstraint {
+        name: String,
+        min: u64,
+        max: u64,
+        multiple_of: u64,
+    },
+    #[error("artifact requires architecture {required}, device is {found}")]
+    IncompatibleArchitecture { required: String, found: String },
+    #[error("artifact requires CUDA driver {required}, device has {found}")]
+    DriverTooOld {
+        required: CudaVersion,
+        found: CudaVersion,
+    },
+    #[error("artifact size mismatch: expected {expected} bytes, found {found}")]
+    ArtifactSizeMismatch { expected: u64, found: u64 },
+    #[error("artifact sha256 mismatch: expected {expected}, found {found}")]
+    ArtifactHashMismatch { expected: String, found: String },
+    #[error(
+        "artifact already registered for {contract} v{contract_version}, {algorithm}, {architecture}"
+    )]
+    DuplicateArtifact {
+        contract: String,
+        contract_version: u32,
+        algorithm: String,
+        architecture: String,
+    },
+    #[error("no artifact for {contract} v{contract_version}, {algorithm}, {architecture}")]
+    ArtifactNotFound {
+        contract: String,
+        contract_version: u32,
+        algorithm: String,
+        architecture: String,
+    },
+    #[error("missing required artifact property {name:?}")]
+    MissingProperty { name: String },
+    #[error("unexpected artifact property {name:?}")]
+    UnexpectedProperty { name: String },
+    #[error("property {name:?} must be {expected:?}, found {found:?}")]
+    PropertyMismatch {
+        name: String,
+        expected: String,
+        found: String,
+    },
+    #[error("missing required artifact dimension {name:?}")]
+    MissingDimension { name: String },
+    #[error("unexpected artifact dimension {name:?}")]
+    UnexpectedDimension { name: String },
+    #[error("dimension {name:?}={value} is outside [{min}, {max}]")]
+    DimensionOutOfRange {
+        name: String,
+        value: u64,
+        min: u64,
+        max: u64,
+    },
+    #[error("dimension {name:?}={value} is not a multiple of {multiple_of}")]
+    DimensionNotMultiple {
+        name: String,
+        value: u64,
+        multiple_of: u64,
+    },
+}
+
+fn validate_identifier(field: &'static str, value: &str) -> Result<(), TileArtifactError> {
+    let mut characters = value.chars();
+    let valid = characters
+        .next()
+        .is_some_and(|character| character.is_ascii_alphanumeric())
+        && characters.all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(TileArtifactError::InvalidIdentifier {
+            field,
+            value: value.to_owned(),
+        })
+    }
+}
+
+fn validate_metadata(field: &'static str, value: &str) -> Result<(), TileArtifactError> {
+    if value.trim().is_empty() {
+        Err(TileArtifactError::InvalidMetadata { field })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_file_name(file_name: &str, format: ArtifactFormat) -> Result<(), TileArtifactError> {
+    let path = Path::new(file_name);
+    let is_single_file = !file_name.contains(['/', '\\'])
+        && matches!(path.components().next(), Some(Component::Normal(_)))
+        && path.components().count() == 1;
+    if !is_single_file {
+        return Err(TileArtifactError::InvalidFileName {
+            file_name: file_name.to_owned(),
+        });
+    }
+
+    let expected_extension = match format {
+        ArtifactFormat::Cubin => "cubin",
+        ArtifactFormat::Ptx => "ptx",
+    };
+    if path.extension().and_then(|extension| extension.to_str()) != Some(expected_extension) {
+        return Err(TileArtifactError::ArtifactFormatMismatch {
+            file_name: file_name.to_owned(),
+            format,
+        });
+    }
+    Ok(())
+}
+
+fn validate_sha256(digest: &str) -> Result<(), TileArtifactError> {
+    if digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(TileArtifactError::InvalidSha256)
+    }
+}
+
+fn validate_alignment(field: &'static str, value: u32) -> Result<(), TileArtifactError> {
+    if value.is_power_of_two() {
+        Ok(())
+    } else {
+        Err(TileArtifactError::InvalidAlignment { field, value })
+    }
+}
+
+fn validate_launch(
+    symbol: &str,
+    requirements: LaunchRequirements,
+) -> Result<(), TileArtifactError> {
+    if requirements.grid_dimensions.contains(&0) {
+        return Err(TileArtifactError::InvalidLaunchDimensions {
+            symbol: symbol.to_owned(),
+            field: "grid_dimensions",
+            dimensions: requirements.grid_dimensions,
+        });
+    }
+    let block_threads = requirements
+        .block_dimensions
+        .iter()
+        .map(|dimension| u64::from(*dimension))
+        .product::<u64>();
+    if block_threads == 0 || block_threads > 1024 {
+        return Err(TileArtifactError::InvalidLaunchDimensions {
+            symbol: symbol.to_owned(),
+            field: "block_dimensions",
+            dimensions: requirements.block_dimensions,
+        });
+    }
+    if let Some(cluster_dimensions) = requirements.cluster_dimensions
+        && cluster_dimensions.contains(&0)
+    {
+        return Err(TileArtifactError::InvalidLaunchDimensions {
+            symbol: symbol.to_owned(),
+            field: "cluster_dimensions",
+            dimensions: cluster_dimensions,
+        });
+    }
+    Ok(())
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ARTIFACT_BYTES: &[u8] = b"oxide tile artifact";
+
+    fn manifest() -> TileArtifactManifest {
+        TileArtifactManifest {
+            schema_version: TILE_ARTIFACT_SCHEMA_VERSION,
+            provider: OXIDE_TILE_PROVIDER.to_owned(),
+            contract: ContractIdentity {
+                name: "attention.paged_prefill".to_owned(),
+                version: 1,
+            },
+            algorithm: "gqa4_bf16".to_owned(),
+            artifact: ArtifactDescriptor {
+                file_name: "paged_prefill_sm90a.cubin".to_owned(),
+                format: ArtifactFormat::Cubin,
+                sha256: sha256(ARTIFACT_BYTES),
+                size_bytes: ARTIFACT_BYTES.len() as u64,
+            },
+            toolchain: TileToolchain {
+                tilelang_version: "0.1.13".to_owned(),
+                source_revision: "8001cc4ccf6149382d2019654a19f59c1d4d0482".to_owned(),
+                cuda_toolkit_version: "13.1".to_owned(),
+            },
+            target: CudaTarget {
+                architecture: "sm_90a".to_owned(),
+                minimum_driver: CudaVersion {
+                    major: 590,
+                    minor: 48,
+                    patch: 1,
+                },
+            },
+            launch_abi_version: TILE_LAUNCH_ABI_VERSION,
+            entry_points: vec![KernelEntryPoint {
+                symbol: "oxide_paged_prefill".to_owned(),
+                parameters: vec![
+                    KernelParameter {
+                        name: "query".to_owned(),
+                        parameter_type: KernelParameterType::DevicePointer {
+                            element: "bf16".to_owned(),
+                            access: AccessMode::Read,
+                            alignment: 16,
+                        },
+                    },
+                    KernelParameter {
+                        name: "tokens".to_owned(),
+                        parameter_type: KernelParameterType::Scalar {
+                            scalar: ScalarType::U32,
+                        },
+                    },
+                ],
+                allowed_aliases: Vec::new(),
+                launch: LaunchRequirements {
+                    grid_dimensions: [96, 16, 1],
+                    block_dimensions: [128, 1, 1],
+                    cluster_dimensions: None,
+                    dynamic_shared_memory_bytes: 49_152,
+                },
+                workspace: WorkspaceRequirement {
+                    bytes: 0,
+                    alignment: 256,
+                },
+            }],
+            numerics: NumericalContract {
+                accumulation: "f32".to_owned(),
+                output: "bf16".to_owned(),
+                determinism: Determinism::Required,
+            },
+            qualification: QualificationRecords {
+                correctness: "results/paged_prefill_correctness.json".to_owned(),
+                sanitizer: "results/paged_prefill_sanitizer.json".to_owned(),
+                graph: "results/paged_prefill_graph.json".to_owned(),
+                benchmark: "results/paged_prefill_benchmark.json".to_owned(),
+            },
+            properties: BTreeMap::from([
+                ("dtype".to_owned(), "bf16".to_owned()),
+                ("layout".to_owned(), "paged".to_owned()),
+                ("mask".to_owned(), "causal".to_owned()),
+            ]),
+            dimensions: BTreeMap::from([
+                (
+                    "head_dim".to_owned(),
+                    DimensionConstraint {
+                        min: 128,
+                        max: 128,
+                        multiple_of: 8,
+                    },
+                ),
+                (
+                    "query_tokens".to_owned(),
+                    DimensionConstraint {
+                        min: 1,
+                        max: 4096,
+                        multiple_of: 1,
+                    },
+                ),
+            ]),
+        }
+    }
+
+    fn device() -> DeviceCompatibility {
+        DeviceCompatibility {
+            architecture: "sm_90a".to_owned(),
+            driver: CudaVersion {
+                major: 590,
+                minor: 48,
+                patch: 2,
+            },
+        }
+    }
+
+    fn request() -> ArtifactRequest {
+        ArtifactRequest {
+            contract: "attention.paged_prefill".to_owned(),
+            contract_version: 1,
+            algorithm: "gqa4_bf16".to_owned(),
+            architecture: "sm_90a".to_owned(),
+            properties: BTreeMap::from([
+                ("dtype".to_owned(), "bf16".to_owned()),
+                ("layout".to_owned(), "paged".to_owned()),
+                ("mask".to_owned(), "causal".to_owned()),
+            ]),
+            dimensions: BTreeMap::from([
+                ("head_dim".to_owned(), 128),
+                ("query_tokens".to_owned(), 2048),
+            ]),
+        }
+    }
+
+    #[test]
+    fn parses_verifies_registers_and_resolves_exact_artifact() {
+        let json = serde_json::to_vec(&manifest()).unwrap();
+        let parsed = TileArtifactManifest::from_json(&json).unwrap();
+        let verified = parsed.verify(ARTIFACT_BYTES.to_vec(), &device()).unwrap();
+        assert_eq!(verified.bytes(), ARTIFACT_BYTES);
+
+        let mut registry = TileArtifactRegistry::new();
+        registry.register(verified).unwrap();
+        let resolved = registry.resolve(&request()).unwrap();
+        assert_eq!(resolved.manifest().algorithm, "gqa4_bf16");
+    }
+
+    #[test]
+    fn rejects_unknown_json_fields() {
+        let mut json = serde_json::to_value(manifest()).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .insert("fallback".to_owned(), serde_json::Value::Bool(true));
+        let error =
+            TileArtifactManifest::from_json(&serde_json::to_vec(&json).unwrap()).unwrap_err();
+        assert!(matches!(error, TileArtifactError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn rejects_changed_artifact_bytes_and_size() {
+        let hash_error = manifest()
+            .verify(b"oxide tile artifacU".to_vec(), &device())
+            .unwrap_err();
+        assert!(matches!(
+            hash_error,
+            TileArtifactError::ArtifactHashMismatch { .. }
+        ));
+
+        let size_error = manifest().verify(b"short".to_vec(), &device()).unwrap_err();
+        assert!(matches!(
+            size_error,
+            TileArtifactError::ArtifactSizeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_incompatible_runtime_and_target() {
+        let mut wrong_schema = manifest();
+        wrong_schema.schema_version += 1;
+        assert!(matches!(
+            wrong_schema.validate().unwrap_err(),
+            TileArtifactError::UnsupportedSchema { .. }
+        ));
+
+        let mut wrong_abi = manifest();
+        wrong_abi.launch_abi_version += 1;
+        assert!(matches!(
+            wrong_abi.validate().unwrap_err(),
+            TileArtifactError::UnsupportedLaunchAbi { .. }
+        ));
+
+        let mut wrong_provider = manifest();
+        wrong_provider.provider = "fallback".to_owned();
+        assert!(matches!(
+            wrong_provider.validate().unwrap_err(),
+            TileArtifactError::UnsupportedProvider { .. }
+        ));
+
+        let wrong_architecture = DeviceCompatibility {
+            architecture: "sm_100".to_owned(),
+            ..device()
+        };
+        assert!(matches!(
+            manifest()
+                .verify(ARTIFACT_BYTES.to_vec(), &wrong_architecture)
+                .unwrap_err(),
+            TileArtifactError::IncompatibleArchitecture { .. }
+        ));
+
+        let old_driver = DeviceCompatibility {
+            driver: CudaVersion {
+                major: 590,
+                minor: 47,
+                patch: 9,
+            },
+            ..device()
+        };
+        assert!(matches!(
+            manifest()
+                .verify(ARTIFACT_BYTES.to_vec(), &old_driver)
+                .unwrap_err(),
+            TileArtifactError::DriverTooOld { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_names_alignments_and_duplicates() {
+        let mut invalid_file = manifest();
+        invalid_file.artifact.file_name = "../artifact.cubin".to_owned();
+        assert!(matches!(
+            invalid_file.validate().unwrap_err(),
+            TileArtifactError::InvalidFileName { .. }
+        ));
+
+        let mut invalid_alignment = manifest();
+        invalid_alignment.entry_points[0].workspace.alignment = 48;
+        assert!(matches!(
+            invalid_alignment.validate().unwrap_err(),
+            TileArtifactError::InvalidAlignment { .. }
+        ));
+
+        let mut duplicate_entry = manifest();
+        duplicate_entry
+            .entry_points
+            .push(duplicate_entry.entry_points[0].clone());
+        assert!(matches!(
+            duplicate_entry.validate().unwrap_err(),
+            TileArtifactError::DuplicateEntryPoint { .. }
+        ));
+
+        let mut duplicate_parameter = manifest();
+        let parameter = duplicate_parameter.entry_points[0].parameters[0].clone();
+        duplicate_parameter.entry_points[0]
+            .parameters
+            .push(parameter);
+        assert!(matches!(
+            duplicate_parameter.validate().unwrap_err(),
+            TileArtifactError::DuplicateParameter { .. }
+        ));
+
+        let mut invalid_launch = manifest();
+        invalid_launch.entry_points[0].launch.block_dimensions = [1025, 1, 1];
+        assert!(matches!(
+            invalid_launch.validate().unwrap_err(),
+            TileArtifactError::InvalidLaunchDimensions { .. }
+        ));
+
+        let mut invalid_alias = manifest();
+        invalid_alias.entry_points[0]
+            .allowed_aliases
+            .push(AllowedAlias {
+                first: "query".to_owned(),
+                second: "tokens".to_owned(),
+            });
+        assert!(matches!(
+            invalid_alias.validate().unwrap_err(),
+            TileArtifactError::InvalidAlias { .. }
+        ));
+    }
+
+    #[test]
+    fn registry_rejects_fallbacks_and_contract_mismatches() {
+        let verified = manifest()
+            .verify(ARTIFACT_BYTES.to_vec(), &device())
+            .unwrap();
+        let mut registry = TileArtifactRegistry::new();
+        registry.register(verified.clone()).unwrap();
+        assert!(matches!(
+            registry.register(verified).unwrap_err(),
+            TileArtifactError::DuplicateArtifact { .. }
+        ));
+
+        let mut wrong_property = request();
+        wrong_property
+            .properties
+            .insert("dtype".to_owned(), "f16".to_owned());
+        assert!(matches!(
+            registry.resolve(&wrong_property).unwrap_err(),
+            TileArtifactError::PropertyMismatch { .. }
+        ));
+
+        let mut wrong_multiple = request();
+        wrong_multiple.dimensions.insert("head_dim".to_owned(), 127);
+        assert!(matches!(
+            registry.resolve(&wrong_multiple).unwrap_err(),
+            TileArtifactError::DimensionOutOfRange { .. }
+        ));
+
+        let mut missing = request();
+        missing.contract_version = 2;
+        assert!(matches!(
+            registry.resolve(&missing).unwrap_err(),
+            TileArtifactError::ArtifactNotFound { .. }
+        ));
+    }
+}

--- a/crates/oxide-infer-cuda/src/lib.rs
+++ b/crates/oxide-infer-cuda/src/lib.rs
@@ -1,9 +1,12 @@
 #![cfg_attr(feature = "cuda", allow(internal_features))]
 #![cfg_attr(feature = "cuda", feature(core_intrinsics))]
 
-//! Rust CUDA providers for Oxide Infer.
+//! Checked CUDA resources and offline artifact contracts for Oxide Infer.
 //!
-//! Enable the `cuda` feature inside the pinned cuda-oxide toolchain.
+//! The artifact contract is pure Rust. Enable the transitional `cuda` feature
+//! inside the pinned cuda-oxide toolchain for the current device providers.
+
+pub mod artifact;
 
 #[cfg(feature = "cuda")]
 pub mod attention;

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,22 +23,26 @@ applies only to its recorded source, contract, artifact, hardware, and command.
 1. [Standalone engine architecture](design/standalone-oxide-engine.md)
    defines the accepted server, engine, runtime, TileLang, and provenance
    boundaries.
-2. [Control-plane source map](design/control-plane-source-map.md) defines what
+2. [Product differentiation](design/product-differentiation.md) defines the
+   Mistral.rs, PegaInfer, PegaFlow, FlashInfer, vLLM, and SGLang boundaries.
+3. [TileLang artifact manifest](design/tile-artifact-manifest.md) defines the
+   current versioned schema, verification, and fail-closed registry contract.
+4. [Control-plane source map](design/control-plane-source-map.md) defines what
    is imported, split, referenced, or excluded from the upstream baseline.
-3. [Current operator architecture](design/oxide-infer-architecture.md)
+5. [Current operator architecture](design/oxide-infer-architecture.md)
    defines the source that is being migrated.
-4. [Engine benchmark plan](development/engine-benchmark-plan.md) defines
+6. [Engine benchmark plan](development/engine-benchmark-plan.md) defines
    kernel, model, and serving comparisons.
-5. [Repository layout](design/repository-layout.md) separates current and
+7. [Repository layout](design/repository-layout.md) separates current and
    target source trees.
-6. [Operator catalog](operator-catalog.md) lists current, experimental, and
+8. [Operator catalog](operator-catalog.md) lists current, experimental, and
    planned contracts.
-7. [Roadmap](roadmap.md) orders work and defines admission and exit gates.
-8. [FlashInfer parity](flashinfer-parity.md) tracks the pinned comparison
+9. [Roadmap](roadmap.md) orders work and defines admission and exit gates.
+10. [FlashInfer parity](flashinfer-parity.md) tracks the pinned comparison
    surface without claiming full parity.
-9. [Historical reference integration](integrations/mistralrs.md) records the
+11. [Historical reference integration](integrations/mistralrs.md) records the
    former paired-repository proof and benchmark provenance.
-10. [Evidence index](results/README.md) lists immutable device and benchmark
+12. [Evidence index](results/README.md) lists immutable device and benchmark
    records.
 
 The [rename provenance](design/rename-provenance.md) maps the former project

--- a/docs/design/product-differentiation.md
+++ b/docs/design/product-differentiation.md
@@ -1,0 +1,173 @@
+# Product differentiation and peer boundaries
+
+**Decision date:** 2026-08-14. This document describes intended position, not
+current performance leadership.
+
+Oxide Infer is a narrow, NVIDIA-focused Rust inference engine whose custom GPU
+computation is supplied exclusively as qualified ahead-of-time TileLang
+artifacts. Its distinguishing unit is not a new HTTP wrapper or a Rust rewrite
+of every inference feature. It is the complete, auditable path from a model
+contract through a typed execution plan to one immutable kernel artifact and
+reproducible evidence.
+
+## One-sentence position
+
+> Oxide Infer is the fail-closed TileLang AOT inference engine: every supported
+> GPU operation resolves to a manifest-verified artifact, or the model does not
+> load.
+
+This position is only valuable if the final engine is competitive. Artifact
+discipline is not a substitute for kernel latency, scheduler goodput, memory
+efficiency, correctness, or model coverage.
+
+## Peer boundaries
+
+| Project | Primary strength and scope | Oxide relationship | Oxide difference |
+| --- | --- | --- | --- |
+| Mistral.rs | Broad Rust inference product: many model, quantization, modality, hardware, SDK, and serving capabilities | Pinned behavioral oracle and source baseline for admitted non-compute modules | Oxide deliberately supports fewer profiles, owns a framework-free model/KV data plane, and optimizes one NVIDIA AOT path deeply |
+| PegaInfer | Production-oriented pure Rust and CUDA engine assembled from reusable frontend, KV, cache, and kernel components | Closest Rust-native engine peer and an engine benchmark candidate when a model profile overlaps | Oxide uses one custom-kernel supply chain and a shared narrow model IR; PegaInfer currently composes multiple kernel technologies and model-specific crates |
+| PegaFlow | Standalone Rust external KV cache service with host memory, SSD, RDMA, and cross-engine sharing | Future optional external KV backend, not an engine competitor | Oxide owns inference, local scheduling, model execution, and HBM page use; it does not initially reproduce PegaFlow's distributed storage plane |
+| FlashInfer | High-performance GPU operator library | Matched kernel correctness and performance baseline | Oxide owns a complete engine and artifact lifecycle; it does not link FlashInfer as a production fallback |
+| vLLM and SGLang | Mature high-throughput serving engines | Primary neutral serving baselines | Oxide targets a smaller Rust-native, AOT-only production footprint and must prove that trade against their goodput and latency |
+
+The statements above are pinned to public project state on the decision date:
+
+- [Mistral.rs repository](https://github.com/EricLBuehler/mistral.rs)
+- [PegaInfer repository](https://github.com/pegainfer-project/pegainfer)
+- [PegaInfer 0.1 architecture and measurements](https://openedinfer.com/blog/pegainfer-010/)
+- [PegaFlow repository](https://github.com/novitalabs/pegaflow)
+- [vLLM and PegaFlow architecture](https://github.com/vllm-project/vllm-project.github.io/blob/main/_posts/2026-05-18-pegaflow.md)
+
+## Why this is not Mistral.rs with another kernel backend
+
+Oxide may transplant complete implementations for protocol types, HTTP and
+SSE handling, tokenizer and chat-template behavior, request state, tools,
+grammar constraints, telemetry, and process lifecycle. It preserves the
+source license and provenance and tests behavior against the external source
+engine.
+
+The boundary stops before framework tensors and GPU state. Model forward
+implementations, device mapping, framework storage, physical KV cache,
+attention implementations, quantized layers, and GPU-provider routing belong
+to the data plane even when their filenames do not say `kernel`. Copying those
+paths would leave the product dependent on the upstream execution architecture
+and make `OxideTile` only another optional backend.
+
+Oxide instead owns:
+
+```text
+ModelSpec -> narrow model IR -> immutable prefill/decode plans
+          -> Oxide KV handles -> checked artifact requests
+          -> verified TileLang bytes -> CommandScope -> Completion
+```
+
+Mistral.rs therefore supplies mature behavior and source experience, not the
+runtime identity of the product.
+
+## Difference from PegaInfer
+
+PegaInfer demonstrates that a useful Rust engine should reuse stable
+components. Its public architecture directly uses the vLLM Rust frontend,
+Dynamo logical KV management, PegaFlow physical offload, and a heterogeneous
+kernel portfolio: handwritten CUDA and cuBLAS, FlashInfer, Triton AOT, CuTe
+DSL, and TileLang. Model-specific crates own the relevant execution and kernel
+feature sets.
+
+Oxide adopts the component lesson but chooses a different optimization:
+
+- one manifest and launch ABI for every custom compute family;
+- one build-time source language and qualification path;
+- one checked Rust resource lifecycle from operands to completion;
+- one shared narrow model IR, with model profiles rather than a new execution
+  architecture per model;
+- model load fails when exact artifact coverage is incomplete;
+- kernel evidence and engine evidence ship as first-class release records.
+
+This reduces provider interaction, runtime compilation, and artifact ambiguity.
+It also creates a real cost: TileLang must reach competitive performance for
+GEMM, attention, sampling, fusion, and future MoE shapes without falling back
+to a stronger library. PegaInfer is currently much broader and closer to
+production; Oxide has not yet earned an engine-level comparison claim.
+
+## Difference from PegaFlow
+
+PegaFlow treats KV cache as a long-lived service asset independent of an
+engine process. Its daemon owns host pools, SSD, topology, RDMA, indexing, and
+background work. That is a clean failure and lifecycle boundary for multi-node
+serving, but it is not the scheduler, model executor, or GPU kernel engine.
+
+Oxide first owns an in-process HBM KV pager because model plans, block tables,
+CUDA Graph addresses, and attention artifacts must be proven together. A
+future `ExternalKvBackend` boundary may export and import immutable logical KV
+blocks. PegaFlow can implement that boundary without becoming part of the
+kernel or scheduler dependency graph.
+
+Oxide will not build an SSD/RDMA cache service merely to claim feature parity.
+That work is admitted only if a measured deployment cannot use PegaFlow or
+another stable external service through the boundary.
+
+## Target architecture and code layout
+
+```text
+apps/oxide-infer
+  process assembly and CLI
+        |
+crates/oxide-infer-server
+  source-derived API, tokenizer, streaming, request state
+        |
+crates/oxide-infer-engine
+  model IR, weights, scheduler, local KV pager, sampling, plans
+        |
+crates/oxide-infer-cuda        crates/oxide-infer
+  checked resources,           semantic contracts,
+  artifact registry, launch    CPU references
+        |
+kernels/tilelang
+  offline sources, schedules, profiles, build and qualification
+        |
+artifacts/manifests + external immutable cubin/PTX
+
+crates/oxide-infer-lab and benchmarks/
+  correctness, FlashInfer kernel comparison, neutral engine comparison
+
+future optional boundary:
+oxide-infer-engine <-> external KV connector <-> PegaFlow or another service
+```
+
+Target repository ownership is:
+
+| Path | Ownership |
+| --- | --- |
+| `apps/oxide-infer` | Release binary and process composition |
+| `crates/oxide-infer-server` | Protocol, tokenizer, streaming, configuration, telemetry |
+| `crates/oxide-infer-engine` | Model IR, weights, sequence scheduler, KV policy, execution plans, sampling |
+| `crates/oxide-infer-cuda` | Memory, streams, modules, Graphs, manifest verification, checked launch and completion |
+| `crates/oxide-infer` | Backend-independent operator contracts and references |
+| `kernels/tilelang` | Offline kernel definitions, fixed schedules, target profiles, artifact build |
+| `artifacts/manifests` | Release-visible artifact identities; generated binaries remain external |
+| `crates/oxide-infer-lab` | Non-product device gates and evidence generation |
+| `benchmarks/kernels` | Matched FlashInfer comparisons |
+| `benchmarks/engines` | Neutral Mistral.rs, PegaInfer, vLLM, and SGLang drivers where profiles overlap |
+| `docs/provenance` | Source-to-source mapping, upstream revisions, licenses, modifications |
+
+Directories land only with their first working vertical slice. The target tree
+is not created as empty scaffolding.
+
+## What must be proven
+
+Oxide's difference is accepted only after evidence answers four separate
+questions:
+
+1. **Artifact integrity:** can a release reproduce the source, compiler,
+   target, ABI, hash, and exact shape domain of every loaded artifact?
+2. **Kernel quality:** on matched inputs, how does each TileLang contract
+   compare with FlashInfer or the appropriate diagnostic baseline?
+3. **Engine quality:** on the same model and trace, how do TTFT, inter-token
+   latency, throughput, goodput, memory, startup, and errors compare with the
+   pinned peer engines?
+4. **Operational quality:** do cancellation, overload, invalid artifacts,
+   Graph misses, and teardown fail without leaks or hidden provider fallback?
+
+Until those gates pass, the accurate claim is “Oxide is implementing a
+standalone TileLang AOT Rust inference engine,” not “Oxide is faster” or
+“production ready.”

--- a/docs/design/tile-artifact-manifest.md
+++ b/docs/design/tile-artifact-manifest.md
@@ -1,0 +1,168 @@
+# TileLang artifact manifest and launch ABI
+
+**State:** the schema, pure-Rust validation, byte verification, and exact
+registry selection are current. CUDA module loading and launch remain planned
+under roadmap phase E1.
+
+Oxide compiles TileLang outside the production process. The serving runtime
+accepts only immutable cubin or PTX bytes accompanied by a versioned manifest.
+The manifest is a compatibility contract, not build-system metadata.
+
+The current Rust implementation is
+`crates/oxide-infer-cuda/src/artifact.rs`. It has no CUDA dependency, so a
+release builder and CI can reject malformed artifacts before a GPU or driver
+is present.
+
+## Artifact identity
+
+One registry key is the exact tuple:
+
+```text
+(contract name, contract version, algorithm, CUDA architecture)
+```
+
+Properties such as dtype, layout, and mask mode and all declared dimensions
+must also match the selected manifest. A request with a missing, additional,
+or incompatible field fails. Registry selection never searches for a nearby
+shape, another architecture, or another provider.
+
+The schema and launch ABI are versioned separately:
+
+- `schema_version` changes when manifest interpretation changes;
+- `launch_abi_version` changes when the Rust-to-kernel calling convention
+  changes;
+- `contract.version` changes when operator behavior changes;
+- `algorithm` changes when an implementation is independently qualified.
+
+Only provider `oxide_tile` is accepted by the target artifact path.
+
+## Version 1 example
+
+```json
+{
+  "schema_version": 1,
+  "provider": "oxide_tile",
+  "contract": {
+    "name": "attention.paged_prefill",
+    "version": 1
+  },
+  "algorithm": "gqa4_bf16",
+  "artifact": {
+    "file_name": "paged_prefill_sm90a.cubin",
+    "format": "cubin",
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "size_bytes": 123456
+  },
+  "toolchain": {
+    "tilelang_version": "0.1.13",
+    "source_revision": "8001cc4ccf6149382d2019654a19f59c1d4d0482",
+    "cuda_toolkit_version": "13.1"
+  },
+  "target": {
+    "architecture": "sm_90a",
+    "minimum_driver": {
+      "major": 590,
+      "minor": 48,
+      "patch": 1
+    }
+  },
+  "launch_abi_version": 1,
+  "entry_points": [
+    {
+      "symbol": "oxide_paged_prefill",
+      "parameters": [
+        {
+          "name": "query",
+          "parameter_type": {
+            "kind": "device_pointer",
+            "element": "bf16",
+            "access": "read",
+            "alignment": 16
+          }
+        },
+        {
+          "name": "query_tokens",
+          "parameter_type": {
+            "kind": "scalar",
+            "scalar": "u32"
+          }
+        }
+      ],
+      "allowed_aliases": [],
+      "launch": {
+        "grid_dimensions": [96, 16, 1],
+        "block_dimensions": [128, 1, 1],
+        "cluster_dimensions": null,
+        "dynamic_shared_memory_bytes": 49152
+      },
+      "workspace": {
+        "bytes": 0,
+        "alignment": 256
+      }
+    }
+  ],
+  "numerics": {
+    "accumulation": "f32",
+    "output": "bf16",
+    "determinism": "required"
+  },
+  "qualification": {
+    "correctness": "results/paged_prefill-correctness.json",
+    "sanitizer": "results/paged_prefill-sanitizer.json",
+    "graph": "results/paged_prefill-graph.json",
+    "benchmark": "results/paged_prefill-benchmark.json"
+  },
+  "properties": {
+    "dtype": "bf16",
+    "layout": "paged",
+    "mask": "causal"
+  },
+  "dimensions": {
+    "head_dim": {
+      "min": 128,
+      "max": 128,
+      "multiple_of": 8
+    },
+    "query_tokens": {
+      "min": 1,
+      "max": 4096,
+      "multiple_of": 1
+    }
+  }
+}
+```
+
+Unknown JSON fields are rejected. File names must be a single local component
+with an extension matching the declared format. SHA-256 is canonical lowercase
+hexadecimal. Entry-point and parameter names are unique, alignments are
+non-zero powers of two, and dimension ranges are internally consistent.
+
+## Runtime admission order
+
+The checked path is:
+
+```text
+strict JSON decode
+  -> schema, provider, ABI, and structural validation
+  -> exact device architecture and minimum-driver validation
+  -> byte length and SHA-256 verification
+  -> verified bytes owned by the registry
+  -> exact property and dimension selection
+  -> planned CUDA module and function loading
+  -> checked operands and CommandScope launch
+```
+
+`VerifiedTileArtifact` owns the bytes that were hashed. It does not return a
+validated path that could later be replaced with different file contents.
+CUDA loading will consume those owned bytes.
+
+## Deliberately excluded from version 1
+
+Version 1 does not perform runtime JIT, auto-tuning, network retrieval,
+filesystem discovery, provider fallback, or best-effort forward compatibility.
+It also does not claim that a structurally valid artifact is numerically
+correct or fast. Those facts require separate immutable correctness, sanitizer,
+Graph, and benchmark records before release promotion.
+
+The next E1 slice connects one manifest-verified BF16 paged-prefill cubin to
+the existing memory, stream, command, and completion lifecycle.

--- a/docs/development/engine-benchmark-plan.md
+++ b/docs/development/engine-benchmark-plan.md
@@ -3,7 +3,8 @@
 Oxide Infer needs two independent performance proofs:
 
 1. matched kernel comparisons against FlashInfer where contracts overlap;
-2. complete inference and serving comparisons against vLLM and SGLang.
+2. complete inference and serving comparisons against vLLM and SGLang, plus
+   the pinned source-reference engine.
 
 A faster kernel does not prove a faster engine. A faster unloaded server does
 not prove production goodput. Correctness, kernel timing, model execution, and
@@ -166,6 +167,27 @@ All three engines use:
 Engine-native optimizations may be enabled only in a separately named
 "best configured" cohort. The primary cohort isolates the core engine under
 matched semantics.
+
+## Rust-native peer cohort
+
+PegaInfer is a useful architectural and performance peer, but it is not forced
+into the first release matrix unless it supports the same model profile,
+weights, dtype, context, and semantics. Its current public measurements use
+Qwen3-4B on an RTX 5090, which cannot be compared numerically with Oxide's
+historical H20 operator records or the first Qwen2.5-1.5B target.
+
+When both engines admit an identical profile, run PegaInfer through the same
+neutral JSONL workload driver and fairness controls. Report it as a separate
+Rust-native cohort until repeated results justify changing a primary release
+gate. PegaFlow is not an engine baseline; external-KV comparisons belong to a
+future cache-service matrix with fixed cache budget, hit trace, topology, and
+transfer semantics.
+
+Pinned peer references:
+
+- <https://github.com/pegainfer-project/pegainfer>
+- <https://openedinfer.com/blog/pegainfer-010/>
+- <https://github.com/novitalabs/pegaflow>
 
 ## Competitive claim gate
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -115,7 +115,13 @@ Exit gate:
 
 ## E1: Build the TileLang artifact boundary
 
-**State:** planned.
+**State:** in progress.
+
+Current source defines strict manifest JSON, independent schema and launch ABI
+versions, structural validation, target and driver checks, SHA-256 and size
+verification, owned verified bytes, and exact fail-closed registry selection.
+CUDA module loading, checked launch, packaging, and device evidence remain
+open.
 
 Work:
 


### PR DESCRIPTION
## What changed

- add a CUDA-independent `artifact` module with versioned TileLang manifest and launch ABI contracts
- validate schema/provider/ABI, toolchain metadata, local artifact names, launch geometry, pointer alignment and aliases, numerical identity, qualification records, and dimension domains
- verify exact architecture, minimum driver, byte size, and SHA-256 before retaining owned artifact bytes
- add a fail-closed registry keyed by contract, contract version, algorithm, and CUDA architecture with exact property and dimension matching
- cover strict JSON parsing, successful resolution, altered bytes, incompatible runtime, malformed launch/alias metadata, duplicates, and fallback rejection
- document the target code layout and the product boundaries relative to Mistral.rs, PegaInfer, PegaFlow, FlashInfer, vLLM, and SGLang
- mark roadmap E1 as in progress and add a fair Rust-native peer benchmark cohort

## Why

The accepted standalone architecture needs a stable boundary between offline TileLang compilation and the production Rust runtime. Loading a path or an unversioned cubin would leave compatibility, provenance, and fallback behavior implicit. This change makes the first boundary explicit and testable before CUDA module loading is connected.

Oxide's intended distinction is a single auditable `TileLang source -> immutable artifact -> strict manifest -> checked Rust launch` supply chain, not merely another kernel backend inside an upstream engine.

## Impact

The new contract is available without the transitional `cuda` feature. Existing CUDA providers are unchanged. No product kernel is promoted and no new device-performance claim is made by this PR.

The next E1 slice can consume `VerifiedTileArtifact` bytes to load one fixed BF16 paged-prefill module and bind it to the existing memory, command, Graph, and completion lifecycle.

## Validation

- `make check`
  - Rust fmt, workspace Clippy with warnings denied, all-target tests, release check, package verification
  - 65 Rust unit tests
  - 26 Python evidence-tool tests
  - Astro check and production build
  - npm audit: 0 vulnerabilities
- targeted artifact Clippy and tests
- `git diff --check`

No CUDA device gate was run because this PR introduces the host-only artifact contract and does not yet load or launch an artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict, versioned TileLang artifact manifests with compatibility and integrity verification.
  * Added fail-closed artifact registration and exact-match resolution.
  * Added support for validating CUDA targets, drivers, launch parameters, and artifact metadata.

* **Documentation**
  * Added artifact manifest, product differentiation, and repository design documentation.
  * Updated the roadmap and benchmark plan to reflect artifact-boundary capabilities and expanded comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->