### PR TITLE
Harden TileLang artifact launch validation

### DIFF
--- a/crates/oxide-infer-cuda/src/artifact.rs
+++ b/crates/oxide-infer-cuda/src/artifact.rs
@@ -706,19 +706,26 @@ fn validate_launch(
     symbol: &str,
     requirements: LaunchRequirements,
 ) -> Result<(), TileArtifactError> {
-    if requirements.grid_dimensions.contains(&0) {
+    const MAX_GRID_DIMENSIONS: [u32; 3] = [2_147_483_647, 65_535, 65_535];
+    const MAX_BLOCK_DIMENSIONS: [u32; 3] = [1024, 1024, 64];
+
+    if !dimensions_in_range(requirements.grid_dimensions, MAX_GRID_DIMENSIONS) {
         return Err(TileArtifactError::InvalidLaunchDimensions {
             symbol: symbol.to_owned(),
             field: "grid_dimensions",
             dimensions: requirements.grid_dimensions,
         });
     }
-    let block_threads = requirements
-        .block_dimensions
-        .iter()
-        .map(|dimension| u64::from(*dimension))
-        .product::<u64>();
-    if block_threads == 0 || block_threads > 1024 {
+    if !dimensions_in_range(requirements.block_dimensions, MAX_BLOCK_DIMENSIONS) {
+        return Err(TileArtifactError::InvalidLaunchDimensions {
+            symbol: symbol.to_owned(),
+            field: "block_dimensions",
+            dimensions: requirements.block_dimensions,
+        });
+    }
+    let [block_x, block_y, block_z] = requirements.block_dimensions;
+    let block_threads = u64::from(block_x) * u64::from(block_y) * u64::from(block_z);
+    if block_threads > 1024 {
         return Err(TileArtifactError::InvalidLaunchDimensions {
             symbol: symbol.to_owned(),
             field: "block_dimensions",
@@ -726,7 +733,12 @@ fn validate_launch(
         });
     }
     if let Some(cluster_dimensions) = requirements.cluster_dimensions
-        && cluster_dimensions.contains(&0)
+        && (!dimensions_in_range(cluster_dimensions, requirements.grid_dimensions)
+            || requirements
+                .grid_dimensions
+                .iter()
+                .zip(cluster_dimensions)
+                .any(|(grid, cluster)| grid % cluster != 0))
     {
         return Err(TileArtifactError::InvalidLaunchDimensions {
             symbol: symbol.to_owned(),
@@ -735,6 +747,13 @@ fn validate_launch(
         });
     }
     Ok(())
+}
+
+fn dimensions_in_range(dimensions: [u32; 3], maximum: [u32; 3]) -> bool {
+    dimensions
+        .iter()
+        .zip(maximum)
+        .all(|(dimension, maximum)| *dimension != 0 && *dimension <= maximum)
 }
 
 fn sha256(bytes: &[u8]) -> String {
@@ -836,6 +855,14 @@ mod tests {
                     },
                 ),
                 (
+                    "page_size".to_owned(),
+                    DimensionConstraint {
+                        min: 16,
+                        max: 64,
+                        multiple_of: 16,
+                    },
+                ),
+                (
                     "query_tokens".to_owned(),
                     DimensionConstraint {
                         min: 1,
@@ -871,6 +898,7 @@ mod tests {
             ]),
             dimensions: BTreeMap::from([
                 ("head_dim".to_owned(), 128),
+                ("page_size".to_owned(), 16),
                 ("query_tokens".to_owned(), 2048),
             ]),
         }
@@ -1005,9 +1033,16 @@ mod tests {
         ));
 
         let mut invalid_launch = manifest();
-        invalid_launch.entry_points[0].launch.block_dimensions = [1025, 1, 1];
+        invalid_launch.entry_points[0].launch.block_dimensions = [u32::MAX; 3];
         assert!(matches!(
             invalid_launch.validate().unwrap_err(),
+            TileArtifactError::InvalidLaunchDimensions { .. }
+        ));
+
+        let mut invalid_grid = manifest();
+        invalid_grid.entry_points[0].launch.grid_dimensions = [1, 65_536, 1];
+        assert!(matches!(
+            invalid_grid.validate().unwrap_err(),
             TileArtifactError::InvalidLaunchDimensions { .. }
         ));
 
@@ -1045,11 +1080,18 @@ mod tests {
             TileArtifactError::PropertyMismatch { .. }
         ));
 
+        let mut wrong_range = request();
+        wrong_range.dimensions.insert("head_dim".to_owned(), 127);
+        assert!(matches!(
+            registry.resolve(&wrong_range).unwrap_err(),
+            TileArtifactError::DimensionOutOfRange { .. }
+        ));
+
         let mut wrong_multiple = request();
-        wrong_multiple.dimensions.insert("head_dim".to_owned(), 127);
+        wrong_multiple.dimensions.insert("page_size".to_owned(), 24);
         assert!(matches!(
             registry.resolve(&wrong_multiple).unwrap_err(),
-            TileArtifactError::DimensionOutOfRange { .. }
+            TileArtifactError::DimensionNotMultiple { .. }
         ));
 
         let mut missing = request();

--- a/docs/design/product-differentiation.md
+++ b/docs/design/product-differentiation.md
@@ -1,7 +1,7 @@
 # Product differentiation and peer boundaries
 
-**Decision date:** 2026-08-14. This document describes intended position, not
-current performance leadership.
+**Decision date:** 2026-08-14 (Asia/Shanghai). This document describes intended
+position, not current performance leadership.
 
 Oxide Infer is a narrow, NVIDIA-focused Rust inference engine whose custom GPU
 computation is supplied exclusively as qualified ahead-of-time TileLang

--- a/docs/design/tile-artifact-manifest.md
+++ b/docs/design/tile-artifact-manifest.md
@@ -4,9 +4,10 @@
 registry selection are current. CUDA module loading and launch remain planned
 under roadmap phase E1.
 
-Oxide compiles TileLang outside the production process. The serving runtime
-accepts only immutable cubin or PTX bytes accompanied by a versioned manifest.
-The manifest is a compatibility contract, not build-system metadata.
+Oxide compiles TileLang outside the production process. The target serving
+runtime will accept only immutable cubin or PTX bytes accompanied by a
+versioned manifest. The manifest is a compatibility contract, not build-system
+metadata.
 
 The current Rust implementation is
 `crates/oxide-infer-cuda/src/artifact.rs`. It has no CUDA dependency, so a
@@ -122,6 +123,11 @@ Only provider `oxide_tile` is accepted by the target artifact path.
       "min": 128,
       "max": 128,
       "multiple_of": 8
+    },
+    "page_size": {
+      "min": 16,
+      "max": 64,
+      "multiple_of": 16
     },
     "query_tokens": {
       "min": 1,

--- a/docs/development/engine-benchmark-plan.md
+++ b/docs/development/engine-benchmark-plan.md
@@ -153,7 +153,8 @@ rate.
 
 ## Fairness controls
 
-All three engines use:
+All four engines in the primary cohort—Oxide, the pinned source-reference
+engine, vLLM, and SGLang—use:
 
 - the same GPU and exclusive host allocation;
 - the same local model and tokenizer file hashes;


### PR DESCRIPTION
## What changed

Follow-up to #126 after its review completed concurrently with merge:

- reject CUDA grid dimensions above `[2^31-1, 65535, 65535]`
- reject block dimensions above `[1024, 1024, 64]` before calculating total threads, preventing debug panic and release overflow
- require non-zero cluster dimensions bounded by and divisible into the grid
- add overflow, grid-bound, out-of-range, and `DimensionNotMultiple` coverage
- clarify the planned serving path, primary four-engine benchmark cohort, and Asia/Shanghai decision date

## Why

Manifest dimensions are untrusted input. Multiplying three arbitrary `u32` block dimensions before bounding them can overflow `u64`, violating the artifact boundary's fail-closed contract.

## Validation

- `cargo clippy -p oxide-infer-cuda --lib --tests -- -D warnings`
- `cargo test -p oxide-infer-cuda --lib` (6 passed)
- CI-matched `typos v1.37.2`
- `git diff --check`

The CUDA limits were cross-checked against NVIDIA's current CUDA Programming Guide compute-capability table.